### PR TITLE
Fix dotnetspy panic on premature exit and add tests.

### DIFF
--- a/pkg/agent/dotnetspy/dotnetspy.go
+++ b/pkg/agent/dotnetspy/dotnetspy.go
@@ -3,14 +3,11 @@
 package dotnetspy
 
 import (
-	"sync"
-
 	"github.com/pyroscope-io/pyroscope/pkg/agent/spy"
 )
 
 type DotnetSpy struct {
 	session *session
-	m       sync.Mutex
 	reset   bool
 }
 
@@ -29,14 +26,10 @@ func (s *DotnetSpy) Stop() error {
 }
 
 func (s *DotnetSpy) Reset() {
-	s.m.Lock()
-	defer s.m.Unlock()
 	s.reset = true
 }
 
 func (s *DotnetSpy) Snapshot(cb func([]byte, uint64, error)) {
-	s.m.Lock()
-	defer s.m.Unlock()
 	if !s.reset {
 		return
 	}

--- a/pkg/agent/dotnetspy/dotnetspy_suite_test.go
+++ b/pkg/agent/dotnetspy/dotnetspy_suite_test.go
@@ -1,0 +1,15 @@
+// +build dotnetspy
+
+package dotnetspy_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestDotnetSpy(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, ".NET Spy Suite")
+}

--- a/pkg/agent/dotnetspy/dotnetspy_test.go
+++ b/pkg/agent/dotnetspy/dotnetspy_test.go
@@ -1,0 +1,36 @@
+// +build dotnetspy
+
+package dotnetspy
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("agent.DotnetSpy", func() {
+	Describe("Does not panic if a session has not been established", func() {
+		s := newSession(31337)
+		s.timeout = time.Millisecond * 10
+		Expect(s.start()).To(HaveOccurred())
+		spy := &DotnetSpy{session: s}
+
+		It("On Snapshot before Reset", func() {
+			spy.Snapshot(func(name []byte, samples uint64, err error) {
+				Fail("Snapshot callback must not be called")
+			})
+		})
+
+		It("On Snapshot after Reset", func() {
+			spy.Reset()
+			spy.Snapshot(func(name []byte, samples uint64, err error) {
+				Fail("Snapshot callback must not be called")
+			})
+		})
+
+		It("On Stop", func() {
+			Expect(spy.Stop()).ToNot(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
There is a case when `dotnetspy` couldn't establish a connection to Diagnostics Server before the next snapshot/stop call (e.g, target process exited, or the socket file cannot be found, etc).

This fix adds a check whether the session has been actually created before accessing it. Given that there are no race conditions between reset/stop/snapshot calls, redundant mutexes were removed.