### PR TITLE
fix(gospy.go): Snapshot add custom_pprof.StopCPUProfile()

### DIFF
--- a/pkg/agent/gospy/gospy.go
+++ b/pkg/agent/gospy/gospy.go
@@ -107,6 +107,7 @@ func (s *GoSpy) Snapshot(cb func([]byte, uint64, error)) {
 	if s.profileType == spy.ProfileCPU {
 		// stop the previous cycle of sample collection
 		pprof.StopCPUProfile()
+		custom_pprof.StopCPUProfile()
 		defer func() {
 			// start a new cycle of sample collection
 			if err := startCPUProfile(s.buf, s.sampleRate); err != nil {


### PR DESCRIPTION
Hello:
    There is a problem happen with me: when I use custom sampling, the pyroscope can not display CPU profiles.
    Discover by debug, there is an err: cpu profiling already in use
![image](https://user-images.githubusercontent.com/15027927/125813623-ce82301e-5bee-4f70-b300-2dca439740b9.png)

    I found that custom sampling did not stop, so unable to call startCPUProfile from the second time.

