### PR TITLE
Disable inlining for golang example

### DIFF
--- a/examples/golang/main.go
+++ b/examples/golang/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pyroscope-io/pyroscope/pkg/agent/profiler"
 )
 
+//go:noinline
 func work(n int) {
 	// revive:disable:empty-block this is fine because this is a example app, not real production code
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
Otherwise, `work` function is inlined (go1.16.4 windows/amd64) and flamegraph becomes slightly less demonstrative.

Inlined:
![image](https://user-images.githubusercontent.com/12090599/119378941-1e6a7200-bcbf-11eb-96fe-8bbdcb4cfb7b.png)

With `go:noinline`:
![image](https://user-images.githubusercontent.com/12090599/119378969-288c7080-bcbf-11eb-8e3c-e355960968a2.png)
