### PR TITLE
Fix issue #154: Add ability to change sampling rate

### DIFF
--- a/pkg/agent/cli/agent.go
+++ b/pkg/agent/cli/agent.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pyroscope-io/pyroscope/pkg/agent"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/csock"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/spy"
+	"github.com/pyroscope-io/pyroscope/pkg/agent/types"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/upstream"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/upstream/remote"
 	"github.com/pyroscope-io/pyroscope/pkg/config"
@@ -66,7 +67,7 @@ func (a *Agent) controlSocketHandler(req *csock.Request) *csock.Response {
 			Upstream:         a.u,
 			AppName:          "testapp",
 			ProfilingTypes:   []spy.ProfileType{spy.ProfileCPU, spy.ProfileAllocObjects, spy.ProfileAllocSpace, spy.ProfileInuseObjects, spy.ProfileInuseSpace},
-			SpyName:          "gospy",
+			SpyName:          types.GoSpy,
 			SampleRate:       100,
 			UploadRate:       10 * time.Second,
 			Pid:              0,

--- a/pkg/agent/gospy/gospy.go
+++ b/pkg/agent/gospy/gospy.go
@@ -37,7 +37,9 @@ func Start(profileType spy.ProfileType, disableGCRuns bool) (spy.Spy, error) {
 		disableGCRuns: disableGCRuns,
 	}
 	if s.profileType == spy.ProfileCPU {
-		_ = pprof.StartCPUProfile(s.buf)
+		if err := pprof.StartCPUProfile(s.buf); err != nil {
+			return nil, err
+		}
 	}
 	return s, nil
 }

--- a/pkg/agent/selfprofile.go
+++ b/pkg/agent/selfprofile.go
@@ -3,20 +3,19 @@ package agent
 import (
 	"time"
 
-	"github.com/pyroscope-io/pyroscope/pkg/agent/spy"
+	"github.com/pyroscope-io/pyroscope/pkg/agent/types"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/upstream"
 	"github.com/pyroscope-io/pyroscope/pkg/config"
 	"github.com/pyroscope-io/pyroscope/pkg/util/atexit"
 )
 
