### PR TITLE
fix connection reuse

### DIFF
--- a/pkg/agent/upstream/remote/remote.go
+++ b/pkg/agent/upstream/remote/remote.go
@@ -130,8 +130,11 @@ func (u *Remote) uploadProfile(j *uploadJob) {
 
 	if err != nil {
 		log.Error("Error happened when uploading a profile:", err)
+		return
 	}
+
 	if resp != nil {
+		defer resp.Body.Close()
 		_, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			log.Error("Error happened while reading server response:", err)

--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -82,6 +82,7 @@ func (ctrl *Controller) Start() {
 		Handler:        mux,
 		ReadTimeout:    10 * time.Second,
 		WriteTimeout:   10 * time.Second,
+		IdleTimeout:    30 * time.Second,
 		MaxHeaderBytes: 1 << 20,
 		ErrorLog:       golog.New(w, "", 0),
 	}


### PR DESCRIPTION
When I use pyroscope with golang, I got some problem, as the same with the issue [#70](https://github.com/pyroscope-io/pyroscope/issues/70), and I found something with wireshark as blow:
![image](https://user-images.githubusercontent.com/1380777/108510372-61e8c500-72f9-11eb-9435-0eb4743fe1a8.png)
The Server closed connection, the reason is: without setting `IdleTimeout` in `http.Server`,  `ReadTimeout` will be used instead,  We can find instructions [here](https://github.com/golang/go/blob/release-branch.go1.14/src/net/http/server.go#L2560),  besides,  the agent will sent to server at 10s intervals, so that's what happens in the picture above。
So I set `IdleTimeout` with magic number `30`, so the connection can be reused.