### PR TITLE
fix upload panic(do upload with recover)

### DIFF
--- a/pkg/agent/upstream/direct/direct.go
+++ b/pkg/agent/upstream/direct/direct.go
@@ -92,7 +92,7 @@ func (u *Direct) uploadLoop() {
 		select {
 		case j := <-u.todo:
 			logrus.Debug("upload profile")
-			u.uploadProfile(j)
+			u.safeUpload(j)
 		case <-u.done:
 			return
 		}

--- a/pkg/agent/upstream/direct/direct.go
+++ b/pkg/agent/upstream/direct/direct.go
@@ -1,6 +1,7 @@
 package direct
 
 import (
+	"runtime/debug"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -96,4 +97,15 @@ func (u *Direct) uploadLoop() {
 			return
 		}
 	}
+}
+
+// do safe upload
+func (u *Direct) safeUpload(j *uploadJob) {
+	defer func() {
+		if r := recover(); r != nil {
+			logrus.Errorf("panic, stack = : %v", debug.Stack())
+		}
+	}()
+
+	u.uploadProfile(j)
 }

--- a/pkg/agent/upstream/remote/remote.go
+++ b/pkg/agent/upstream/remote/remote.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"runtime/debug"
 	"strconv"
 	"strings"
 	"sync"
@@ -158,7 +159,7 @@ func (u *Remote) uploadLoop() {
 	for {
 		select {
 		case j := <-u.todo:
-			u.uploadProfile(j)
+			u.safeUpload(j)
 		case wg := <-u.done:
 			wg.Done()
 			return
@@ -168,4 +169,17 @@ func (u *Remote) uploadLoop() {
 
 func requiresAuthToken(u *url.URL) bool {
 	return strings.HasSuffix(u.Host, cloudHostnameSuffix)
+}
+
+// do safe upload
+func (u *Remote) safeUpload(j *uploadJob) {
+	defer func() {
+		if r := recover(); r != nil {
+			if u.Logger != nil {
+				u.Logger.Errorf("panic, stack = : %v", debug.Stack())
+			}
+		}
+	}()
+
+	u.uploadProfile(j)
 }


### PR DESCRIPTION
panic callstack

```bash
INFO[227235] storage.Put                                   endTime="2021-04-03 01:13:00 +0000 UTC" key="pyroscope.server.cpu{}" samples=14 startTime="2021-04-03 01:13:00 +0000 UTC"
panic: division by zero

goroutine 8 [running]:
math/big.(*Rat).SetFrac64(0xc027d889c0, 0x0, 0x0, 0x0)
	math/big/rat.go:321 +0xff
math/big.NewRat(...)
	math/big/rat.go:34
github.com/pyroscope-io/pyroscope/pkg/storage/segment.overlapWrite(0x0, 0xed7cbcd80, 0x1bf0b00, 0x0, 0xed8646400, 0x1bf0b00, 0x0, 0xed7f9b81c, 0x1bf0b00, 0x0, ...)
	github.com/pyroscope-io/pyroscope/pkg/storage/segment/overlap.go:45 +0x229
github.com/pyroscope-io/pyroscope/pkg/storage/segment.(*streeNode).overlapWrite(0xc02360c1e0, 0x0, 0xed7f9b81c, 0x1bf0b00, 0x0, 0xed7f9b81c, 0x1bf0b00, 0xed7f9b81c)
	github.com/pyroscope-io/pyroscope/pkg/storage/segment/segment.go:49 +0x125
github.com/pyroscope-io/pyroscope/pkg/storage/segment.(*streeNode).put(0xc02360c1e0, 0x0, 0xed7f9b81c, 0x1bf0b00, 0x0, 0xed7f9b81c, 0x1bf0b00, 0xe, 0xc01b79bbc8)
	github.com/pyroscope-io/pyroscope/pkg/storage/segment/segment.go:108 +0x68c
github.com/pyroscope-io/pyroscope/pkg/storage/segment.(*Segment).Put(0xc01bac9380, 0x0, 0xed7f9b81c, 0x1bf0b00, 0x0, 0xed7f9b81c, 0x1bf0b00, 0xe, 0xc01b79bc90)
	github.com/pyroscope-io/pyroscope/pkg/storage/segment/segment.go:252 +0x235
github.com/pyroscope-io/pyroscope/pkg/storage.(*Storage).Put(0xc0001a6770, 0x0, 0xed7f9b81c, 0x1bf0b00, 0x0, 0xed7f9b81c, 0x1bf0b00, 0xc0284dfce8, 0xc02f12e8c0, 0x132d525, ...)
	github.com/pyroscope-io/pyroscope/pkg/storage/storage.go:195 +0x74c
github.com/pyroscope-io/pyroscope/pkg/agent/upstream/direct.(*Direct).uploadProfile(0xc0000a1240, 0xc023abac00)
	github.com/pyroscope-io/pyroscope/pkg/agent/upstream/direct/direct.go:86 +0x196
github.com/pyroscope-io/pyroscope/pkg/agent/upstream/direct.(*Direct).uploadLoop(0xc0000a1240)
	github.com/pyroscope-io/pyroscope/pkg/agent/upstream/direct/direct.go:94 +0xaa
created by github.com/pyroscope-io/pyroscope/pkg/agent/upstream/direct.(*Direct).start
	github.com/pyroscope-io/pyroscope/pkg/agent/upstream/direct/direct.go:46 +0x49
```