### PR TITLE
Adds PHP support via phpspy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,9 @@ COPY --from=rust-builder /opt/rustdeps/librustdeps.a /opt/pyroscope/third_party/
 COPY third_party/rustdeps/rbspy.h /opt/pyroscope/third_party/rustdeps/rbspy.h
 COPY third_party/rustdeps/pyspy.h /opt/pyroscope/third_party/rustdeps/pyspy.h
 
+COPY third_party/phpspy/phpspy.h /opt/pyroscope/third_party/phpspy/phpspy.h
+COPY --from=pyroscope/phpspy:dev /var/www/html/phpspy/libphpspy.a /opt/pyroscope/third_party/phpspy/libphpspy.a
+
 COPY --from=js-builder /opt/pyroscope/webapp/public ./webapp/public
 COPY pkg ./pkg
 COPY cmd ./cmd

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ifeq ("$(shell go env GOARCH || true)", "arm64")
 endif
 
 ifeq ("$(shell go env GOOS || true)", "linux")
-	ENABLED_SPIES ?= "ebpfspy,rbspy,pyspy"
+	ENABLED_SPIES ?= "ebpfspy,rbspy,pyspy,phpspy"
 else
 	ENABLED_SPIES ?= "rbspy,pyspy"
 endif

--- a/examples/php/Dockerfile
+++ b/examples/php/Dockerfile
@@ -1,0 +1,11 @@
+FROM php:7.3.27
+
+WORKDIR /var/www/html
+
+COPY --from=pyroscope/pyroscope:dev /usr/bin/pyroscope /usr/bin/pyroscope
+COPY main.php ./main.php
+
+ENV PYROSCOPE_APPLICATION_NAME=simple.php.app
+ENV PYROSCOPE_SERVER_ADDRESS=http://pyroscope:4040/
+ENV PYROSCOPE_LOG_LEVEL=debug
+CMD ["pyroscope", "exec", "php", "main.php"]

--- a/examples/php/docker-compose.yml
+++ b/examples/php/docker-compose.yml
@@ -1,0 +1,14 @@
+---
+version: "3.9"
+services:
+  pyroscope:
+    image: "pyroscope/pyroscope:latest"
+    ports:
+      - "4040:4040"
+    command:
+      - "server"
+  app:
+    build: .
+    cap_add:
+      - SYS_PTRACE
+

--- a/examples/php/main.php
+++ b/examples/php/main.php
@@ -1,0 +1,9 @@
+<?php
+$x = 1;
+
+while(true) {
+  echo "The number is: $x\n";
+  $x++;
+  sleep(1);
+}
+?>

--- a/pkg/agent/phpspy/phpspy.go
+++ b/pkg/agent/phpspy/phpspy.go
@@ -1,0 +1,79 @@
+// +build phpspy
+
+// Package phpspy is a wrapper around this library called phpspy written in Rust
+package phpspy
+
+// #cgo darwin LDFLAGS: -L../../../third_party/phpspy -lphpspy
+// #cgo linux LDFLAGS: -L../../../third_party/phpspy -lphpspy
+// #include "../../../third_party/phpspy/phpspy.h"
+import "C"
+
+import (
+	"errors"
+	"time"
+	"unsafe"
+
+	"github.com/pyroscope-io/pyroscope/pkg/agent/spy"
+)
+
+// TODO: make this configurable
+// TODO: pass lower level structures between go and rust?
+var bufferLength = 1024 * 64
+
+type PhpSpy struct {
+	dataBuf []byte
+	dataPtr unsafe.Pointer
+
+	errorBuf []byte
+	errorPtr unsafe.Pointer
+
+	pid int
+}
+
+func Start(pid int) (spy.Spy, error) {
+	dataBuf := make([]byte, bufferLength)
+	dataPtr := unsafe.Pointer(&dataBuf[0])
+
+	errorBuf := make([]byte, bufferLength)
+	errorPtr := unsafe.Pointer(&errorBuf[0])
+
+	// Sometimes phpspy doesn't initialize properly right after the process starts so we need to give it some time
+	// TODO: handle this better
+	time.Sleep(1 * time.Second)
+
+	r := C.phpspy_init(C.int(pid), errorPtr, C.int(bufferLength))
+
+	if r < 0 {
+		return nil, errors.New(string(errorBuf[:-r]))
+	}
+
+	return &PhpSpy{
+		dataPtr:  dataPtr,
+		dataBuf:  dataBuf,
+		errorBuf: errorBuf,
+		errorPtr: errorPtr,
+		pid:      pid,
+	}, nil
+}
+
+func (s *PhpSpy) Stop() error {
+	r := C.phpspy_cleanup(C.int(s.pid), s.errorPtr, C.int(bufferLength))
+	if r < 0 {
+		return errors.New(string(s.errorBuf[:-r]))
+	}
+	return nil
+}
+
+// Snapshot calls callback function with stack-trace or error.
+func (s *PhpSpy) Snapshot(cb func([]byte, uint64, error)) {
+	r := C.phpspy_snapshot(C.int(s.pid), s.dataPtr, C.int(bufferLength), s.errorPtr, C.int(bufferLength))
+	if r < 0 {
+		cb(nil, 0, errors.New(string(s.errorBuf[:-r])))
+	} else {
+		cb(s.dataBuf[:r], 1, nil)
+	}
+}
+
+func init() {
+	spy.RegisterSpy("phpspy", Start)
+}

