### PR TITLE
Add config option for setting the app's base url

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ type Server struct {
 
 	StoragePath string `def:"<installPrefix>/var/lib/pyroscope" desc:"directory where pyroscope stores profiling data"`
 	ApiBindAddr string `def:":4040" desc:"port for the HTTP server used for data ingestion and web UI"`
+	BaseURL     string `def:"" desc:"base URL for when the server is behind a reverse proxy with a different path"`
 
 	// These will eventually be replaced by some sort of a system that keeps track of RAM
 	//   and updates

--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -119,6 +119,7 @@ type indexPage struct {
 	InitialState  string
 	BuildInfo     string
 	ExtraMetadata string
+	BaseURL       string
 }
 
 func (ctrl *Controller) renderIndexPage(dir http.FileSystem, rw http.ResponseWriter, _ *http.Request) {
@@ -185,6 +186,7 @@ func (ctrl *Controller) renderIndexPage(dir http.FileSystem, rw http.ResponseWri
 		InitialState:  initialStateStr,
 		BuildInfo:     buildInfoStr,
 		ExtraMetadata: extraMetadataStr,
+		BaseURL:       ctrl.cfg.Server.BaseURL,
 	})
 	if err != nil {
 		renderServerError(rw, fmt.Sprintf("could not marshal json: %q", err))

--- a/webapp/javascript/util/update_requests.js
+++ b/webapp/javascript/util/update_requests.js
@@ -1,7 +1,7 @@
 export function buildRenderURL(state) {
   const { from, until } = state;
 
-  let url = `/render?from=${encodeURIComponent(from)}&until=${encodeURIComponent(until)}`;
+  let url = `render?from=${encodeURIComponent(from)}&until=${encodeURIComponent(until)}`;
   const nameLabel = state.labels.find((x) => x.name == '__name__');
 
   if (nameLabel) {

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -7,6 +7,9 @@
   <meta name="viewport" content="width=device-width">
   <title>Pyroscope</title>
   <link rel="stylesheet" href="build/styles.<%= webpack.hash %>.css">
+  {{- if .BaseURL }}
+  <base href="{{ .BaseURL }}">
+  {{- end }}
   {{ .ExtraMetadata }}
   <%= extra_metadata %>
   <% if (mode == "development") { %>


### PR DESCRIPTION
This PR adds a config option to add a [base](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) meta tag in the pyroscope webapp.

The rationalle behind this is to allow the app to be served as a path behind a reverse proxy (ie. `https://some.host/pyroscope/`)

This can technically be done via the `EXTRA_METADATA` env var, but requires a path to a file which makes it a bit more cumbersome. (And the render path would need to be made relative still.)

---

In order to test this out you can do so in a local docker-compose with caddy.

You'll need a `docker-compose.yml`:

```yml
version: "3.8"

services:
  caddy:
    image: caddy
    container_name: caddy
    ports:
      - 8080:8080
    volumes:
      - ./Caddyfile:/etc/caddy/Caddyfile:ro
  
  pyroscope:
    image: pyroscope/pyroscope:dev
    container_name: pyroscope
    ports:
      - 4040:4040
    environment:
      - PYROSCOPE_BASE_URL
    command: server
```

and a `Caddyfile`:

```
{
    http_port 8080
    auto_https off
}

http://localhost {
    redir /pyroscope /pyroscope/
    route /pyroscope* {
        uri strip_prefix pyroscope
        reverse_proxy pyroscope:4040
    }
}
```

Running `docker-compose up` and visiting `http://localhost:8080/pyroscope/` should work fine (assuming you've first build the container using `make build-dev`).