### PR TITLE
Improvements to Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 target
 third_party/*/target
 webapp/public/*
+node_modules
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,22 +8,21 @@
 FROM alpine:3.12 as rust-builder
 
 RUN apk update &&\
-    apk add git gcc g++ make build-base openssl-dev musl musl-dev \
-    rust cargo curl
+    apk add --no-cache git gcc g++ make build-base openssl-dev musl musl-dev curl
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN /root/.cargo/bin/rustup target add $(uname -m)-unknown-linux-musl
 
-RUN wget https://github.com/libunwind/libunwind/releases/download/v1.3.1/libunwind-1.3.1.tar.gz
-RUN tar -zxvf libunwind-1.3.1.tar.gz
-RUN cd libunwind-1.3.1/ && ./configure --disable-minidebuginfo --enable-ptrace --disable-tests --disable-documentation && make && make install
+RUN wget https://github.com/libunwind/libunwind/releases/download/v1.3.1/libunwind-1.3.1.tar.gz && \
+    tar -zxf libunwind-1.3.1.tar.gz && \
+    cd libunwind-1.3.1/ && \
+    ./configure --disable-minidebuginfo --enable-ptrace --disable-tests --disable-documentation && make && make install
 
 COPY third_party/rustdeps /opt/rustdeps
 
 WORKDIR /opt/rustdeps
 
-ENV RUSTFLAGS="-C target-feature=+crt-static"
-RUN /root/.cargo/bin/cargo build --release --target $(uname -m)-unknown-linux-musl
+RUN RUSTFLAGS="-C target-feature=+crt-static" /root/.cargo/bin/cargo build --release --target $(uname -m)-unknown-linux-musl
 RUN mv /opt/rustdeps/target/$(uname -m)-unknown-linux-musl/release/librustdeps.a /opt/rustdeps/librustdeps.a
 
 


### PR DESCRIPTION
This does some small cleanup in the Dockerfile

1. Remove the `apk install cargo rust`. This is being done in the next line, and it gives the following warning -
```
---> Running in 0851d6e7854d
info: downloading installer
warning: it looks like you have an existing installation of Rust at:
warning: /usr/bin
warning: rustup should not be installed alongside Rust. Please uninstall your existing Rust first.
warning: Otherwise you may have confusion unless you are careful with your PATH
warning: If you are sure that you want both rustup and your already installed Rust
warning: then please reply `y' or `yes' or set RUSTUP_INIT_SKIP_PATH_CHECK to yes
warning: or pass `-y' to ignore all ignorable checks.
error: cannot install while Rust is installed
warning: continuing (because the -y flag is set and the error is ignorable)
...
```

It also has the benefit of reducing the size of packages downloaded by ~200MB

2. Combine some RUN commands into a single one. In the `libunwind` install, if one is changed, all three will have to be changed. The ENV flag is also only applicable to the next command. This reduces the number of intermediate layers by 3

3. Adding `node_modules`, `.git` to dockerignore reduces the build context to 1.5 MB from ~400 MB earlier. This was done since included in https://github.com/BretFisher/node-docker-good-defaults/blob/main/.dockerignore

This is my first time contributing to this project so do let me know if there more information or anything else required from my side!