### PR TITLE
Go lint updates

### DIFF
--- a/pkg/storage/key.go
+++ b/pkg/storage/key.go
@@ -40,7 +40,6 @@ func ParseKey(name string) (*Key, error) {
 	}
 
 	state := nameParserState
-
 	key := ""
 	value := ""
 
@@ -117,25 +116,31 @@ func (k *Key) Normalized() string {
 	sortedMap := sortedmap.New()
 	for k, v := range k.labels {
 		if k == "__name__" {
-			sb.WriteString(v)
+			writeString(&sb, v)
 		} else {
 			sortedMap.Put(k, v)
 		}
 	}
 
-	sb.WriteString("{")
+	writeString(&sb, "{")
 	for i, k := range sortedMap.Keys() {
 		v := sortedMap.Get(k).(string)
 		if i != 0 {
-			sb.WriteString(",")
+			writeString(&sb, ",")
 		}
-		sb.WriteString(k)
-		sb.WriteString("=")
-		sb.WriteString(v)
+		writeString(&sb, k)
+		writeString(&sb, "=")
+		writeString(&sb, v)
 	}
-	sb.WriteString("}")
+	writeString(&sb, "}")
 
 	return sb.String()
+}
+
+func writeString(sb *strings.Builder, value string) {
+	if _, err := sb.WriteString(value); err != nil {
+		panic(err)
+	}
 }
 
 func (k *Key) Hashed() []byte {

--- a/revive.toml
+++ b/revive.toml
@@ -67,6 +67,7 @@ warningCode = 0
 [rule.bare-return]
 [rule.unused-receiver]
 [rule.unhandled-error]
+  arguments = ["sb.WriteString"]
   severity = "error"
 [rule.cognitive-complexity]
   arguments = [7]


### PR DESCRIPTION
This PR addresses

- the ParseKey functions cognitive complexity
- the ParseKey functions cyclomatic complexity
- whitelist the strings.Builder.WriteString() method from unhandled error check