### PR TITLE
Fix signal sending on Windows

### DIFF
--- a/pkg/exec/cli.go
+++ b/pkg/exec/cli.go
@@ -34,8 +34,10 @@ func Cli(cfg *config.Exec, args []string) error {
 	// isExec = false means the process is already there (pyroscope connect)
 	isExec := cfg.Pid == 0
 
-	if isExec && len(args) == 0 {
-		return errors.New("no arguments passed")
+	if isExec {
+		if len(args) == 0 {
+			return errors.New("no arguments passed")
+		}
 	} else if !processExists(cfg.Pid) {
 		return errors.New("process not found")
 	}
@@ -171,7 +173,7 @@ func Cli(cfg *config.Exec, args []string) error {
 func waitForSpawnedProcessToExit(c chan os.Signal, cmd *exec.Cmd) error {
 	go func() {
 		for s := range c {
-			_ = cmd.Process.Signal(s)
+			_ = sendSignal(cmd.Process, s)
 		}
 	}()
 	return cmd.Wait()

--- a/pkg/exec/cli_unix.go
+++ b/pkg/exec/cli_unix.go
@@ -106,3 +106,7 @@ func generateCredentials(userName, groupName string) (*syscall.Credential, error
 func processExists(pid int) bool {
 	return nil == syscall.Kill(pid, 0)
 }
+
+func sendSignal(p *os.Process, s os.Signal) error {
+	return p.Signal(s)
+}

--- a/pkg/exec/cli_windows.go
+++ b/pkg/exec/cli_windows.go
@@ -1,17 +1,31 @@
 package exec
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/windows"
 
 	"github.com/pyroscope-io/pyroscope/pkg/config"
+)
+
+var (
+	kernel32          = syscall.NewLazyDLL("kernel32.dll")
+	procAttachConsole = kernel32.NewProc("AttachConsole")
+	procFreeConsole   = kernel32.NewProc("FreeConsole")
 )
 
 func performOSChecks(_ string) error {
 	return nil
 }
 
-func adjustCmd(_ *exec.Cmd, _ config.Exec) error {
+func adjustCmd(cmd *exec.Cmd, _ config.Exec) error {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_PROCESS_GROUP,
+	}
 	return nil
 }
 
@@ -22,4 +36,48 @@ func processExists(pid int) bool {
 	}
 	_ = p.Release()
 	return true
+}
+
+func sendSignal(p *os.Process, s os.Signal) error {
+	if p == nil || p.Pid == 0 {
+		return nil
+	}
+	if s == syscall.SIGINT {
+		return sendEvent(p.Pid, windows.CTRL_BREAK_EVENT)
+	}
+	return p.Kill()
+}
+
+// A process can be attached to at most one console.
+// Refer to https://docs.microsoft.com/en-us/windows/console/attachconsole.
+var console sync.Mutex
+
+// Interrupt sends CTRL+BREAK signal to the command process group.
+// Refer to https://github.com/golang/go/issues/6720 for details.
+func sendEvent(pid int, e uint32) (err error) {
+	console.Lock()
+	defer console.Unlock()
+	ret, _, err := procAttachConsole.Call(uintptr(pid))
+	if ret == 0 && err != windows.ERROR_ACCESS_DENIED {
+		// A process can be attached to at most one console. If the calling
+		// process is already attached to a console, the error code returned is
+		// ERROR_ACCESS_DENIED (5). If the specified process does not have a
+		// console, the error code returned is ERROR_INVALID_HANDLE (6). If the
+		// specified process does not exist, the error code returned is
+		// ERROR_INVALID_PARAMETER (87).
+		return fmt.Errorf("AttachConsole: %w", err)
+	}
+	defer func() {
+		// A process can use the FreeConsole function to detach itself from its
+		// console. If other processes share the console, the console is not
+		// destroyed, but the process that called FreeConsole cannot refer to it.
+		// If the calling process is not already attached to a console,
+		// the error code returned is ERROR_INVALID_PARAMETER (87).
+		_, _, _ = procFreeConsole.Call()
+	}()
+	// Note on CTRL_C_EVENT: This signal cannot be generated for process
+	// groups. If dwProcessGroupId is nonzero, this function will succeed, but
+	// the CTRL+C signal will not be received by processes within the specified
+	// process group.
+	return windows.GenerateConsoleCtrlEvent(e, uint32(pid))
 }


### PR DESCRIPTION
A regression has been introduced with graceful shutdown refactoring: signals (including `SIGINT`) are not sent to child process on Windows in `exec` mode. As a workaround, `CTRL_BREAK_EVENT` event will be send instead of `SIGINT`, any other signal will cause process termination.

Event `CTRL_C_EVENT` which is more close analogue of `SIGING` is sent to all processes sharing the current console (including parent): https://github.com/golang/go/issues/6720#issuecomment-66087740. Although, there is a way to disable signal handler, it may cause `pyroscope exec` process would become unresponsive.

It is worth it to mention that not all processes on Windows will exit on `CTRL_BREAK_EVENT` (it depends on the handler function the application sets for events), in particular, GUI applications would ignore any events sent with `GenerateConsoleCtrlEvent`.