--- a/pkg/agent/phpspy/phpspy.go
+++ b/pkg/agent/phpspy/phpspy.go
@@ -9,6 +9,7 @@ package phpspy
 import "C"
 
 import (
+	"bytes"
 	"errors"
 	"time"
 	"unsafe"
@@ -70,10 +71,17 @@ func (s *PhpSpy) Snapshot(cb func([]byte, uint64, error)) {
 	if r < 0 {
 		cb(nil, 0, errors.New(string(s.errorBuf[:-r])))
 	} else {
-		cb(s.dataBuf[:r], 1, nil)
+		cb(trimSemicolon(s.dataBuf[:r]), 1, nil)
 	}
 }
 
 func init() {
 	spy.RegisterSpy("phpspy", Start)
+}
+
+func trimSemicolon(b []byte) []byte {
+	if bytes.HasSuffix(b, []byte(";")) {
+		return b[:len(b)-1]
+	}
+	return b
 }

--- a/pkg/agent/phpspy/placeholder.go
+++ b/pkg/agent/phpspy/placeholder.go
@@ -1,0 +1,3 @@
+// +build !phpspy
+
+package phpspy

--- a/pkg/agent/session.go
+++ b/pkg/agent/session.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/pyroscope-io/pyroscope/pkg/agent/debugspy"
 	_ "github.com/pyroscope-io/pyroscope/pkg/agent/ebpfspy"
 	_ "github.com/pyroscope-io/pyroscope/pkg/agent/gospy"
+	_ "github.com/pyroscope-io/pyroscope/pkg/agent/phpspy"
 	_ "github.com/pyroscope-io/pyroscope/pkg/agent/pyspy"
 	_ "github.com/pyroscope-io/pyroscope/pkg/agent/rbspy"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/upstream"

--- a/pkg/agent/spy/spy.go
+++ b/pkg/agent/spy/spy.go
@@ -28,6 +28,8 @@ var autoDetectionMapping = map[string]string{
 	"uwsgi":   "pyspy",
 	"pipenv":  "pyspy",
 
+	"php": "phpspy",
+
 	"ruby":   "rbspy",
 	"bundle": "rbspy",
 	"rails":  "rbspy",

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -81,6 +81,8 @@ type metrics struct {
 	SpyRbspy         int       `json:"spy_rbspy"`
 	SpyPyspy         int       `json:"spy_pyspy"`
 	SpyGospy         int       `json:"spy_gospy"`
+	SpyEbpfspy       int       `json:"spy_ebpfspy"`
+	SpyPhpspy        int       `json:"spy_phpspy"`
 	AppsCount        int       `json:"apps_count"`
 }
 
@@ -138,6 +140,8 @@ func (s *Service) sendReport() {
 		SpyRbspy:         controllerStats["ingest:rbspy"],
 		SpyPyspy:         controllerStats["ingest:pyspy"],
 		SpyGospy:         controllerStats["ingest:gospy"],
+		SpyEbpfspy:       controllerStats["ingest:ebpfspy"],
+		SpyPhpspy:        controllerStats["ingest:phpspy"],
 		AppsCount:        s.c.AppsCount(),
 	}
 

--- a/third_party/phpspy/phpspy.h
+++ b/third_party/phpspy/phpspy.h
@@ -1,0 +1,5 @@
+#include <sys/types.h>
+
+int phpspy_init(pid_t pid, void* err_ptr, int err_len);
+int phpspy_cleanup(pid_t pid, void* err_ptr, int err_len);
+int phpspy_snapshot(pid_t pid, void* ptr, int len, void* err_ptr, int err_len);


### PR DESCRIPTION
## TODO:
* [x] set up C library scaffolding, make `phpspy` code compile into a static library.
* [x] connect [the interface](https://github.com/pyroscope-io/phpspy/blob/main/pyroscope_api.c) with the [actual profiling code](https://github.com/pyroscope-io/phpspy/blob/main/phpspy.c#L345)
* [x] connect C library with go code


## Instructions
These are instructions on how to test changes in this PR
### Setup

* clone pyroscope repo
```
git clone https://github.com/pyroscope-io/pyroscope
```
* clone phpspy library repo
```
git clone https://github.com/pyroscope-io/phpspy
```


### Test Changes

To test changes you make in phpspy repo:

* first, build phpspy library:
```bash
cd phpspy
docker build . --tag pyroscope/phpspy:dev
```

* second, build a new pyroscope version:
```bash
cd pyroscope
docker build . --tag pyroscope/pyroscope:dev
```

* third, build and run the example application with the new pyroscope version:
```bash
cd pyroscope/examples/php
docker-compose build && docker-compose up
```