### PR TITLE
Use bash to run scripts

### DIFF
--- a/scripts/generate-build-flags.sh
+++ b/scripts/generate-build-flags.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/scripts/pinned-tool.sh
+++ b/scripts/pinned-tool.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # this is basically $(yarn bin <command name>) alternative for golang
 


### PR DESCRIPTION
Fixes a `Bad Substitution` error when running `make lint` on Ubuntu 18.04. `/bin/sh` doesn't have the `${@:2}` syntax. Error:
```
$ make lint                             
scripts/pinned-tool.sh github.com/mgechev/revive -config revive.toml -exclude ./vendor/... -formatter stylish ./...
scripts/pinned-tool.sh: 5: scripts/pinned-tool.sh: Bad substitution
Makefile:73: recipe for target 'lint' failed
make: *** [lint] Error 2
```

After fixing this, the `$(go list -m -f '{{.Dir}}' $1)` part was returning empty string, which resulted in `go run: cannot run non-main package` error. Found after adding some debug statements -

```
$ make lint
scripts/pinned-tool.sh github.com/mgechev/revive -config revive.toml -exclude ./vendor/... -formatter stylish ./...
+ echo github.com/mgechev/revive
github.com/mgechev/revive
++ go list -m -f '{{.Dir}}' github.com/mgechev/revive
+ echo ''

++ go list -m -f '{{.Dir}}' github.com/mgechev/revive
+ go run '' -config revive.toml -exclude ./vendor/... -formatter stylish ./...
go run: cannot run non-main package
Makefile:73: recipe for target 'lint' failed
make: *** [lint] Error 1
```

Running `go list github.com/mgechev/revive` manually fixed the problem. Mentioned here if someone else also runs into this.

```
$ go list github.com/mgechev/revive 
go: downloading github.com/pyroscope-io/revive v1.0.6-0.20210330033039-4a71146f9dc1
github.com/mgechev/revive
```

The `generate-build-flags.sh` change fixes the problem with `source` not being a valid command, mentioned in #140