### PR TITLE
scripts/decode-resp: decode flamebearer response for debugging

### DIFF
--- a/scripts/decode-resp/decode.go
+++ b/scripts/decode-resp/decode.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"github.com/pyroscope-io/pyroscope/pkg/storage/segment"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
+)
+
+type Input struct {
+	Timeline    *segment.Timeline `json:"timeline"`
+	Flamebearer *tree.Flamebearer `json:"flamebearer"`
+	Metadata    *InputMetadata    `json:"metadata"`
+}
+
+type InputMetadata struct {
+	SpyName    string `json:"spyName"`
+	SampleRate uint32 `json:"sampleRate"`
+	Units      string `json:"units"`
+}
+
+type Output struct {
+	Flamebearer *OutputFlamebearer `json:"flamebearer"`
+}
+
+type OutputFlamebearer struct {
+	Levels [][]OutputItem `json:"levels"`
+}
+
+type OutputItem struct {
+	Name  string `json:"name"`
+	Total int    `json:"total"`
+	Self  int    `json:"self"`
+}
+
+func decodeLevels(in *Input) *Output {
+	names, levels := in.Flamebearer.Names, in.Flamebearer.Levels
+	outLevels := make([][]OutputItem, 0, len(levels))
+
+	for _, row := range levels {
+		offset := 0
+		outRow := make([]OutputItem, 0, len(row))
+
+		for i, N := 0, len(row); i < N; i += 4 {
+			offset += row[i]
+			outItem := OutputItem{
+				Name:  names[row[i+3]],
+				Total: offset + row[i+1],
+				Self:  row[i+2],
+			}
+			outRow = append(outRow, outItem)
+		}
+		outLevels = append(outLevels, outRow)
+	}
+
+	out := &Output{
+		Flamebearer: &OutputFlamebearer{
+			Levels: outLevels,
+		},
+	}
+	return out
+}

--- a/scripts/decode-resp/decode_suite_test.go
+++ b/scripts/decode-resp/decode_suite_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	testing2 "github.com/pyroscope-io/pyroscope/pkg/testing"
+)
+
+func TestDecode(t *testing.T) {
+	testing2.SetupLogging()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Decode Suite")
+}

--- a/scripts/decode-resp/decode_test.go
+++ b/scripts/decode-resp/decode_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Decode", func() {
+	Context("simple case", func() {
+		It("should decode correctly", func() {
+			names := strings.Split("total,a,b,c", ",")
+			levels := [][]int{
+				{0, 3, 0, 0},             // total
+				{0, 3, 0, 1},             // a
+				{0, 1, 1, 3, 2, 0, 2, 2}, // b, c
+			}
+			in := &Input{
+				Flamebearer: &tree.Flamebearer{
+					Names:  names,
+					Levels: levels,
+				},
+			}
+			out := decodeLevels(in)
+			outJson := marshal(out)
+			expected := `{
+  "flamebearer": {
+    "levels": [
+      [
+        {
+          "name": "total",
+          "total": 3,
+          "self": 0
+        }
+      ],
+      [
+        {
+          "name": "a",
+          "total": 3,
+          "self": 0
+        }
+      ],
+      [
+        {
+          "name": "c",
+          "total": 1,
+          "self": 1
+        },
+        {
+          "name": "b",
+          "total": 2,
+          "self": 2
+        }
+      ]
+    ]
+  }
+}`
+			Expect(outJson).To(Equal(expected))
+		})
+	})
+})
+
+func marshal(out interface{}) string {
+	data, _ := json.MarshalIndent(out, "", "  ")
+	return strings.TrimSpace(string(data))
+}

--- a/scripts/decode-resp/main.go
+++ b/scripts/decode-resp/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func usage() {
+	f, w := flag.CommandLine, flag.CommandLine.Output()
+	fmt.Fprintf(w, `Decode response from pyroscope, for debugging
+
+Usage: decode-resp -file <response.json>
+  where <response.json> is the body response from /render API
+  example: http://localhost:4040/render?from=now-1h&until=now&name=pyroscope.server.alloc_objects{}&max-nodes=1024&format=json
+
+Flags:
+`)
+	f.PrintDefaults()
+}
+
+func main() {
+	var inFile string
+	var outFile string
+
+	flag.StringVar(&inFile, "file", "", "path to response file (required)")
+	flag.StringVar(&outFile, "out", "", "name of output file (default to NAME.out.EXT)")
+	flag.Usage = usage
+	flag.Parse()
+
+	if inFile == "" {
+		usage()
+		os.Exit(2)
+	}
+	if outFile == "" {
+		dir, base := filepath.Dir(inFile), filepath.Base(inFile)
+		ext := filepath.Ext(base)
+		name := base[:len(base)-len(ext)]
+		outFile = filepath.Join(dir, name+".out"+ext)
+	}
+
+	// read file
+	inData, err := ioutil.ReadFile(inFile)
+	must(err)
+	var input Input
+	must(json.Unmarshal(inData, &input))
+
+	// decode
+	output := decodeLevels(&input)
+
+	// write file
+	outData, err := json.MarshalIndent(output, "", "  ")
+	must(err)
+	must(ioutil.WriteFile(outFile, outData, 0644))
+
+	fmt.Fprintf(os.Stderr, "decoded to %v\n", outFile)
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
This PR adds scripts/decode-resp for decoding response.

```
Decode response from pyroscope, for debugging

Usage: decode-resp -file <response.json>
  where <response.json> is the body response from /render API
  example: http://localhost:4040/render?from=now-1h&until=now&name=pyroscope.server.alloc_objects{}&max-nodes=1024&format=json

Flags:
  -file string
    	path to response file (required)
  -out string
    	name of output file (default to NAME.out.EXT)
```