### PR TITLE
Adds a few more colors to flamegraph color palette

### DIFF
--- a/webapp/javascript/util/format.js
+++ b/webapp/javascript/util/format.js
@@ -5,40 +5,28 @@ export function numberWithCommas(x) {
 }
 
 export function colorBasedOnPackageName(name, a) {
-  const purple = `hsla(246, 40%, 65%, ${a})` //Purple:
-  const blueDark = `hsla(211, 48%, 60%, ${a})` //BlueDark:
-  const blueCyan = `hsla(194, 52%, 61%, ${a})` //CyanBlue:
-  const yellow = `hsla(34, 65%, 65%, ${a})` //Yellow:
-  const green = `hsla(163, 45%, 55%, ${a})` //Green:
-  const orange = `hsla(24, 69%, 60%, ${a})` //Orange:
-  const red = `hsla(3, 62%, 67%, ${a})` // Red:
-  const grey = `hsla(225, 2%, 51%, ${a})` //Grey:
+  const purple = `hsla(246, 40%, 65%, ${a})` //Purple
+  const blueDark = `hsla(211, 48%, 60%, ${a})` //BlueDark
+  const blueCyan = `hsla(194, 52%, 61%, ${a})` //CyanBlue
+  const yellowDark = `hsla(34, 65%, 65%, ${a})` //Dark Yellow
+  const yellowLight = `hsla(47, 100%, 73%, ${a})` //Light Yellow
+  const green = `hsla(163, 45%, 55%, ${a})` //Green
+  const orange = `hsla(24, 69%, 60%, ${a})` //Orange
+  const pink = `hsla(305, 63%, 79%, ${a})` //Pink
+  // const red = `hsla(3, 62%, 67%, ${a})` // Red
+  // const grey = `hsla(225, 2%, 51%, ${a})` //Grey
 
   const items = [
     // red,
     orange,
-    yellow,
-    green,
+    yellowDark,
     blueCyan,
+    green,
     blueDark,
     purple,
+    pink,
+    yellowLight,
   ]
-
-  // const darkGreen = `hsla(160, 40%, 21%, ${a})` //Dark green:
-  // const darkPurple = `hsla(240, 30%, 29%, ${a})` //puprple:
-  // const darkBlue = `hsla(226, 36%, 26%, ${a})` //Dark blue:
-  // const darkPink = `hsla(315, 40%, 24%, ${a})` //Pink:
-  // const darkYellow = `hsla(62, 29%, 22%, ${a})` //Yellow/mustard:
-  // const darkRed = `hsla(10, 41%, 23%, ${a})` //Red:
-  //
-  // const items = [
-  //   darkGreen,
-  //   darkPurple,
-  //   darkBlue,
-  //   darkPink,
-  //   darkYellow,
-  //   darkRed,
-  // ]
 
   let colorIndex = murmurhash3_32_gc(name) % items.length;
   return items[colorIndex];


### PR DESCRIPTION
Currently there are not enough colors so often two filenames/packages look like they're one (i.e. if a function in `filename_a.py` calls a function `filename_b.py` they may both be orange making it hard to tell that the two functions come from different files. 

This just adds a few more colors to help fix that without making the flame graph look too busy.

Fixes #12 