### PR TITLE
fix upload URL to include existing path

### DIFF
--- a/pkg/agent/upstream/remote/remote.go
+++ b/pkg/agent/upstream/remote/remote.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -111,7 +112,7 @@ func (u *Remote) uploadProfile(j *uploadJob) {
 	q.Set("spyName", j.spyName)
 	q.Set("sampleRate", strconv.Itoa(j.sampleRate))
 
-	urlObj.Path = "/ingest"
+	urlObj.Path = path.Join(urlObj.Path, "/ingest")
 	urlObj.RawQuery = q.Encode()
 	buf := j.t.Bytes()
 	log.Info("uploading at ", urlObj.String())


### PR DESCRIPTION
Currently the upload URL overrides the whole path on the server URL given to the agent.
Assuming the server URL of `https://localhost/pyroscope/` is given to the agent, it will attempt to upload to `https://localhost/ingest` instead of the (imo at least) expected `https://localhost/pyroscope/ingest`.

If you think this might break things please let me know of any better ways of dealing with this issue and I can update the PR. :)

Thank you very much in advance!