### PR TITLE
Fix some Revive lint warnings

### DIFF
--- a/pkg/agent/csock/csock.go
+++ b/pkg/agent/csock/csock.go
@@ -57,7 +57,11 @@ func (c *CSock) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		logrus.Error(err) // TODO: handle
 	}
 	req := &Request{}
-	json.Unmarshal(buf, &req)
+	err = json.Unmarshal(buf, &req)
+	if err != nil {
+		logrus.Error(err)
+	}
+
 	req.Command = commandFromRequest(r)
 	resp := c.callback(req)
 	rw.WriteHeader(200)
@@ -65,7 +69,10 @@ func (c *CSock) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logrus.Error(err) // TODO: handle
 	}
-	rw.Write(b)
+	_, err = rw.Write(b)
+	if err != nil {
+		logrus.Error(err)
+	}
 }
 
 func (c *CSock) CanonicalAddr() string {

--- a/pkg/storage/dict/trie.go
+++ b/pkg/storage/dict/trie.go
@@ -70,55 +70,55 @@ OuterLoop:
 			varint.Write(w, uint64(len(key)))
 			// fn(newTn)
 			return
-		} else {
-			leadKey := tn.children[leadIndex].label
-			// log.Debug("lead key", string(leadKey))
-			lk := len(key)
-			llk := len(leadKey)
-			for i := 0; i < lk; i++ {
-				if i == llk { // 4 fooo / foo i = 3 llk = 3
-					// log.Debug("case 4")
-					tn = tn.children[leadIndex]
-					key = key[llk:]
-					varint.Write(w, uint64(leadIndex))
-					varint.Write(w, uint64(llk))
-					continue OuterLoop
-				}
-				if leadKey[i] != key[i] { // 3
-					a := leadKey[:i] // ab
-					b := leadKey[i:] // c
-					newTn := newTrieNode(a)
-					newTn.children = []*trieNode{tn.children[leadIndex]}
-					tn.children[leadIndex].label = b
-					tn.children[leadIndex] = newTn
-					tn = newTn
-					key = key[i:]
+		}
 
-					varint.Write(w, uint64(leadIndex))
-					varint.Write(w, uint64(i))
-					continue OuterLoop
-				}
+		leadKey := tn.children[leadIndex].label
+		// log.Debug("lead key", string(leadKey))
+		lk := len(key)
+		llk := len(leadKey)
+		for i := 0; i < lk; i++ {
+			if i == llk { // 4 fooo / foo i = 3 llk = 3
+				// log.Debug("case 4")
+				tn = tn.children[leadIndex]
+				key = key[llk:]
+				varint.Write(w, uint64(leadIndex))
+				varint.Write(w, uint64(llk))
+				continue OuterLoop
 			}
-			// lk < llk
-			if !bytes.Equal(key, leadKey) { // 3
-				a := leadKey[:lk] // ab
-				b := leadKey[lk:] // c
+			if leadKey[i] != key[i] { // 3
+				a := leadKey[:i] // ab
+				b := leadKey[i:] // c
 				newTn := newTrieNode(a)
 				newTn.children = []*trieNode{tn.children[leadIndex]}
 				tn.children[leadIndex].label = b
 				tn.children[leadIndex] = newTn
 				tn = newTn
-				key = key[lk:]
+				key = key[i:]
 
 				varint.Write(w, uint64(leadIndex))
-				varint.Write(w, uint64(lk))
+				varint.Write(w, uint64(i))
 				continue OuterLoop
-			} else {
-				// 2
-				varint.Write(w, uint64(leadIndex))
-				varint.Write(w, uint64(len(leadKey)))
-				return
 			}
 		}
+		// lk < llk
+		if !bytes.Equal(key, leadKey) { // 3
+			a := leadKey[:lk] // ab
+			b := leadKey[lk:] // c
+			newTn := newTrieNode(a)
+			newTn.children = []*trieNode{tn.children[leadIndex]}
+			tn.children[leadIndex].label = b
+			tn.children[leadIndex] = newTn
+			tn = newTn
+			key = key[lk:]
+
+			varint.Write(w, uint64(leadIndex))
+			varint.Write(w, uint64(lk))
+			continue OuterLoop
+		}
+
+		// 2
+		varint.Write(w, uint64(leadIndex))
+		varint.Write(w, uint64(len(leadKey)))
+		return
 	}
 }

--- a/pkg/util/attime/attime_test.go
+++ b/pkg/util/attime/attime_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 var _ = Describe("metadata", func() {
-
 	Describe("Parse", func() {
 		Context("simple cases", func() {
 			It("works correctly", func() {


### PR DESCRIPTION
Continuation of #49

Warnings fixed -

```
pkg/agent/csock/csock.go
  (60, 2)  https://revive.run/r#unhandled-error  Unhandled error in call to function json.Unmarshal  
  (68, 2)  https://revive.run/r#unhandled-error  Unhandled error in call to function rw.Write 

pkg/util/attime/attime_test.go
  (10, 37)  https://revive.run/r#empty-lines  extra empty line at the start of a bloc

pkg/storage/dict/trie.go   
  (116, 11)  https://revive.run/r#superfluous-else      if block ends with a continue statement, so drop this else and outdent its block  
  (73, 10)   https://revive.run/r#indent-error-flow     if block ends with a return statement, so drop this else and outdent its block
```

Unified diff is slightly difficult to read, easier to view the split one to ensure nothing has changed