-func SelfProfile(_ *config.Config, u upstream.Upstream, appName string, logger Logger) error {
-	// TODO: sample rate and upload rate should come from config
+func SelfProfile(cfg *config.Config, u upstream.Upstream, appName string, logger Logger) error {
 	c := SessionConfig{
 		Upstream:         u,
 		AppName:          appName,
-		ProfilingTypes:   []spy.ProfileType{spy.ProfileCPU, spy.ProfileAllocObjects, spy.ProfileAllocSpace, spy.ProfileInuseObjects, spy.ProfileInuseSpace},
-		SpyName:          "gospy",
-		SampleRate:       100,
+		ProfilingTypes:   types.DefaultProfileTypes,
+		SpyName:          types.GoSpy,
+		SampleRate:       uint32(cfg.Server.SampleRate),
 		UploadRate:       10 * time.Second,
 		Pid:              0,
 		WithSubprocesses: false,

--- a/pkg/agent/session.go
+++ b/pkg/agent/session.go
@@ -27,7 +27,7 @@ type ProfileSession struct {
 	upstream   upstream.Upstream
 	appName    string
 	spyName    string
-	sampleRate int
+	sampleRate uint32
 	uploadRate time.Duration
 	pids       []int
 	spies      []spy.Spy
@@ -53,7 +53,7 @@ type SessionConfig struct {
 	ProfilingTypes   []spy.ProfileType
 	DisableGCRuns    bool
 	SpyName          string
-	SampleRate       int
+	SampleRate       uint32
 	UploadRate       time.Duration
 	Pid              int
 	WithSubprocesses bool
@@ -99,7 +99,7 @@ func (ps *ProfileSession) takeSnapshots() {
 			}
 			for i, s := range ps.spies {
 				s.Snapshot(func(stack []byte, v uint64, err error) {
-					if stack != nil && len(stack) > 0 {
+					if len(stack) > 0 {
 						ps.trieMutex.Lock()
 						defer ps.trieMutex.Unlock()
 

--- a/pkg/agent/session.go
+++ b/pkg/agent/session.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/pyroscope-io/pyroscope/pkg/agent/gospy"
 	_ "github.com/pyroscope-io/pyroscope/pkg/agent/pyspy"
 	_ "github.com/pyroscope-io/pyroscope/pkg/agent/rbspy"
+	"github.com/pyroscope-io/pyroscope/pkg/agent/types"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/upstream"
 	"github.com/pyroscope-io/pyroscope/pkg/util/slices"
 
@@ -73,7 +74,7 @@ func NewSession(c *SessionConfig) *ProfileSession {
 		withSubprocesses: c.WithSubprocesses,
 	}
 
-	if ps.spyName == "gospy" {
+	if ps.spyName == types.GoSpy {
 		ps.previousTries = make([]*transporttrie.Trie, len(ps.profileTypes))
 		ps.tries = make([]*transporttrie.Trie, len(ps.profileTypes))
 	} else {
@@ -103,7 +104,7 @@ func (ps *ProfileSession) takeSnapshots() {
 						ps.trieMutex.Lock()
 						defer ps.trieMutex.Unlock()
 
-						if ps.spyName == "gospy" {
+						if ps.spyName == types.GoSpy {
 							ps.tries[i].Insert(stack, v, true)
 						} else {
 							ps.tries[0].Insert(stack, v, true)
@@ -128,7 +129,7 @@ func (ps *ProfileSession) takeSnapshots() {
 func (ps *ProfileSession) Start() error {
 	ps.reset()
 
-	if ps.spyName == "gospy" {
+	if ps.spyName == types.GoSpy {
 		for _, pt := range ps.profileTypes {
 			s, err := gospy.Start(pt, ps.disableGCRuns)
 			if err != nil {

--- a/pkg/agent/spy/spy.go
+++ b/pkg/agent/spy/spy.go
@@ -22,6 +22,10 @@ const (
 	ProfileAllocObjects ProfileType = "alloc_objects"
 	ProfileInuseSpace   ProfileType = "inuse_space"
 	ProfileAllocSpace   ProfileType = "alloc_space"
+
+	Go     = "gospy"
+	Python = "pyspy"
+	Ruby   = "rbspy"
 )
 
 func (t ProfileType) IsCumulative() bool {
@@ -90,7 +94,7 @@ func ResolveAutoName(s string) string {
 func SupportedExecSpies() []string {
 	supportedSpies := []string{}
 	for _, s := range SupportedSpies {
-		if s != "gospy" {
+		if s != Go {
 			supportedSpies = append(supportedSpies, s)
 		}
 	}

--- a/pkg/agent/types/types.go
+++ b/pkg/agent/types/types.go
@@ -1,0 +1,18 @@
+package types
+
+import "github.com/pyroscope-io/pyroscope/pkg/agent/spy"
+
+const (
+	DefaultSampleRate = 100 // 100 times per
+	GoSpy             = spy.Go
+	PySpy             = spy.Python
+	RbSpy             = spy.Ruby
+)
+
+var DefaultProfileTypes = []spy.ProfileType{
+	spy.ProfileCPU,
+	spy.ProfileAllocObjects,
+	spy.ProfileAllocSpace,
+	spy.ProfileInuseObjects,
+	spy.ProfileInuseSpace,
+}

--- a/pkg/agent/upstream/remote/remote.go
+++ b/pkg/agent/upstream/remote/remote.go
@@ -99,7 +99,7 @@ func (u *Remote) uploadProfile(j *upstream.UploadJob) {
 	q.Set("from", strconv.Itoa(int(j.StartTime.Unix())))
 	q.Set("until", strconv.Itoa(int(j.EndTime.Unix())))
 	q.Set("spyName", j.SpyName)
-	q.Set("sampleRate", strconv.Itoa(j.SampleRate))
+	q.Set("sampleRate", strconv.Itoa(int(j.SampleRate)))
 	q.Set("units", j.Units)
 	q.Set("aggregationType", j.AggregationType)
 

--- a/pkg/agent/upstream/upstream.go
+++ b/pkg/agent/upstream/upstream.go
@@ -11,7 +11,7 @@ type UploadJob struct {
 	StartTime       time.Time
 	EndTime         time.Time
 	SpyName         string
-	SampleRate      int
+	SampleRate      uint32
 	Units           string
 	AggregationType string
 	Trie            *transporttrie.Trie

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -178,6 +178,19 @@ func PopulateFlagSet(obj interface{}, flagSet *flag.FlagSet, skip ...string) *So
 				}
 			}
 			flagSet.Uint64Var(val, nameVal, defaultVal, descVal)
+		case reflect.TypeOf(uint(1)):
+			val := fieldV.Addr().Interface().(*uint)
+			var defaultVal uint
+			if defaultValStr == "" {
+				defaultVal = uint(0)
+			} else {
+				out, err := strconv.ParseUint(defaultValStr, 10, 64)
+				if err != nil {
+					logrus.Fatalf("invalid default value: %q (%s)", defaultValStr, nameVal)
+				}
+				defaultVal = uint(out)
+			}
+			flagSet.UintVar(val, nameVal, defaultVal, descVal)
 		default:
 			logrus.Fatalf("type %s is not supported", field.Type)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,6 +59,7 @@ type Server struct {
 	HideApplications []string `def:"" desc:"please don't use, this will soon be deprecated"`
 
 	OutOfSpaceThreshold bytesize.ByteSize `def:"512MB" desc:"Threshold value to consider out of space in bytes"`
+	SampleRate          uint              `def:"100" desc:"sample rate for the profiler in Hz. 100 means reading 100 times per second"`
 }
 
 type Convert struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,7 +79,7 @@ type DbManager struct {
 type Exec struct {
 	SpyName                string        `def:"auto" desc:"name of the profiler you want to use. Supported ones are: <supportedProfilers>"`
 	ApplicationName        string        `def:"" desc:"application name used when uploading profiling data"`
-	SampleRate             uint          `def:"100" desc:"sample rate for reading profile data. 100 means reading 100 times per second"`
+	SampleRate             uint          `def:"100" desc:"sample rate for the profiler in Hz. 100 means reading 100 times per second"`
 	DetectSubprocesses     bool          `def:"true" desc:"makes pyroscope keep track of and profile subprocesses of the main process"`
 	LogLevel               string        `def:"info" desc:"log level: debug|info|warn|error"`
 	ServerAddress          string        `def:"http://localhost:4040" desc:"address of the pyroscope server"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,6 +79,7 @@ type DbManager struct {
 type Exec struct {
 	SpyName                string        `def:"auto" desc:"name of the profiler you want to use. Supported ones are: <supportedProfilers>"`
 	ApplicationName        string        `def:"" desc:"application name used when uploading profiling data"`
+	SampleRate             uint          `def:"100" desc:"sample rate for reading profile data. 100 means reading 100 times per second"`
 	DetectSubprocesses     bool          `def:"true" desc:"makes pyroscope keep track of and profile subprocesses of the main process"`
 	LogLevel               string        `def:"info" desc:"log level: debug|info|warn|error"`
 	ServerAddress          string        `def:"http://localhost:4040" desc:"address of the pyroscope server"`

--- a/pkg/exec/cli.go
+++ b/pkg/exec/cli.go
@@ -16,9 +16,9 @@ import (
 	"github.com/fatih/color"
 	"github.com/mitchellh/go-ps"
 	"github.com/pyroscope-io/pyroscope/pkg/agent"
-	"github.com/pyroscope-io/pyroscope/pkg/agent/profiler"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/pyspy"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/spy"
+	"github.com/pyroscope-io/pyroscope/pkg/agent/types"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/upstream/remote"
 	"github.com/pyroscope-io/pyroscope/pkg/config"
 	"github.com/pyroscope-io/pyroscope/pkg/util/atexit"
@@ -146,7 +146,7 @@ func Cli(cfg *config.Config, args []string) error {
 
 	// if the sample rate is zero, use the default value
 	if cfg.Exec.SampleRate == 0 {
-		cfg.Exec.SampleRate = profiler.DefaultSampleRate
+		cfg.Exec.SampleRate = types.DefaultSampleRate
 	}
 
 	sess := agent.NewSession(&agent.SessionConfig{
@@ -224,7 +224,7 @@ func waitForProcessToExit(pid int) {
 }
 
 func performChecks(spyName string) error {
-	if spyName == "gospy" {
+	if spyName == types.GoSpy {
 		return fmt.Errorf("gospy can not profile other processes. See our documentation on using gospy: %s", color.GreenString("https://pyroscope.io/docs/"))
 	}
 

--- a/pkg/exec/cli.go
+++ b/pkg/exec/cli.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/mitchellh/go-ps"
 	"github.com/pyroscope-io/pyroscope/pkg/agent"
+	"github.com/pyroscope-io/pyroscope/pkg/agent/profiler"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/pyspy"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/spy"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/upstream/remote"
@@ -143,13 +144,17 @@ func Cli(cfg *config.Config, args []string) error {
 		"detect-subprocesses": cfg.Exec.DetectSubprocesses,
 	}).Debug("starting agent session")
 
-	// TODO: add sample rate, make it configurable
+	// if the sample rate is zero, use the default value
+	if cfg.Exec.SampleRate == 0 {
+		cfg.Exec.SampleRate = profiler.DefaultSampleRate
+	}
+
 	sess := agent.NewSession(&agent.SessionConfig{
 		Upstream:         u,
 		AppName:          cfg.Exec.ApplicationName,
 		ProfilingTypes:   []spy.ProfileType{spy.ProfileCPU},
 		SpyName:          spyName,
-		SampleRate:       100,
+		SampleRate:       uint32(cfg.Exec.SampleRate),
 		UploadRate:       10 * time.Second,
 		Pid:              pid,
 		WithSubprocesses: cfg.Exec.DetectSubprocesses,

--- a/pkg/server/ingest.go
+++ b/pkg/server/ingest.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pyroscope-io/pyroscope/pkg/agent/profiler"
+	"github.com/pyroscope-io/pyroscope/pkg/agent/types"
 	"github.com/pyroscope-io/pyroscope/pkg/convert"
 	"github.com/pyroscope-io/pyroscope/pkg/storage"
 	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
@@ -69,12 +69,12 @@ func ingestParamsFromRequest(r *http.Request) *ingestParams {
 		sampleRate, err := strconv.Atoi(sr)
 		if err != nil {
 			logrus.WithField("err", err).Errorf("invalid sample rate: %v", sr)
-			ip.sampleRate = profiler.DefaultSampleRate
+			ip.sampleRate = types.DefaultSampleRate
 		} else {
 			ip.sampleRate = uint32(sampleRate)
 		}
 	} else {
-		ip.sampleRate = profiler.DefaultSampleRate
+		ip.sampleRate = types.DefaultSampleRate
 	}
 
 	if sn := q.Get("spyName"); sn != "" {

--- a/pkg/storage/segment/segment.go
+++ b/pkg/storage/segment/segment.go
@@ -152,7 +152,7 @@ type Segment struct {
 	durations  []time.Duration
 
 	spyName         string
-	sampleRate      int
+	sampleRate      uint32
 	units           string
 	aggregationType string
 }
@@ -262,7 +262,7 @@ func (s *Segment) Get(st, et time.Time, cb func(depth int, samples, writes uint6
 
 // TODO: this should be refactored
 
-func (s *Segment) SetMetadata(spyName string, sampleRate int, units, aggregationType string) {
+func (s *Segment) SetMetadata(spyName string, sampleRate uint32, units, aggregationType string) {
 	s.spyName = spyName
 	s.sampleRate = sampleRate
 	s.units = units
@@ -273,7 +273,7 @@ func (s *Segment) SpyName() string {
 	return s.spyName
 }
 
-func (s *Segment) SampleRate() int {
+func (s *Segment) SampleRate() uint32 {
 	return s.sampleRate
 }
 

--- a/pkg/storage/segment/serialization.go
+++ b/pkg/storage/segment/serialization.go
@@ -15,7 +15,7 @@ const currentVersion = 2
 
 func (s *Segment) populateFromMetadata(metadata map[string]interface{}) {
 	if v, ok := metadata["sampleRate"]; ok {
-		s.sampleRate = int(v.(float64))
+		s.sampleRate = uint32(v.(float64))
 	}
 	if v, ok := metadata["spyName"]; ok {
 		s.spyName = v.(string)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -172,7 +172,7 @@ type PutInput struct {
 	Key             *Key
 	Val             *tree.Tree
 	SpyName         string
-	SampleRate      int
+	SampleRate      uint32
 	Units           string
 	AggregationType string
 }
@@ -242,7 +242,7 @@ type GetOutput struct {
 	Tree       *tree.Tree
 	Timeline   *segment.Timeline
 	SpyName    string
-	SampleRate int
+	SampleRate uint32
 	Units      string
 }
 

--- a/pkg/storage/tree/flamebearer.go
+++ b/pkg/storage/tree/flamebearer.go
@@ -7,7 +7,7 @@ type Flamebearer struct {
 	MaxSelf  int      `json:"maxSelf"`
 	// TODO: see note in render.go
 	SpyName    string `json:"spyName"`
-	SampleRate int    `json:"sampleRate"`
+	SampleRate uint32 `json:"sampleRate"`
 	Units      string `json:"units"`
 }
 


### PR DESCRIPTION
make the sample rate configured for python, ruby and go, but it doesn't take affect for go, because we use the the 'runtime profile' of golang, we need to find the way to build the customer profiler for go.