### PR TITLE
Fixes max memory available detection on linux

### DIFF
--- a/pkg/storage/mem.go
+++ b/pkg/storage/mem.go
@@ -1,44 +1,13 @@
+// +build !linux
+
 package storage
 
 import (
-	"io/ioutil"
-	"os"
-	"strconv"
-	"strings"
-
-	"github.com/pyroscope-io/pyroscope/pkg/util/file"
 	"github.com/shirou/gopsutil/mem"
-	"github.com/sirupsen/logrus"
 )
 
-const memLimitPath = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
-
-func getCgroupMemLimit() (uint64, error) {
-	f, err := os.Open(memLimitPath)
-	if err != nil {
-		return 0, err
-	}
-	b, err := ioutil.ReadAll(f)
-	if err != nil {
-		return 0, err
-	}
-	r, err := strconv.Atoi(strings.TrimSuffix(string(b), "\n"))
-	if err != nil {
-		return 0, err
-	}
-
-	return uint64(r), nil
-}
-
+// on linux we also look at cgroup mem limit
 func getMemTotal() (uint64, error) {
-	if file.Exists(memLimitPath) {
-		v, err := getCgroupMemLimit()
-		if err == nil {
-			return v, nil
-		}
-		logrus.WithError(err).Warn("Could not read cgroup memory limit")
-	}
-
 	vm, err := mem.VirtualMemory()
 	if err != nil {
 		return 0, err

--- a/pkg/storage/mem_linux.go
+++ b/pkg/storage/mem_linux.go
@@ -1,0 +1,55 @@
+// +build linux
+
+package storage
+
+import (
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pyroscope-io/pyroscope/pkg/util/file"
+	"github.com/shirou/gopsutil/mem"
+	"github.com/sirupsen/logrus"
+)
+
+const memLimitPath = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+
+func getCgroupMemLimit() (uint64, error) {
+	f, err := os.Open(memLimitPath)
+	if err != nil {
+		return 0, err
+	}
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return 0, err
+	}
+	r, err := strconv.Atoi(strings.TrimSuffix(string(b), "\n"))
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(r), nil
+}
+
+func getMemTotal() (uint64, error) {
+	vm, err := mem.VirtualMemory()
+	if err != nil {
+		return 0, err
+	}
+
+	if file.Exists(memLimitPath) {
+		v, err := getCgroupMemLimit()
+		if err == nil {
+			if v < vm.Total {
+				return v, nil
+			}
+			return vm.Total, nil
+		}
+
+		logrus.WithError(err).Warn("Could not read cgroup memory limit")
+		return vm.Total, nil
+	}
+
+	return vm.Total, nil
+}


### PR DESCRIPTION
I introduced a pretty big bug in the latest version where it would detect amount of RAM available incorrectly. E.g here we can see pyroscope thought it had 8EB of RAM. So that threw off cache evictions procedure and led to OOM events.


This PR fixes that issue.

This is before / after this fix on a linux machine:

![Screen Shot 2021-06-22 at 6 31 54 PM](https://user-images.githubusercontent.com/662636/123020999-208c2300-d388-11eb-9353-2b0ecdc68eb5.png)