### PR TITLE
Implement mock ui for diff

### DIFF
--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -311,10 +311,11 @@ func (ctrl *Controller) callbackRedirectHandler(getAccountInfoURL string, info *
 func (ctrl *Controller) indexHandler() http.HandlerFunc {
 	fs := http.FileServer(ctrl.dir)
 	return func(rw http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/" {
+		path := r.URL.Path
+		if path == "/" {
 			ctrl.statsInc("index")
 			ctrl.renderIndexPage(rw, r)
-		} else if r.URL.Path == "/comparison" {
+		} else if path == "/comparison" || path == "/comparison-diff" {
 			ctrl.statsInc("index")
 			ctrl.renderIndexPage(rw, r)
 		} else {

--- a/webapp/javascript/components/ComparisonDiffApp.jsx
+++ b/webapp/javascript/components/ComparisonDiffApp.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from "react";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import FlameGraphRenderer from "./FlameGraphRenderer";
+import Header from "./Header";
+import Footer from "./Footer";
+import TimelineChartWrapper from "./TimelineChartWrapper";
+import { buildRenderURL } from "../util/updateRequests";
+import { fetchNames, fetchTimeline } from "../redux/actions";
+
+function ComparisonDiffApp(props) {
+  const { actions, renderURL } = props;
+  const prevPropsRef = useRef();
+
+  useEffect(() => {
+    if (prevPropsRef.renderURL !== renderURL) {
+      actions.fetchTimeline(renderURL);
+    }
+  }, [renderURL]);
+
+  return (
+    <div className="pyroscope-app">
+      <div className="main-wrapper">
+        <Header />
+        <TimelineChartWrapper id="timeline-chart-diff" viewSide="both" />
+        <FlameGraphRenderer viewType="diff" />
+      </div>
+      <Footer />
+    </div>
+  );
+}
+
+const mapStateToProps = (state) => ({
+  ...state,
+  renderURL: buildRenderURL(state),
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  actions: bindActionCreators(
+    {
+      fetchTimeline,
+      fetchNames,
+    },
+    dispatch
+  ),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ComparisonDiffApp);

--- a/webapp/javascript/components/FlameGraphRenderer.jsx
+++ b/webapp/javascript/components/FlameGraphRenderer.jsx
@@ -18,7 +18,7 @@
 // This component is based on flamebearer project
 //   https://github.com/mapbox/flamebearer
 
-import React from "react";
+import React, { Fragment } from "react";
 import { connect } from "react-redux";
 
 import clsx from "clsx";
@@ -349,9 +349,9 @@ class FlameGraphRenderer extends React.Component {
             barIndex + numBarTicks === level[j + 3] &&
             level[j + 4] * this.pxPerTick <= COLLAPSE_THRESHOLD &&
             nodeIsInQuery ===
-              ((this.query && names[level[j + 5]].indexOf(this.query) >= 0) ||
-                false)
-          ) {
+            ((this.query && names[level[j + 5]].indexOf(this.query) >= 0) ||
+              false)
+            ) {
             j += 4;
             numBarTicks += level[j + 1];
           }
@@ -512,9 +512,6 @@ class FlameGraphRenderer extends React.Component {
       ? [this.props.timeline.map((x) => [x[0], x[1] === 0 ? null : x[1] - 1])]
       : [];
 
-    let instructionsText = this.props.viewType === "double" ? `Select ${this.props.viewSide} time range` : null;
-    let instructionsClassName = this.props.viewType === "double" ? `${this.props.viewSide}-instructions` : null;
-
     return (
       <div className={clsx("canvas-renderer", { "double": this.props.viewType === "double" })}>
 
@@ -526,17 +523,36 @@ class FlameGraphRenderer extends React.Component {
             updateView={this.updateView}
             resetStyle={this.state.resetStyle}
           />
-          <div className={`${instructionsClassName}-wrapper`}>
-            <span className={`${instructionsClassName}-text`}>{instructionsText}</span>
-          </div>
           {
-            this.props.viewType === "double" ?
-              <TimelineChartWrapper
-                key={`timeline-chart-${this.props.viewSide}`}
-                id={`timeline-chart-${this.props.viewSide}`}
-                viewSide={this.props.viewSide}
-              /> :
-              null
+            this.props.viewType === "double"
+              ? <Fragment>
+                <InstructionText {...this.props}/>
+                <TimelineChartWrapper
+                  key={`timeline-chart-${this.props.viewSide}`}
+                  id={`timeline-chart-${this.props.viewSide}`}
+                  viewSide={this.props.viewSide}
+                />
+              </Fragment>
+              : this.props.viewType === "diff"
+              ? <div className="diff-instructions-wrapper">
+                <div className="diff-instructions-wrapper-side">
+                  <InstructionText {...this.props} viewSide="left"/>
+                  <TimelineChartWrapper
+                    key={`timeline-chart-left`}
+                    id={`timeline-chart-left`}
+                    viewSide="left"
+                  />
+                </div>
+                <div className="diff-instructions-wrapper-side">
+                  <InstructionText {...this.props} viewSide="right"/>
+                  <TimelineChartWrapper
+                    key={`timeline-chart-right`}
+                    id={`timeline-chart-right`}
+                    viewSide="right"
+                  />
+                </div>
+              </div>
+              : null
           }
           <div className={clsx("flamegraph-container panes-wrapper", { "vertical-orientation": this.props.viewType === "double" })}>
             {
@@ -571,7 +587,19 @@ class FlameGraphRenderer extends React.Component {
         </div>
       </div>
     )
+  }
 }
+
+function InstructionText(props) {
+  const {viewType, viewSide} = props;
+  let instructionsText = viewType === "double" || viewType === "diff" ? `Select ${viewSide} time range` : null;
+  let instructionsClassName = viewType === "double" || viewType === "diff" ? `${viewSide}-instructions` : null;
+
+  return (
+    <div className={`${instructionsClassName}-wrapper`}>
+      <span className={`${instructionsClassName}-text`}>{instructionsText}</span>
+    </div>
+  )
 }
 
 const mapStateToProps = (state) => ({

--- a/webapp/javascript/components/Sidebar.jsx
+++ b/webapp/javascript/components/Sidebar.jsx
@@ -13,6 +13,7 @@ import {
   faColumns,
   faBell,
   faSignOutAlt,
+  faChartBar,
 } from "@fortawesome/free-solid-svg-icons";
 import { faWindowMaximize } from "@fortawesome/free-regular-svg-icons";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
@@ -115,6 +116,17 @@ function Sidebar(props) {
           onClick={() => updateRoute("/comparison")}
         >
           <FontAwesomeIcon icon={faColumns} />
+        </button>
+      </SidebarItem>
+      <SidebarItem tooltipText="Diff View">
+        <button
+          className={clsx({
+            "active-route": state.currentRoute === "/comparison-diff",
+          })}
+          type="button"
+          onClick={() => updateRoute("/comparison-diff")}
+        >
+          <FontAwesomeIcon icon={faChartBar} />
         </button>
       </SidebarItem>
       <SidebarItem tooltipText="Alerts - Coming Soon">

--- a/webapp/javascript/index.jsx
+++ b/webapp/javascript/index.jsx
@@ -9,6 +9,7 @@ import store from "./redux/store";
 
 import PyroscopeApp from "./components/PyroscopeApp";
 import ComparisonApp from "./components/ComparisonApp";
+import ComparisonDiffApp from "./components/ComparisonDiffApp";
 import Sidebar from "./components/Sidebar";
 
 import history from "./util/history";
@@ -33,6 +34,9 @@ ReactDOM.render(
           </Route>
           <Route path="/comparison">
             <ComparisonApp />
+          </Route>
+          <Route path="/comparison-diff">
+            <ComparisonDiffApp />
           </Route>
         </Switch>
       </ShortcutProvider>

--- a/webapp/sass/profile.scss
+++ b/webapp/sass/profile.scss
@@ -243,6 +243,16 @@ $pane-width: 6px;
   }
 }
 
+.diff-instructions-wrapper {
+  display: flex;
+  gap: 30px;
+  padding-bottom: 10px;
+}
+
+.diff-instructions-wrapper-side {
+  flex: 1 1 0;
+}
+
 .left-instructions-wrapper {
   display: flex;
   width: 50%;


### PR DESCRIPTION
This PR implements a mock UI for comparision-diff:

- [x] New sidebar button: Diff View
  - [ ] Currently using a mock icon
- [x] New URL: /comparision-diff
- [x] Mock UI for selecting from 2 time ranges (left & right)

This serves as a reference for discussing the UI and control. Other features will be pushed in other PRs:

- [x] FE: Request combined data for rendering from 2 time ranges
        #289
- [x] BE: Respond combined data for 2 time ranges
        New URL format: `/render?leftFrom=...&leftUntil=...&rightFrom=....&rightUntil=...`
        #290 
- [x] FE: Actually render the differences
        #289
- [ ] FE: Add more columns to the ProfilerTable
- [ ] FE: Add diff text to tooltip
- [ ] FE: Support different rendering options: left, right, both, percentage
- [ ] FE: Allow selecting between 3 different options

Issues: #95

<img width="1275" alt="Screen Shot 2021-07-16 at 22 36 15" src="https://user-images.githubusercontent.com/6618620/125973136-39ee4bd8-1892-41cd-a598-35260cde0d90.png">