### PR TITLE
implement diff rendering

### DIFF
--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -311,10 +311,11 @@ func (ctrl *Controller) callbackRedirectHandler(getAccountInfoURL string, info *
 func (ctrl *Controller) indexHandler() http.HandlerFunc {
 	fs := http.FileServer(ctrl.dir)
 	return func(rw http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/" {
+		path := r.URL.Path
+		if path == "/" {
 			ctrl.statsInc("index")
 			ctrl.renderIndexPage(rw, r)
-		} else if r.URL.Path == "/comparison" {
+		} else if path == "/comparison" || path == "/comparison-diff" {
 			ctrl.statsInc("index")
 			ctrl.renderIndexPage(rw, r)
 		} else {

--- a/pkg/server/render.go
+++ b/pkg/server/render.go
@@ -5,13 +5,23 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/pyroscope-io/pyroscope/pkg/flameql"
 	"github.com/pyroscope-io/pyroscope/pkg/storage"
 	"github.com/pyroscope-io/pyroscope/pkg/storage/segment"
 	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
 	"github.com/pyroscope-io/pyroscope/pkg/util/attime"
+)
+
+type RenderFormat string
+
+const (
+	FormatSingle = "single"
+	FormatDouble = "double"
 )
 
 var (
@@ -39,20 +49,42 @@ func (ctrl *Controller) renderHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out, err := ctrl.storage.Get(p.gi)
-	ctrl.statsInc("render")
-	if err != nil {
-		ctrl.writeInternalServerError(w, err, "failed to retrieve data")
-		return
+	var out *storage.GetOutput
+	var fs *tree.Flamebearer
+	var err error
+	var format RenderFormat
+
+	leftStartTime, leftEndTime, leftOK := parseRenderRangeParams(r.URL.Query(), "leftFrom", "leftUntil")
+	rghtStartTime, rghtEndTime, rghtOK := parseRenderRangeParams(r.URL.Query(), "rightFrom", "rightUntil")
+
+	if rghtOK || leftOK {
+		var leftOut, rghtOut *storage.GetOutput
+		leftOut, rghtOut, err = ctrl.loadDiffOutput(p.gi, leftStartTime, leftEndTime, rghtStartTime, rghtEndTime)
+		ctrl.statsInc("render")
+		if err != nil {
+			ctrl.writeInternalServerError(w, err, "failed to retrieve data")
+			return
+		}
+		out = leftOut // to be compatible with responding code
+		fs = tree.CombineToFlamebearerStruct(leftOut.Tree, rghtOut.Tree, p.maxNodes)
+		format = FormatDouble
+
+	} else {
+		out, err = ctrl.storage.Get(p.gi)
+		ctrl.statsInc("render")
+		if err != nil {
+			ctrl.writeInternalServerError(w, err, "failed to retrieve data")
+			return
+		}
+
+		// TODO: handle properly
+		if out == nil {
+			out = &storage.GetOutput{Tree: tree.New()}
+		}
+		fs = out.Tree.FlamebearerStruct(p.maxNodes)
+		format = FormatSingle
 	}
 
-	// TODO: handle properly
-	if out == nil {
-		out = &storage.GetOutput{Tree: tree.New()}
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	fs := out.Tree.FlamebearerStruct(p.maxNodes)
 	// TODO remove this duplication? We're already adding this to metadata
 	fs.SpyName = out.SpyName
 	fs.SampleRate = out.SampleRate
@@ -64,9 +96,11 @@ func (ctrl *Controller) renderHandler(w http.ResponseWriter, r *http.Request) {
 			"spyName":    out.SpyName,
 			"sampleRate": out.SampleRate,
 			"units":      out.Units,
+			"format":     format, // "single" | "double"
 		},
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	if err = json.NewEncoder(w).Encode(res); err != nil {
 		ctrl.writeJSONEncodeError(w, err)
 	}
@@ -105,4 +139,60 @@ func (ctrl *Controller) renderParametersFromRequest(r *http.Request, p *renderPa
 	p.gi.EndTime = attime.Parse(v.Get("until"))
 	p.format = v.Get("format")
 	return nil
+}
+
+func parseRenderRangeParams(v url.Values, from, until string) (startTime, endTime time.Time, ok bool) {
+	fromStr, untilStr := v.Get(from), v.Get(until)
+	startTime, endTime = attime.Parse(fromStr), attime.Parse(untilStr)
+	return startTime, endTime, fromStr != "" || untilStr != ""
+}
+
+func (ctrl *Controller) loadDiffOutput(
+	gi *storage.GetInput,
+	leftStartTime, leftEndTime time.Time,
+	rghtStartTime, rghtEndTime time.Time,
+) (*storage.GetOutput, *storage.GetOutput, error) {
+
+	var leftOut, rghtOut *storage.GetOutput
+	var leftErr, rghtErr error
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); leftOut, leftErr = ctrl.loadDiffOutputExec(gi, leftStartTime, leftEndTime) }()
+	go func() { defer wg.Done(); rghtOut, rghtErr = ctrl.loadDiffOutputExec(gi, rghtStartTime, rghtEndTime) }()
+	wg.Wait()
+
+	if leftErr != nil {
+		return nil, nil, leftErr
+	}
+	if rghtErr != nil {
+		return nil, nil, rghtErr
+	}
+	leftOut.Tree, rghtOut.Tree = combineTree(leftOut.Tree, rghtOut.Tree)
+	return leftOut, rghtOut, nil
+}
+
+func (ctrl *Controller) loadDiffOutputExec(gi *storage.GetInput, startTime, endTime time.Time) (_ *storage.GetOutput, _err error) {
+	defer func() {
+		rerr := recover()
+		if rerr != nil {
+			_err = fmt.Errorf("panic: %v", rerr)
+		}
+	}()
+
+	_gi := *gi // clone the struct
+	_gi.StartTime, _gi.EndTime = startTime, endTime
+	out, err := ctrl.storage.Get(&_gi)
+	if err != nil {
+		return nil, err
+	}
+	if out == nil {
+		// TODO: handle properly
+		return &storage.GetOutput{Tree: tree.New()}, nil
+	}
+	return out, nil
+}
+
+func combineTree(leftTree, rightTree *tree.Tree) (*tree.Tree, *tree.Tree) {
+	return tree.CombineTree(leftTree, rightTree)
 }

--- a/pkg/storage/tree/flamebearer.go
+++ b/pkg/storage/tree/flamebearer.go
@@ -91,13 +91,7 @@ func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 	}
 
 	// delta encoding
-	for _, l := range res.Levels {
-		prev := 0
-		for i := 0; i < len(l); i += 4 {
-			l[i] -= prev
-			prev += l[i] + l[i+1]
-		}
-	}
+	deltaEncoding(res.Levels, 0, 4)
 
 	// TODO: we used to drop the first level, because it's always an empty node
 	//   but that didn't work because flamebearer doesn't work with more
@@ -106,4 +100,14 @@ func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 	// 	res.Levels = res.Levels[1:]
 	// }
 	return &res
+}
+
+func deltaEncoding(levels [][]int, start, step int) {
+	for _, l := range levels {
+		prev := 0
+		for i := start; i < len(l); i += step {
+			l[i] -= prev
+			prev += l[i] + l[i+1]
+		}
+	}
 }

--- a/pkg/storage/tree/flamebearer.go
+++ b/pkg/storage/tree/flamebearer.go
@@ -1,5 +1,12 @@
 package tree
 
+type Format string
+
+const (
+	FormatSingle Format = "single"
+	FormatDouble Format = "double"
+)
+
 type Flamebearer struct {
 	Names    []string `json:"names"`
 	Levels   [][]int  `json:"levels"`
@@ -9,6 +16,7 @@ type Flamebearer struct {
 	SpyName    string `json:"spyName"`
 	SampleRate uint32 `json:"sampleRate"`
 	Units      string `json:"units"`
+	Format     Format `json:"format"`
 }
 
 func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
@@ -20,6 +28,7 @@ func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 		Levels:   [][]int{},
 		NumTicks: int(t.Samples()),
 		MaxSelf:  int(0),
+		Format:   FormatSingle,
 	}
 
 	nodes := []*treeNode{t.root}

--- a/pkg/storage/tree/treediff.go
+++ b/pkg/storage/tree/treediff.go
@@ -84,7 +84,7 @@ func CombineToFlamebearerStruct(leftTree, rightTree *Tree, maxNodes int) *Flameb
 	res := Flamebearer{
 		Names:    []string{},
 		Levels:   [][]int{},
-		NumTicks: int(leftTree.Samples()),
+		NumTicks: int(leftTree.Samples() + rightTree.Samples()),
 		MaxSelf:  int(0),
 	}
 

--- a/pkg/storage/tree/treediff.go
+++ b/pkg/storage/tree/treediff.go
@@ -86,6 +86,7 @@ func CombineToFlamebearerStruct(leftTree, rightTree *Tree, maxNodes int) *Flameb
 		Levels:   [][]int{},
 		NumTicks: int(leftTree.Samples() + rightTree.Samples()),
 		MaxSelf:  int(0),
+		Format:   FormatDouble,
 	}
 
 	leftNodes, xLeftOffsets := []*treeNode{leftTree.root}, []int{0}

--- a/pkg/storage/tree/treediff.go
+++ b/pkg/storage/tree/treediff.go
@@ -1,0 +1,239 @@
+package tree
+
+import (
+	"bytes"
+
+	"github.com/pyroscope-io/pyroscope/pkg/structs/cappedarr"
+)
+
+// CombineTree aligns 2 trees by making them having the same structure with the
+// same number of nodes
+// TODO: create a new struct?
+func CombineTree(leftTree, rightTree *Tree) (*Tree, *Tree) {
+	leftTree.Lock()
+	defer leftTree.Unlock()
+	rightTree.Lock()
+	defer rightTree.Unlock()
+
+	leftNodes := []*treeNode{leftTree.root}
+	rghtNodes := []*treeNode{rightTree.root}
+
+	for len(leftNodes) > 0 {
+		left, rght := leftNodes[0], rghtNodes[0]
+		leftNodes, rghtNodes = leftNodes[1:], rghtNodes[1:]
+
+		left.ChildrenNodes, rght.ChildrenNodes = combineNodes(left.ChildrenNodes, rght.ChildrenNodes)
+		leftNodes = append(leftNodes, left.ChildrenNodes...)
+		rghtNodes = append(rghtNodes, rght.ChildrenNodes...)
+	}
+	return leftTree, rightTree
+}
+
+func combineNodes(leftNodes, rghtNodes []*treeNode) ([]*treeNode, []*treeNode) {
+	size := nextPow2(max(len(leftNodes), len(rghtNodes)))
+	leftResult := make([]*treeNode, 0, size)
+	rghtResult := make([]*treeNode, 0, size)
+
+	for len(leftNodes) != 0 && len(rghtNodes) != 0 {
+		left, rght := leftNodes[0], rghtNodes[0]
+		switch bytes.Compare(left.Name, rght.Name) {
+		case 0:
+			leftResult = append(leftResult, left)
+			rghtResult = append(rghtResult, rght)
+			leftNodes, rghtNodes = leftNodes[1:], rghtNodes[1:]
+		case -1:
+			leftResult = append(leftResult, left)
+			rghtResult = append(rghtResult, newNode(left.Name))
+			leftNodes = leftNodes[1:]
+		case 1:
+			leftResult = append(leftResult, newNode(rght.Name))
+			rghtResult = append(rghtResult, rght)
+			rghtNodes = rghtNodes[1:]
+		}
+	}
+	leftResult = append(leftResult, leftNodes...)
+	rghtResult = append(rghtResult, rghtNodes...)
+	for _, left := range leftNodes {
+		rghtResult = append(rghtResult, newNode(left.Name))
+	}
+	for _, rght := range rghtNodes {
+		leftResult = append(leftResult, newNode(rght.Name))
+	}
+	return leftResult, rghtResult
+}
+
+// CombineToFlamebearerStruct generates the Flamebearer struct from 2 trees.
+// They must be the response trees from CombineTree (i.e. all children nodes
+// must be the same length). The Flamebearer struct returned from this function
+// is different to the one returned from Tree.FlamebearerStruct(). It has the
+// following structure:
+//
+//     i+0 = x offset, left  tree
+//     i+1 = total   , left  tree
+//     i+2 = self    , left  tree
+//     i+3 = x offset, right tree
+//     i+4 = total   , right tree
+//     i+5 = self    , right tree
+//     i+6 = index in the names array
+func CombineToFlamebearerStruct(leftTree, rightTree *Tree, maxNodes int) *Flamebearer {
+	leftTree.RLock()
+	defer leftTree.RUnlock()
+	rightTree.RLock()
+	defer rightTree.RUnlock()
+
+	res := Flamebearer{
+		Names:    []string{},
+		Levels:   [][]int{},
+		NumTicks: int(leftTree.Samples()),
+		MaxSelf:  int(0),
+	}
+
+	leftNodes, xLeftOffsets := []*treeNode{leftTree.root}, []int{0}
+	rghtNodes, xRghtOffsets := []*treeNode{rightTree.root}, []int{0}
+	levels := []int{0}
+	minVal := combineMinValues(leftTree, rightTree, maxNodes)
+	nameLocationCache := map[string]int{}
+
+	for len(leftNodes) > 0 {
+		left, rght := leftNodes[0], rghtNodes[0]
+		leftNodes, rghtNodes = leftNodes[1:], rghtNodes[1:]
+
+		xLeftOffset, xRghtOffset := xLeftOffsets[0], xRghtOffsets[0]
+		xLeftOffsets, xRghtOffsets = xLeftOffsets[1:], xRghtOffsets[1:]
+
+		level := levels[0]
+		levels = levels[1:]
+
+		// both left.Name and rght.Name must be the same
+		name := string(left.Name)
+		if left.Total >= minVal || rght.Total >= minVal || name == "other" {
+			i, ok := nameLocationCache[name]
+			if !ok {
+				i = len(res.Names)
+				nameLocationCache[name] = i
+				if i == 0 {
+					name = "total"
+				}
+				res.Names = append(res.Names, name)
+			}
+
+			if level == len(res.Levels) {
+				res.Levels = append(res.Levels, []int{})
+			}
+			res.MaxSelf = max(res.MaxSelf, int(left.Self))
+			res.MaxSelf = max(res.MaxSelf, int(rght.Self))
+
+			// i+0 = x offset, left  tree
+			// i+1 = total   , left  tree
+			// i+2 = self    , left  tree
+			// i+3 = x offset, right tree
+			// i+4 = total   , right tree
+			// i+5 = self    , right tree
+			// i+6 = index in the names array
+			values := []int{
+				xLeftOffset, int(left.Total), int(left.Self),
+				xRghtOffset, int(rght.Total), int(rght.Self),
+				i,
+			}
+			res.Levels[level] = append(values, res.Levels[level]...)
+
+			xLeftOffset += int(left.Self)
+			xRghtOffset += int(rght.Self)
+			otherLeftTotal, otherRghtTotal := uint64(0), uint64(0)
+
+			// both left and right must have the same number of children nodes
+			for ni := range left.ChildrenNodes {
+				leftNode, rghtNode := left.ChildrenNodes[ni], rght.ChildrenNodes[ni]
+				if leftNode.Total >= minVal || rghtNode.Total >= minVal {
+					levels = append([]int{level + 1}, levels...)
+					xLeftOffsets = append([]int{xLeftOffset}, xLeftOffsets...)
+					xRghtOffsets = append([]int{xRghtOffset}, xRghtOffsets...)
+					leftNodes = append([]*treeNode{leftNode}, leftNodes...)
+					rghtNodes = append([]*treeNode{rghtNode}, rghtNodes...)
+					xLeftOffset += int(leftNode.Total)
+					xRghtOffset += int(rghtNode.Total)
+				} else {
+					otherLeftTotal += leftNode.Total
+					otherRghtTotal += rghtNode.Total
+				}
+			}
+			if otherLeftTotal != 0 || otherRghtTotal != 0 {
+				{
+					leftNode := &treeNode{
+						Name:  jsonableSlice("other"),
+						Total: otherLeftTotal,
+						Self:  otherLeftTotal,
+					}
+					levels = append([]int{level + 1}, levels...)
+					xLeftOffsets = append([]int{xLeftOffset}, xLeftOffsets...)
+					leftNodes = append([]*treeNode{leftNode}, leftNodes...)
+					xLeftOffset += int(leftNode.Total)
+				}
+				{
+					rghtNode := &treeNode{
+						Name:  jsonableSlice("other"),
+						Total: otherRghtTotal,
+						Self:  otherRghtTotal,
+					}
+					levels = append([]int{level + 1}, levels...)
+					xRghtOffsets = append([]int{xRghtOffset}, xRghtOffsets...)
+					rghtNodes = append([]*treeNode{rghtNode}, rghtNodes...)
+					xRghtOffset += int(rghtNode.Total)
+				}
+			}
+		}
+	}
+
+	// delta encoding
+	deltaEncoding(res.Levels, 0, 7)
+	deltaEncoding(res.Levels, 3, 7)
+	return &res
+}
+
+func combineMinValues(leftTree, rightTree *Tree, maxNodes int) uint64 {
+	c := cappedarr.New(maxNodes)
+	combineIterateWithCum(leftTree, rightTree, func(left uint64, right uint64) bool {
+		return c.Push(maxUint64(left, right))
+	})
+	return c.MinValue()
+}
+
+// iterate both trees, both trees must be returned from CombineTree
+func combineIterateWithCum(leftTree, rightTree *Tree, cb func(uint64, uint64) bool) {
+	leftNodes, rghtNodes := []*treeNode{leftTree.root}, []*treeNode{rightTree.root}
+	i := 0
+	for len(leftNodes) > 0 {
+		leftNode, rghtNode := leftNodes[0], rghtNodes[0]
+		leftNodes, rghtNodes = leftNodes[1:], rghtNodes[1:]
+		i++
+		if cb(leftNode.Total, rghtNode.Total) {
+			leftNodes = append(leftNode.ChildrenNodes, leftNodes...)
+			rghtNodes = append(rghtNode.ChildrenNodes, rghtNodes...)
+		}
+	}
+}
+
+func maxUint64(a, b uint64) uint64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func nextPow2(a int) int {
+	a--
+	a |= a >> 1
+	a |= a >> 2
+	a |= a >> 4
+	a |= a >> 8
+	a |= a >> 16
+	a++
+	return a
+}

--- a/pkg/storage/tree/treediff_test.go
+++ b/pkg/storage/tree/treediff_test.go
@@ -1,0 +1,137 @@
+package tree
+
+import (
+	"fmt"
+	"math/rand"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// StringWithEmpty is used for testing only, hence declared in this file. It's
+// different to String() as it includes nodes with zero value.
+func (t *Tree) StringWithEmpty() string {
+	t.RLock()
+	defer t.RUnlock()
+
+	res := ""
+	t.iterate(func(k []byte, v uint64) {
+		if len(k) >= 2 {
+			res += fmt.Sprintf("%q %d\n", k[2:], v)
+		}
+	})
+	return res
+}
+
+var _ = Describe("tree package", func() {
+	Context("diff", func() {
+		Context("similar trees", func() {
+			treeA := New()
+			treeA.Insert([]byte("a;b"), uint64(1))
+			treeA.Insert([]byte("a;c"), uint64(2))
+			It("properly sets up tree A", func() {
+				Expect(treeA.StringWithEmpty()).To(Equal(treeStr(`"a" 0|"a;b" 1|"a;c" 2|`)))
+			})
+
+			treeB := New()
+			treeB.Insert([]byte("a;b"), uint64(4))
+			treeB.Insert([]byte("a;c"), uint64(8))
+			It("properly sets up tree B", func() {
+				Expect(treeB.StringWithEmpty()).To(Equal(treeStr(`"a" 0|"a;b" 4|"a;c" 8|`)))
+			})
+
+			It("properly combine trees", func() {
+				CombineTree(treeA, treeB)
+
+				Expect(treeA.StringWithEmpty()).To(Equal(treeStr(`"a" 0|"a;b" 1|"a;c" 2|`)))
+				Expect(treeB.StringWithEmpty()).To(Equal(treeStr(`"a" 0|"a;b" 4|"a;c" 8|`)))
+			})
+
+			It("properly combine trees to flamebearer", func() {
+				f := CombineToFlamebearerStruct(treeA, treeB, 1024)
+
+				Expect(f.Names).To(ConsistOf("total", "a", "b", "c"))
+				Expect(f.Levels).To(Equal([][]int{
+					// i+0 = x offset, left  tree
+					// i+1 = total   , left  tree
+					// i+2 = self    , left  tree
+					// i+3 = x offset, right tree
+					// i+4 = total   , right tree
+					// i+5 = self    , right tree
+					// i+6 = index in the names array
+					{0, 3, 0, 0, 12, 0, 0},
+					{0, 3, 0, 0, 12, 0, 1},
+					{0, 1, 1, 0, 4, 4, 3, 0, 2, 2, 0, 8, 8, 2},
+				}))
+				Expect(f.NumTicks).To(Equal(3))
+				Expect(f.MaxSelf).To(Equal(8))
+			})
+		})
+
+		Context("tree with an extra node", func() {
+			treeA := New()
+			treeA.Insert([]byte("a;b"), uint64(1))
+			treeA.Insert([]byte("a;c"), uint64(2))
+			treeA.Insert([]byte("a;e"), uint64(3))
+			It("properly sets up tree A", func() {
+				Expect(treeA.StringWithEmpty()).To(Equal(treeStr(`"a" 0|"a;b" 1|"a;c" 2|"a;e" 3|`)))
+			})
+
+			treeB := New()
+			treeB.Insert([]byte("a;b"), uint64(4))
+			treeB.Insert([]byte("a;d"), uint64(8))
+			treeB.Insert([]byte("a;e"), uint64(12))
+			It("properly sets up tree B", func() {
+				Expect(treeB.StringWithEmpty()).To(Equal(treeStr(`"a" 0|"a;b" 4|"a;d" 8|"a;e" 12|`)))
+			})
+
+			It("properly combine trees", func() {
+				CombineTree(treeA, treeB)
+
+				expectedA := `"a" 0|"a;b" 1|"a;c" 2|"a;d" 0|"a;e" 3|`
+				expectedB := `"a" 0|"a;b" 4|"a;c" 0|"a;d" 8|"a;e" 12|`
+				Expect(treeA.StringWithEmpty()).To(Equal(treeStr(expectedA)))
+				Expect(treeB.StringWithEmpty()).To(Equal(treeStr(expectedB)))
+			})
+
+			It("properly combine trees to flamebearer", func() {
+				f := CombineToFlamebearerStruct(treeA, treeB, 1024)
+
+				Expect(f.Names).To(ConsistOf("total", "a", "b", "c", "d", "e"))
+				Expect(f.Levels).To(Equal([][]int{
+					// i+0 = x offset, left  tree
+					// i+1 = total   , left  tree
+					// i+2 = self    , left  tree
+					// i+3 = x offset, right tree
+					// i+4 = total   , right tree
+					// i+5 = self    , right tree
+					// i+6 = index in the names array
+					{0, 6, 0, 0, 24, 0, 0}, // total
+					{0, 6, 0, 0, 24, 0, 1}, //    a
+					{
+						0, 1, 1, 0, 4, 4, 5, //   e
+						0, 2, 2, 0, 0, 0, 4, //   d
+						0, 0, 0, 0, 8, 8, 3, //   c
+						0, 3, 3, 0, 12, 12, 2, // b
+					},
+				}))
+				Expect(f.NumTicks).To(Equal(6))
+				Expect(f.MaxSelf).To(Equal(12))
+			})
+		})
+
+		Context("tree with many nodes", func() {
+			It("groups nodes into a new \"other\" node", func() {
+				treeA, treeB := New(), New()
+				r := rand.New(rand.NewSource(123))
+				for i := 0; i < 2048; i++ {
+					treeA.Insert([]byte(fmt.Sprintf("foo;bar%d", i)), uint64(r.Intn(4000)))
+					treeB.Insert([]byte(fmt.Sprintf("foo;bar%d", i)), uint64(r.Intn(4000)))
+				}
+
+				f := CombineToFlamebearerStruct(treeA, treeB, 10)
+				Expect(f.Names).To(ContainElement("other"))
+			})
+		})
+	})
+})

--- a/pkg/storage/tree/treediff_test.go
+++ b/pkg/storage/tree/treediff_test.go
@@ -15,7 +15,7 @@ func (t *Tree) StringWithEmpty() string {
 	defer t.RUnlock()
 
 	res := ""
-	t.iterate(func(k []byte, v uint64) {
+	t.Iterate(func(k []byte, v uint64) {
 		if len(k) >= 2 {
 			res += fmt.Sprintf("%q %d\n", k[2:], v)
 		}

--- a/pkg/storage/tree/treediff_test.go
+++ b/pkg/storage/tree/treediff_test.go
@@ -63,7 +63,7 @@ var _ = Describe("tree package", func() {
 					{0, 3, 0, 0, 12, 0, 1},
 					{0, 1, 1, 0, 4, 4, 3, 0, 2, 2, 0, 8, 8, 2},
 				}))
-				Expect(f.NumTicks).To(Equal(3))
+				Expect(f.NumTicks).To(Equal(15))
 				Expect(f.MaxSelf).To(Equal(8))
 			})
 		})
@@ -115,7 +115,7 @@ var _ = Describe("tree package", func() {
 						0, 3, 3, 0, 12, 12, 2, // b
 					},
 				}))
-				Expect(f.NumTicks).To(Equal(6))
+				Expect(f.NumTicks).To(Equal(30))
 				Expect(f.MaxSelf).To(Equal(12))
 			})
 		})

--- a/webapp/javascript/components/ComparisonDiffApp.jsx
+++ b/webapp/javascript/components/ComparisonDiffApp.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from "react";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import FlameGraphRenderer from "./FlameGraphRenderer";
+import Header from "./Header";
+import Footer from "./Footer";
+import TimelineChartWrapper from "./TimelineChartWrapper";
+import { buildRenderURL } from "../util/updateRequests";
+import { fetchNames, fetchTimeline } from "../redux/actions";
+
+function ComparisonDiffApp(props) {
+  const { actions, renderURL } = props;
+  const prevPropsRef = useRef();
+
+  useEffect(() => {
+    if (prevPropsRef.renderURL !== renderURL) {
+      actions.fetchTimeline(renderURL);
+    }
+  }, [renderURL]);
+
+  return (
+    <div className="pyroscope-app">
+      <div className="main-wrapper">
+        <Header />
+        <TimelineChartWrapper id="timeline-chart-diff" viewSide="both" />
+        <FlameGraphRenderer viewType="diff" />
+      </div>
+      <Footer />
+    </div>
+  );
+}
+
+const mapStateToProps = (state) => ({
+  ...state,
+  renderURL: buildRenderURL(state),
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  actions: bindActionCreators(
+    {
+      fetchTimeline,
+      fetchNames,
+    },
+    dispatch
+  ),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ComparisonDiffApp);

--- a/webapp/javascript/components/ComparisonDiffApp.jsx
+++ b/webapp/javascript/components/ComparisonDiffApp.jsx
@@ -5,18 +5,18 @@ import FlameGraphRenderer from "./FlameGraphRenderer";
 import Header from "./Header";
 import Footer from "./Footer";
 import TimelineChartWrapper from "./TimelineChartWrapper";
-import { buildRenderURL } from "../util/updateRequests";
+import { buildDiffRenderURL } from "../util/updateRequests";
 import { fetchNames, fetchTimeline } from "../redux/actions";
 
 function ComparisonDiffApp(props) {
-  const { actions, renderURL } = props;
+  const { actions, diffRenderURL } = props;
   const prevPropsRef = useRef();
 
   useEffect(() => {
-    if (prevPropsRef.renderURL !== renderURL) {
-      actions.fetchTimeline(renderURL);
+    if (prevPropsRef.diffRenderURL !== diffRenderURL) {
+      actions.fetchTimeline(diffRenderURL);
     }
-  }, [renderURL]);
+  }, [diffRenderURL]);
 
   return (
     <div className="pyroscope-app">
@@ -32,7 +32,7 @@ function ComparisonDiffApp(props) {
 
 const mapStateToProps = (state) => ({
   ...state,
-  renderURL: buildRenderURL(state),
+  diffRenderURL: buildDiffRenderURL(state),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/webapp/javascript/components/FlameGraphRenderer.jsx
+++ b/webapp/javascript/components/FlameGraphRenderer.jsx
@@ -147,13 +147,11 @@ class FlameGraphRenderer extends React.Component {
     fetch(`${url}&format=json`, { signal: this.currentJSONController.signal })
       .then((response) => response.json())
       .then((data) => {
-        let { flamebearer, metadata } = data;
-        // TODO: handle different format of /render
-        deltaDiffWrapper(metadata.format, flamebearer.levels);
+        let { flamebearer } = data;
+        deltaDiffWrapper(flamebearer.format, flamebearer.levels);
 
         this.setState({
           flamebearer: flamebearer,
-          metadata: metadata,
         }, () => {
           this.updateData();
         })
@@ -220,15 +218,14 @@ class FlameGraphRenderer extends React.Component {
   }
 
   updateData = () => {
-    const { names, levels, numTicks, sampleRate, units } = this.state.flamebearer;
-    const { metadata } = this.state;
+    const { names, levels, numTicks, sampleRate, units, format } = this.state.flamebearer;
     this.setState({
       names: names,
       levels: levels,
       numTicks: numTicks,
       sampleRate: sampleRate,
       units: units,
-      format: metadata.format, // "single" | "double"
+      format: format, // "single" | "double"
     }, () => {
       this.renderCanvas();
     });

--- a/webapp/javascript/components/FlameGraphRenderer.jsx
+++ b/webapp/javascript/components/FlameGraphRenderer.jsx
@@ -18,7 +18,7 @@
 // This component is based on flamebearer project
 //   https://github.com/mapbox/flamebearer
 
-import React from "react";
+import React, { Fragment } from "react";
 import { connect } from "react-redux";
 
 import clsx from "clsx";
@@ -349,9 +349,9 @@ class FlameGraphRenderer extends React.Component {
             barIndex + numBarTicks === level[j + 3] &&
             level[j + 4] * this.pxPerTick <= COLLAPSE_THRESHOLD &&
             nodeIsInQuery ===
-              ((this.query && names[level[j + 5]].indexOf(this.query) >= 0) ||
-                false)
-          ) {
+            ((this.query && names[level[j + 5]].indexOf(this.query) >= 0) ||
+              false)
+            ) {
             j += 4;
             numBarTicks += level[j + 1];
           }
@@ -512,9 +512,6 @@ class FlameGraphRenderer extends React.Component {
       ? [this.props.timeline.map((x) => [x[0], x[1] === 0 ? null : x[1] - 1])]
       : [];
 
-    let instructionsText = this.props.viewType === "double" ? `Select ${this.props.viewSide} time range` : null;
-    let instructionsClassName = this.props.viewType === "double" ? `${this.props.viewSide}-instructions` : null;
-
     return (
       <div className={clsx("canvas-renderer", { "double": this.props.viewType === "double" })}>
 
@@ -526,17 +523,36 @@ class FlameGraphRenderer extends React.Component {
             updateView={this.updateView}
             resetStyle={this.state.resetStyle}
           />
-          <div className={`${instructionsClassName}-wrapper`}>
-            <span className={`${instructionsClassName}-text`}>{instructionsText}</span>
-          </div>
           {
-            this.props.viewType === "double" ?
-              <TimelineChartWrapper
-                key={`timeline-chart-${this.props.viewSide}`}
-                id={`timeline-chart-${this.props.viewSide}`}
-                viewSide={this.props.viewSide}
-              /> :
-              null
+            this.props.viewType === "double"
+              ? <Fragment>
+                <InstructionText {...this.props}/>
+                <TimelineChartWrapper
+                  key={`timeline-chart-${this.props.viewSide}`}
+                  id={`timeline-chart-${this.props.viewSide}`}
+                  viewSide={this.props.viewSide}
+                />
+              </Fragment>
+              : this.props.viewType === "diff"
+              ? <div className="diff-instructions-wrapper">
+                <div className="diff-instructions-wrapper-side">
+                  <InstructionText {...this.props} viewSide="left"/>
+                  <TimelineChartWrapper
+                    key={`timeline-chart-left`}
+                    id={`timeline-chart-left`}
+                    viewSide="left"
+                  />
+                </div>
+                <div className="diff-instructions-wrapper-side">
+                  <InstructionText {...this.props} viewSide="right"/>
+                  <TimelineChartWrapper
+                    key={`timeline-chart-right`}
+                    id={`timeline-chart-right`}
+                    viewSide="right"
+                  />
+                </div>
+              </div>
+              : null
           }
           <div className={clsx("flamegraph-container panes-wrapper", { "vertical-orientation": this.props.viewType === "double" })}>
             {
@@ -571,7 +587,19 @@ class FlameGraphRenderer extends React.Component {
         </div>
       </div>
     )
+  }
 }
+
+function InstructionText(props) {
+  const {viewType, viewSide} = props;
+  let instructionsText = viewType === "double" || viewType === "diff" ? `Select ${viewSide} time range` : null;
+  let instructionsClassName = viewType === "double" || viewType === "diff" ? `${viewSide}-instructions` : null;
+
+  return (
+    <div className={`${instructionsClassName}-wrapper`}>
+      <span className={`${instructionsClassName}-text`}>{instructionsText}</span>
+    </div>
+  )
 }
 
 const mapStateToProps = (state) => ({

--- a/webapp/javascript/components/FlameGraphRenderer.jsx
+++ b/webapp/javascript/components/FlameGraphRenderer.jsx
@@ -470,6 +470,16 @@ class FlameGraphRenderer extends React.Component {
     const percent = formatPercent(numBarTicks / this.state.numTicks);
     const tooltipTitle = this.state.names[level[j + ff.jName]];
 
+    var tooltipText = `${percent}, ${numberWithCommas(numBarTicks)} samples, ${this.formatter.format(numBarTicks, this.state.sampleRate)}`;
+    if (ff.format === "double") {
+      const totalLeft = ff.getBarTotalLeft(level, j);
+      const totalRght = ff.getBarTotalRght(level, j);
+      const totalDiff = ff.getBarTotalDiff(level, j);
+      tooltipText += `\nLeft: ${numberWithCommas(totalLeft)} samples, ${this.formatter.format(totalLeft, this.state.sampleRate)}`;
+      tooltipText += `\nRight: ${numberWithCommas(totalRght)} samples, ${this.formatter.format(totalRght, this.state.sampleRate)}`;
+      tooltipText += ` (${totalDiff > 0 ? '+' : ''}${formatPercent(totalDiff / totalLeft)})`;
+    }
+
     // Before you change all of this to React consider performance implications.
     // Doing this with setState leads to significant lag.
     // See this issue https://github.com/pyroscope-io/pyroscope/issues/205
@@ -485,9 +495,7 @@ class FlameGraphRenderer extends React.Component {
     tooltipEl.style.top = `${e.clientY+12}px`;
 
     tooltipEl.children[0].innerText = tooltipTitle;
-    tooltipEl.children[1].innerText = `${percent}, ${numberWithCommas(
-      numBarTicks
-    )} samples, ${this.formatter.format(numBarTicks, this.state.sampleRate)}`;
+    tooltipEl.children[1].innerText = tooltipText;
   };
 
   mouseOutHandler = () => {

--- a/webapp/javascript/components/FlameGraphRenderer.jsx
+++ b/webapp/javascript/components/FlameGraphRenderer.jsx
@@ -34,7 +34,7 @@ import {
   getPackageNameFromStackTrace,
   getFormatter,
 } from "../util/format";
-import { colorBasedOnPackageName, colorGreyscale } from "../util/color";
+import { colorBasedOnDiff, colorBasedOnPackageName, colorGreyscale } from "../util/color";
 import TimelineChartWrapper from "./TimelineChartWrapper";
 import ProfilerTable from "./ProfilerTable";
 import ProfilerHeader from "./ProfilerHeader";
@@ -335,6 +335,7 @@ class FlameGraphRenderer extends React.Component {
 
     const { names, levels, numTicks, sampleRate, units } = this.state;
     const ff = this.parseFormat();
+    const isDiff = this.props.viewType === "diff";
 
     this.graphWidth = this.canvas.width = this.canvas.clientWidth;
     this.pxPerTick =
@@ -370,6 +371,7 @@ class FlameGraphRenderer extends React.Component {
           (this.query && names[level[j + ff.jName]].indexOf(this.query) >= 0) || false;
         // merge very small blocks into big "collapsed" ones for performance
         const collapsed = numBarTicks * this.pxPerTick <= COLLAPSE_THRESHOLD;
+        const numBarDiff = collapsed? 0 : ff.getBarTotalDiff(level, j);
 
         // const collapsed = false;
         if (collapsed) { // TODO: fix collapsed code
@@ -399,7 +401,11 @@ class FlameGraphRenderer extends React.Component {
         const { spyName } = this.state.flamebearer;
 
         let nodeColor;
-        if (collapsed) {
+        if (isDiff && collapsed) {
+          nodeColor = colorGreyscale(200, 0.66);
+        } else if (isDiff) {
+          nodeColor = colorBasedOnDiff(numBarDiff, numBarTicks, a);
+        } else if (collapsed) {
           nodeColor = colorGreyscale(200, 0.66);
         } else if (queryExists && nodeIsInQuery) {
           nodeColor = HIGHLIGHT_NODE_COLOR;

--- a/webapp/javascript/components/FlameGraphRenderer.jsx
+++ b/webapp/javascript/components/FlameGraphRenderer.jsx
@@ -56,7 +56,7 @@ const unitsToFlamegraphTitle = {
 }
 
 class FlameGraphRenderer extends React.Component {
-  constructor() {
+  constructor(props) {
     super();
     this.state = {
       highlightStyle: { display: "none" },
@@ -65,6 +65,7 @@ class FlameGraphRenderer extends React.Component {
       sortBy: "self",
       sortByDirection: "desc",
       view: "both",
+      viewDiff: props.viewType === "diff" ? "diff" : undefined,
       flamebearer: null,
     };
     this.canvasRef = React.createRef();
@@ -324,6 +325,13 @@ class FlameGraphRenderer extends React.Component {
     setTimeout(this.renderCanvas, 0);
   };
 
+  updateViewDiff = (newView) => {
+    this.setState({
+      viewDiff: newView,
+    });
+    setTimeout(this.renderCanvas, 0);
+  };
+
   createFormatter = () => {
     return getFormatter(this.state.numTicks, this.state.sampleRate, this.state.units);
   }
@@ -513,6 +521,7 @@ class FlameGraphRenderer extends React.Component {
           sortBy={this.state.sortBy}
           updateSortBy={this.updateSortBy}
           view={this.state.view}
+          viewDiff={this.state.viewDiff}
         />
       </div>
     )
@@ -552,9 +561,11 @@ class FlameGraphRenderer extends React.Component {
         <div className="canvas-container">
           <ProfilerHeader
             view={this.state.view}
+            viewDiff={this.state.viewDiff}
             handleSearchChange={this.handleSearchChange}
             reset={this.reset}
             updateView={this.updateView}
+            updateViewDiff={this.updateViewDiff}
             resetStyle={this.state.resetStyle}
           />
           {

--- a/webapp/javascript/components/FlameGraphRenderer.jsx
+++ b/webapp/javascript/components/FlameGraphRenderer.jsx
@@ -55,6 +55,8 @@ const unitsToFlamegraphTitle = {
   "samples": "CPU time per function",
 }
 
+const diffLegend = [20, 10, 5, 3, 2, 1, 0, -1, -2, -3, -5, -10, -20];
+
 class FlameGraphRenderer extends React.Component {
   constructor(props) {
     super();
@@ -541,7 +543,22 @@ class FlameGraphRenderer extends React.Component {
       >
         <div className='flamegraph-header'>
           <span></span>
-          <span>Frame width represents {unitsToFlamegraphTitle[this.state.units]}</span>
+          <div>
+            <div className="row">
+              Frame width represents {unitsToFlamegraphTitle[this.state.units]}
+            </div>
+            { !this.state.viewDiff ? null :
+              <div className="row flamegraph-legend">
+                <div className="flamegraph-legend-list">
+                  {diffLegend.map((v) => (
+                    <div className="flamegraph-legend-item" style={{ backgroundColor: colorBasedOnDiff(v, 100, 0.8) }}>
+                      {v > 0 ? '+' : ''}{v}%
+                    </div>
+                  ))}
+                </div>
+              </div>
+            }
+          </div>
           <ExportData flameCanvas={this.canvasRef}/>
         </div>
         <canvas

--- a/webapp/javascript/components/ProfilerHeader.jsx
+++ b/webapp/javascript/components/ProfilerHeader.jsx
@@ -2,17 +2,22 @@ import React from "react";
 import clsx from "clsx";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-  faIcicles,
+  faAlignLeft,
+  faBars,
   faColumns,
+  faIcicles,
+  faListUl,
   faTable,
 } from "@fortawesome/free-solid-svg-icons";
 
 export default function ProfilerHeader({
   view,
+  viewDiff,
   handleSearchChange,
   resetStyle,
   reset,
   updateView,
+  updateViewDiff,
 }) {
   return (
     <div className="navbar-2">
@@ -33,6 +38,34 @@ export default function ProfilerHeader({
         Reset View
       </button>
       <div className="navbar-space-filler" />
+      {!viewDiff ? null : (
+        <div className="btn-group viz-switch">
+          <button
+            type="button"
+            className={clsx("btn", { active: viewDiff === "self" })}
+            onClick={() => updateViewDiff("self")}
+          >
+            <FontAwesomeIcon icon={faListUl} />
+            &nbsp;&thinsp;Self
+          </button>
+          <button
+            type="button"
+            className={clsx("btn", { active: viewDiff === "total" })}
+            onClick={() => updateViewDiff("total")}
+          >
+            <FontAwesomeIcon icon={faBars} />
+            &nbsp;&thinsp;Total
+          </button>
+          <button
+            type="button"
+            className={clsx("btn", { active: viewDiff === "diff" })}
+            onClick={() => updateViewDiff("diff")}
+          >
+            <FontAwesomeIcon icon={faAlignLeft} />
+            &nbsp;&thinsp;Diff
+          </button>
+        </div>
+      )}
       <div className="btn-group viz-switch">
         <button
           type="button"

--- a/webapp/javascript/components/ProfilerTable.jsx
+++ b/webapp/javascript/components/ProfilerTable.jsx
@@ -4,7 +4,7 @@
 import React from "react";
 import clsx from "clsx";
 import { getFormatter, getPackageNameFromStackTrace } from "../util/format";
-import { colorBasedOnPackageName, defaultColor } from "../util/color";
+import { colorBasedOnPackageName, defaultColor, diffColorGreen, diffColorRed } from "../util/color";
 import { parseFlamebearerFormat } from "../util/flamebearer";
 
 const zero = (v) => v || 0;
@@ -78,8 +78,8 @@ function backgroundImageDiffStyle(a, b, total, color, side) {
   const k = w - (Math.min(a, b) / total) * w;
   const kd = w - (Math.max(a, b) / total) * w;
   const clr = color.alpha(1.0);
-  const cld = b < a ? color.rgb(0, 200, 0).alpha(0.8)
-                    : color.rgb(200, 0, 0).alpha(0.8);
+  const cld = b < a ? diffColorGreen.alpha(0.8)
+                    : diffColorRed.alpha(0.8);
 
   if (side === 'L' && a < b) {
     return `

--- a/webapp/javascript/components/ProfilerTable.jsx
+++ b/webapp/javascript/components/ProfilerTable.jsx
@@ -1,8 +1,33 @@
+/* eslint no-nested-ternary: 0 */
+/* eslint prettier/prettier: 0 */
+
 import React from "react";
 import clsx from "clsx";
 import { getFormatter, getPackageNameFromStackTrace } from "../util/format";
-import { colorBasedOnPackageName } from "../util/color";
+import { colorBasedOnPackageName, defaultColor } from "../util/color";
 import { parseFlamebearerFormat } from "../util/flamebearer";
+
+const zero = (v) => v || 0;
+
+function generateCellSingle(ff, cell, level, j) {
+  const c = cell;
+  c.self = zero(c.self) + ff.getBarSelf(level, j);
+  c.total = zero(c.total) + ff.getBarTotal(level, j);
+  return c;
+}
+
+function generateCellDouble(ff, cell, level, j) {
+  const c = cell;
+  c.self = zero(c.self) + ff.getBarSelf(level, j);
+  c.total = zero(c.total) + ff.getBarTotal(level, j);
+  c.selfLeft = zero(c.selfLeft) + ff.getBarSelfLeft(level, j);
+  c.selfRght = zero(c.selfRght) + ff.getBarSelfRght(level, j);
+  c.selfDiff = zero(c.selfDiff) + ff.getBarSelfDiff(level, j);
+  c.totalLeft = zero(c.totalLeft) + ff.getBarTotalLeft(level, j);
+  c.totalRght = zero(c.totalRght) + ff.getBarTotalRght(level, j);
+  c.totalDiff = zero(c.totalDiff) + ff.getBarTotalDiff(level, j);
+  return c;
+}
 
 // generates a table from data in flamebearer format
 const generateTable = (flamebearer) => {
@@ -12,6 +37,9 @@ const generateTable = (flamebearer) => {
   }
   const { names, levels, format } = flamebearer;
   const ff = parseFlamebearerFormat(format);
+  const generateCell =
+    format !== "double" ? generateCellSingle : generateCellDouble;
+
   const hash = {};
   // eslint-disable-next-line no-plusplus
   for (let i = 0; i < levels.length; i++) {
@@ -19,17 +47,15 @@ const generateTable = (flamebearer) => {
     for (let j = 0; j < level.length; j += ff.jStep) {
       const key = ff.getBarName(level, j);
       const name = names[key];
-      hash[name] = hash[name] || {
-        name: name || "<empty>",
-        self: 0,
-        total: 0,
-      };
-      hash[name].total += ff.getBarTotal(level, j);
-      hash[name].self += ff.getBarSelf(level, j);
+      hash[name] = hash[name] || { name: name || "<empty>" };
+      generateCell(ff, hash[name], level, j);
     }
   }
   return Object.values(hash);
 };
+
+// the value must be negative or zero
+function neg(v) { return Math.min(0, v); }
 
 function backgroundImageStyle(a, b, color) {
   const w = 148;
@@ -43,11 +69,47 @@ function backgroundImageStyle(a, b, color) {
   };
 }
 
+// side: _ | L | R : indicates how to render the diff color
+// - _: render both diff color
+// - L: only render diff color on the left, if the left is longer than the right (better, green)
+// - R: only render diff color on the right, if the right is longer than the left (worse, red)
+function backgroundImageDiffStyle(a, b, total, color, side) {
+  const w = 148;
+  const k = w - (Math.min(a, b) / total) * w;
+  const kd = w - (Math.max(a, b) / total) * w;
+  const clr = color.alpha(1.0);
+  const cld = b < a ? color.rgb(0, 200, 0).alpha(0.8)
+                    : color.rgb(200, 0, 0).alpha(0.8);
+
+  if (side === 'L' && a < b) {
+    return `
+    background-image: linear-gradient(${clr}, ${clr});
+    background-position: ${neg(-k)}px 0px;
+    background-repeat: no-repeat;
+  `;
+  }
+  if (side === 'R' && b < a) {
+    return `
+    background-image: linear-gradient(${clr}, ${clr});
+    background-position: ${neg(-k)}px 0px;
+    background-repeat: no-repeat;
+  `;
+  }
+
+  // NOTE: it seems React does not understand multiple backgrounds, have to workaround
+  return `
+    background-image: linear-gradient(${clr}, ${clr}), linear-gradient(${cld}, ${cld});
+    background-position: ${neg(-k)}px 0px, ${neg(-kd)}px 0px;
+    background-repeat: no-repeat;
+  `;
+}
+
 export default function ProfilerTable({
   flamebearer,
   sortByDirection,
   sortBy,
   updateSortBy,
+  viewDiff,
 }) {
   return (
     <Table
@@ -55,43 +117,64 @@ export default function ProfilerTable({
       updateSortBy={updateSortBy}
       sortBy={sortBy}
       sortByDirection={sortByDirection}
+      viewDiff={viewDiff}
     />
   );
 }
 
-function Table({ flamebearer, updateSortBy, sortBy, sortByDirection }) {
+const tableFormatSingle = [
+  { sortable: 1, name: "name", label: "Location" },
+  { sortable: 1, name: "self", label: "Self" },
+  { sortable: 1, name: "total", label: "Total" },
+];
+
+const tableFormatDiffDef = {
+  name:      { sortable: 1, name: "name", label: "Location" },
+  selfLeft:  { sortable: 1, name: "selfLeft", label: "Self (Left)" },
+  selfRght:  { sortable: 1, name: "selfRght", label: "Self (Right)" },
+  selfDiff:  { sortable: 1, name: "selfDiff", label: "Self (Diff)" },
+  totalLeft: { sortable: 1, name: "totalLeft", label: "Total (Left)" },
+  totalRght: { sortable: 1, name: "totalRght", label: "Total (Right)" },
+  totalDiff: { sortable: 1, name: "totalDiff", label: "Total (Diff)" },
+};
+
+const tableFormatDiff = ((def) => ({
+  diff:  [def.name, def.selfDiff,  def.totalDiff],
+  self:  [def.name, def.selfLeft,  def.selfRght],
+  total: [def.name, def.totalLeft, def.totalRght],
+}))(tableFormatDiffDef);
+
+function Table({ flamebearer, updateSortBy, sortBy, sortByDirection, viewDiff }) {
   if (!flamebearer || flamebearer.numTicks === 0) {
     return [];
   }
+  const tableFormat =
+    !viewDiff ? tableFormatSingle : tableFormatDiff[viewDiff];
 
   return (
     <table className="flamegraph-table">
       <thead>
         <tr>
-          <th className="sortable" onClick={() => updateSortBy("name")}>
-            Location
-            <span
-              className={clsx("sort-arrow", {
-                [sortByDirection]: sortBy === "name",
-              })}
-            />
-          </th>
-          <th className="sortable" onClick={() => updateSortBy("self")}>
-            Self
-            <span
-              className={clsx("sort-arrow", {
-                [sortByDirection]: sortBy === "self",
-              })}
-            />
-          </th>
-          <th className="sortable" onClick={() => updateSortBy("total")}>
-            Total
-            <span
-              className={clsx("sort-arrow", {
-                [sortByDirection]: sortBy === "total",
-              })}
-            />
-          </th>
+          {tableFormat.map((v, idx) =>
+            !v.sortable ? (
+              // eslint-disable-next-line react/no-array-index-key
+              <th key={idx}>{v.label}</th>
+            ) : (
+              <th
+                // eslint-disable-next-line react/no-array-index-key
+                key={idx}
+                className="sortable"
+                onClick={() => updateSortBy(v.name)}
+              >
+                {v.label}
+                <span
+                  className={clsx("sort-arrow", {
+                    [sortByDirection]: sortBy === v.name,
+                  })}
+                />
+              </th>
+            )
+          )}
         </tr>
       </thead>
       <tbody>
@@ -99,14 +182,15 @@ function Table({ flamebearer, updateSortBy, sortBy, sortByDirection }) {
           flamebearer={flamebearer}
           sortBy={sortBy}
           sortByDirection={sortByDirection}
+          viewDiff={viewDiff}
         />
       </tbody>
     </table>
   );
 }
 
-function TableBody({ flamebearer, sortBy, sortByDirection }) {
-  const { numTicks, maxSelf, sampleRate, spyName, units, format } = flamebearer;
+function TableBody({ flamebearer, sortBy, sortByDirection, viewDiff }) {
+  const { numTicks, maxSelf, sampleRate, spyName, units } = flamebearer;
 
   const table = generateTable(flamebearer).sort((a, b) => b.total - a.total);
 
@@ -125,37 +209,93 @@ function TableBody({ flamebearer, sortBy, sortByDirection }) {
 
   const formatter = getFormatter(numTicks, sampleRate, units);
 
-  return sorted.map((x) => {
-    const pn = getPackageNameFromStackTrace(spyName, x.name);
-    const color = colorBasedOnPackageName(pn, 1);
-    const style = {
-      backgroundColor: color,
-    };
-    return (
-      <tr key={x.name+renderID}>
+  const renderRow =
+    !viewDiff ? (x, color, style) => (
+      <tr key={x.name + renderID}>
         <td>
           <span className="color-reference" style={style} />
           <span title={x.name}>{x.name}</span>
         </td>
         <td style={backgroundImageStyle(x.self, maxSelf, color)}>
           {/* <span>{ formatPercent(x.self / numTicks) }</span>
-        &nbsp;
-        <span>{ shortNumber(x.self) }</span>
-        &nbsp; */}
+      &nbsp;
+      <span>{ shortNumber(x.self) }</span>
+      &nbsp; */}
           <span title={formatter.format(x.self, sampleRate)}>
             {formatter.format(x.self, sampleRate)}
           </span>
         </td>
         <td style={backgroundImageStyle(x.total, numTicks, color)}>
           {/* <span>{ formatPercent(x.total / numTicks) }</span>
-        &nbsp;
-        <span>{ shortNumber(x.total) }</span>
-        &nbsp; */}
+      &nbsp;
+      <span>{ shortNumber(x.total) }</span>
+      &nbsp; */}
           <span title={formatter.format(x.total, sampleRate)}>
             {formatter.format(x.total, sampleRate)}
           </span>
         </td>
       </tr>
-    );
+    ) : viewDiff === 'self' ? (x, color, style) => (
+      <tr key={x.name + renderID}>
+        <td>
+          <span className="color-reference" style={style} />
+          <span title={x.name}>{x.name}</span>
+        </td>
+        {/* NOTE: it seems React does not understand multiple backgrounds, have to workaround:  */}
+        {/*   The `style` prop expects a mapping from style properties to values, not a string. */}
+        <td STYLE={backgroundImageDiffStyle(x.selfLeft, x.selfRght, maxSelf, color, 'L')}>
+          <span title={formatter.format(x.selfLeft, sampleRate)}>
+            {formatter.format(x.selfLeft, sampleRate)}
+          </span>
+        </td>
+        <td STYLE={backgroundImageDiffStyle(x.selfLeft, x.selfRght, maxSelf, color, 'R')}>
+          <span title={formatter.format(x.selfRght, sampleRate)}>
+            {formatter.format(x.selfRght, sampleRate)}
+          </span>
+        </td>
+      </tr>
+    ) : viewDiff === 'total' ? (x, color, style) => (
+      <tr key={x.name + renderID}>
+        <td>
+          <span className="color-reference" style={style} />
+          <span title={x.name}>{x.name}</span>
+        </td>
+        <td STYLE={backgroundImageDiffStyle(x.totalLeft, x.totalRght, numTicks / 2, color, 'L')}>
+          <span title={formatter.format(x.totalLeft, sampleRate)}>
+            {formatter.format(x.totalLeft, sampleRate)}
+          </span>
+        </td>
+        <td STYLE={backgroundImageDiffStyle(x.totalLeft, x.totalRght, numTicks / 2, color, 'R')}>
+          <span title={formatter.format(x.totalRght, sampleRate)}>
+            {formatter.format(x.totalRght, sampleRate)}
+          </span>
+        </td>
+      </tr>
+    ) : viewDiff === 'diff' ? (x, color, style) => (
+      <tr key={x.name + renderID}>
+        <td>
+          <span className="color-reference" style={style} />
+          <span title={x.name}>{x.name}</span>
+        </td>
+        <td STYLE={backgroundImageDiffStyle(x.selfLeft, x.selfRght, maxSelf, defaultColor)}>
+          <span title={formatter.format(x.selfDiff, sampleRate)}>
+            {formatter.format(x.selfDiff, sampleRate)}
+          </span>
+        </td>
+        <td STYLE={backgroundImageDiffStyle(x.totalLeft, x.totalRght, numTicks / 2, color)}>
+          <span title={formatter.format(x.totalDiff, sampleRate)}>
+            {formatter.format(x.totalDiff, sampleRate)}
+          </span>
+        </td>
+      </tr>
+    ) : <div>invalid</div>;
+
+  return sorted.map((x) => {
+    const pn = getPackageNameFromStackTrace(spyName, x.name);
+    const color = viewDiff ? defaultColor : colorBasedOnPackageName(pn, 1);
+    const style = {
+      backgroundColor: color,
+    };
+    return renderRow(x, color, style);
   });
 }

--- a/webapp/javascript/components/Sidebar.jsx
+++ b/webapp/javascript/components/Sidebar.jsx
@@ -13,6 +13,7 @@ import {
   faColumns,
   faBell,
   faSignOutAlt,
+  faChartBar,
 } from "@fortawesome/free-solid-svg-icons";
 import { faWindowMaximize } from "@fortawesome/free-regular-svg-icons";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
@@ -115,6 +116,17 @@ function Sidebar(props) {
           onClick={() => updateRoute("/comparison")}
         >
           <FontAwesomeIcon icon={faColumns} />
+        </button>
+      </SidebarItem>
+      <SidebarItem tooltipText="Diff View">
+        <button
+          className={clsx({
+            "active-route": state.currentRoute === "/comparison-diff",
+          })}
+          type="button"
+          onClick={() => updateRoute("/comparison-diff")}
+        >
+          <FontAwesomeIcon icon={faChartBar} />
         </button>
       </SidebarItem>
       <SidebarItem tooltipText="Alerts - Coming Soon">

--- a/webapp/javascript/index.jsx
+++ b/webapp/javascript/index.jsx
@@ -9,6 +9,7 @@ import store from "./redux/store";
 
 import PyroscopeApp from "./components/PyroscopeApp";
 import ComparisonApp from "./components/ComparisonApp";
+import ComparisonDiffApp from "./components/ComparisonDiffApp";
 import Sidebar from "./components/Sidebar";
 
 import history from "./util/history";
@@ -33,6 +34,9 @@ ReactDOM.render(
           </Route>
           <Route path="/comparison">
             <ComparisonApp />
+          </Route>
+          <Route path="/comparison-diff">
+            <ComparisonDiffApp />
           </Route>
         </Switch>
       </ShortcutProvider>

--- a/webapp/javascript/util/color.js
+++ b/webapp/javascript/util/color.js
@@ -29,6 +29,7 @@ const colors = [
   Color.rgb(128, 110, 183),
 ]
 
+export const defaultColor = colors[0];
 
 export function colorBasedOnPackageName(name, a) {
   const hash = murmurhash3_32_gc(name);
@@ -39,8 +40,8 @@ export function colorBasedOnPackageName(name, a) {
 
 export function colorBasedOnDiff(diff, total, a) {
   let v = 200 * Math.sqrt(Math.abs(diff / total));
-  if (diff >= 0) return Color.rgb(200-v, 200-(v/2), 200).alpha(a);
-  return Color.rgb(200, 200-v, 200-v).alpha(a);
+  if (diff >= 0) return Color.rgb(200,  200-v,200-v).alpha(a);
+  return Color.rgb(200-v, 200, 200-v).alpha(a);
 }
 
 export function colorGreyscale(v, a) {

--- a/webapp/javascript/util/color.js
+++ b/webapp/javascript/util/color.js
@@ -37,6 +37,12 @@ export function colorBasedOnPackageName(name, a) {
   return baseClr.alpha(a);
 }
 
+export function colorBasedOnDiff(diff, total, a) {
+  let v = 200 * Math.sqrt(Math.abs(diff / total));
+  if (diff >= 0) return Color.rgb(200-v, 200-(v/2), 200).alpha(a);
+  return Color.rgb(200, 200-v, 200-v).alpha(a);
+}
+
 export function colorGreyscale(v, a) {
   return Color.rgb(v, v, v).alpha(a);
 }

--- a/webapp/javascript/util/color.js
+++ b/webapp/javascript/util/color.js
@@ -30,6 +30,8 @@ const colors = [
 ]
 
 export const defaultColor = colors[0];
+export const diffColorRed = Color.rgb(200, 0, 0);
+export const diffColorGreen = Color.rgb(0, 170, 0);
 
 export function colorBasedOnPackageName(name, a) {
   const hash = murmurhash3_32_gc(name);
@@ -38,8 +40,11 @@ export function colorBasedOnPackageName(name, a) {
   return baseClr.alpha(a);
 }
 
-export function colorBasedOnDiff(diff, total, a) {
-  let v = 200 * Math.sqrt(Math.abs(diff / total));
+// assume: left >= 0 && Math.abs(diff) <= left so diff / left is in [0...1]
+// if left == 0 || Math.abs(diff) > left, we use the color of 100%
+export function colorBasedOnDiff(diff, left, a) {
+  const v = !left || Math.abs(diff) > left ? 1
+    : 200 * Math.sqrt(Math.abs(diff / left));
   if (diff >= 0) return Color.rgb(200,  200-v,200-v).alpha(a);
   return Color.rgb(200-v, 200, 200-v).alpha(a);
 }

--- a/webapp/javascript/util/flamebearer.js
+++ b/webapp/javascript/util/flamebearer.js
@@ -54,7 +54,7 @@ const formatSingle = {
   getBarOffset:    (level, j) => level[j],
   getBarTotal:     (level, j) => level[j + 1],
   getBarTotalDiff: (level, j) => 0,
-  getBarSelf:      (level, j) => level[j + 1],
+  getBarSelf:      (level, j) => level[j + 2],
   getBarSelfDiff:  (level, j) => 0,
   getBarName:      (level, j) => level[j + 3],
 }
@@ -64,8 +64,12 @@ const formatDouble = {
   jName : 6,
   getBarOffset:    (level, j) => (level[j]     + level[j + 3]),
   getBarTotal:     (level, j) => (level[j + 4] + level[j + 1]),
+  getBarTotalLeft: (level, j) =>  level[j + 1],
+  getBarTotalRght: (level, j) =>  level[j + 4],
   getBarTotalDiff: (level, j) => (level[j + 4] - level[j + 1]),
   getBarSelf:      (level, j) => (level[j + 5] + level[j + 2]),
+  getBarSelfLeft:  (level, j) =>  level[j + 2],
+  getBarSelfRght:  (level, j) =>  level[j + 5],
   getBarSelfDiff:  (level, j) => (level[j + 5] - level[j + 2]),
   getBarName:      (level, j) =>  level[j + 6],
 }

--- a/webapp/javascript/util/flamebearer.js
+++ b/webapp/javascript/util/flamebearer.js
@@ -49,8 +49,9 @@ export function deltaDiffWrapper(format, levels) {
 //   j = 6  : position in the main index (jStep)
 
 const formatSingle = {
-  jStep: 4,
-  jName: 3,
+  format: "single",
+  jStep : 4,
+  jName : 3,
   getBarOffset:    (level, j) => level[j],
   getBarTotal:     (level, j) => level[j + 1],
   getBarTotalDiff: (level, j) => 0,
@@ -60,6 +61,7 @@ const formatSingle = {
 }
 
 const formatDouble = {
+  format: "double",
   jStep : 7,
   jName : 6,
   getBarOffset:    (level, j) => (level[j]     + level[j + 3]),

--- a/webapp/javascript/util/flamebearer.js
+++ b/webapp/javascript/util/flamebearer.js
@@ -51,19 +51,23 @@ export function deltaDiffWrapper(format, levels) {
 const formatSingle = {
   jStep: 4,
   jName: 3,
-  getBarTotal: (level, j) => level[j],
-  getBarSelf:  (level, j) => level[j + 1],
-  getBarDiff:  (level, j) => 0,
-  getBarName:  (level, j) => level[j + 3],
+  getBarOffset:    (level, j) => level[j],
+  getBarTotal:     (level, j) => level[j + 1],
+  getBarTotalDiff: (level, j) => 0,
+  getBarSelf:      (level, j) => level[j + 1],
+  getBarSelfDiff:  (level, j) => 0,
+  getBarName:      (level, j) => level[j + 3],
 }
 
 const formatDouble = {
   jStep : 7,
   jName : 6,
-  getBarTotal: (level, j) => (level[j]     + level[j + 3]),
-  getBarSelf:  (level, j) => (level[j + 4] + level[j + 1]),
-  getBarDiff:  (level, j) => (level[j + 4] - level[j + 1]),
-  getBarName:  (level, j) =>  level[j + 6],
+  getBarOffset:    (level, j) => (level[j]     + level[j + 3]),
+  getBarTotal:     (level, j) => (level[j + 4] + level[j + 1]),
+  getBarTotalDiff: (level, j) => (level[j + 4] - level[j + 1]),
+  getBarSelf:      (level, j) => (level[j + 5] + level[j + 2]),
+  getBarSelfDiff:  (level, j) => (level[j + 5] - level[j + 2]),
+  getBarName:      (level, j) =>  level[j + 6],
 }
 
 export function parseFlamebearerFormat(format) {

--- a/webapp/javascript/util/flamebearer.js
+++ b/webapp/javascript/util/flamebearer.js
@@ -47,24 +47,27 @@ export function deltaDiffWrapper(format, levels) {
 //   j = 1,4: width of bar   => width = (level[4] + level[1]) / 2
 //                           =>  diff = (level[4] - level[1]) / (level[1] + level[4])
 //   j = 6  : position in the main index (jStep)
+
+const formatSingle = {
+  jStep: 4,
+  jName: 3,
+  getBarTotal: (level, j) => level[j],
+  getBarSelf:  (level, j) => level[j + 1],
+  getBarDiff:  (level, j) => 0,
+  getBarName:  (level, j) => level[j + 3],
+}
+
+const formatDouble = {
+  jStep : 7,
+  jName : 6,
+  getBarTotal: (level, j) => (level[j]     + level[j + 3]),
+  getBarSelf:  (level, j) => (level[j + 4] + level[j + 1]),
+  getBarDiff:  (level, j) => (level[j + 4] - level[j + 1]),
+  getBarName:  (level, j) =>  level[j + 6],
+}
+
 export function parseFlamebearerFormat(format) {
   const isSingle = format !== "double";
-  if (isSingle) {
-    return {
-      jStep: 4,
-      jName: 3,
-      getBarIndex:    (level, j) => level[j],
-      getNumBarTicks: (level, j) => level[j + 1],
-      getNumBarDiff:  (level, j) => 0,
-      getBarName:     (level, j) => level[j + 3],
-    }
-  }
-  return {
-    jStep : 7,
-    jName : 6,
-    getBarIndex:    (level, j) => (level[j]     + level[j + 3]) / 2,
-    getNumBarTicks: (level, j) => (level[j + 4] + level[j + 1]) / 2,
-    getNumBarDiff:  (level, j) => (level[j + 4] - level[j + 1]) / 2,
-    getBarName:     (level, j) =>  level[j + 6],
-  }
+  if (isSingle) return formatSingle;
+  else return formatDouble;
 }

--- a/webapp/javascript/util/flamebearer.js
+++ b/webapp/javascript/util/flamebearer.js
@@ -17,12 +17,54 @@
 // This component is based on flamebearer project
 //   https://github.com/mapbox/flamebearer
 
-export function deltaDiff(levels) {
+function deltaDiff(levels, start, step) {
   for (const level of levels) {
     let prev = 0;
-    for (let i = 0; i < level.length; i += 4) {
+    for (let i = start; i < level.length; i += step) {
       level[i] += prev;
       prev = level[i] + level[i + 1];
     }
+  }
+}
+
+export function deltaDiffWrapper(format, levels) {
+  if (format === "double") {
+    deltaDiff(levels, 0, 7);
+    deltaDiff(levels, 3, 7);
+
+  } else {
+    deltaDiff(levels, 0, 4);
+  }
+}
+
+// format=single
+//   j = 0: x start of bar
+//   j = 1: width of bar
+//   j = 3: position in the main index (jStep)
+//
+// format=double
+//   j = 0,3: x start of bar =>     x = (level[0] + level[3]) / 2
+//   j = 1,4: width of bar   => width = (level[4] + level[1]) / 2
+//                           =>  diff = (level[4] - level[1]) / (level[1] + level[4])
+//   j = 6  : position in the main index (jStep)
+export function parseFlamebearerFormat(format) {
+  const isSingle = format !== "double";
+  if (isSingle) {
+    return {
+      jStep: 4,
+      jName: 3,
+      getBarIndex:    (level, j) => level[j],
+      getNumBarTicks: (level, j) => level[j + 1],
+      getNumBarDiff:  (level, j) => 0,
+      getBarName:     (level, j) => level[j + 3],
+    }
+  }
+  return {
+    jStep : 7,
+    jName : 6,
+    getBarIndex:    (level, j) => (level[j]     + level[j + 3]) / 2,
+    getNumBarTicks: (level, j) => (level[j + 4] + level[j + 1]) / 2,
+    getNumBarDiff:  (level, j) => (level[j + 4] - level[j + 1]) / 2,
+    getBarName:     (level, j) =>  level[j + 6],
   }
 }

--- a/webapp/javascript/util/format.js
+++ b/webapp/javascript/util/format.js
@@ -52,7 +52,9 @@ export class DurationFormatter {
 
   format(samples, sampleRate) {
     let number = samples / sampleRate / this.divider;
-    if (number < 0.01) {
+    if (number >= 0 && number < 0.01) {
+      number = '< 0.01';
+    } else if (number <= 0 && number > -0.01) {
       number = '< 0.01';
     } else {
       number = number.toFixed(2);
@@ -87,7 +89,9 @@ export class BytesFormatter {
 
   format(samples, sampleRate) {
     let number = samples / this.divider;
-    if (number < 0.01) {
+    if (number >= 0 && number < 0.01) {
+      number = '< 0.01';
+    } else if (number <= 0 && number > -0.01) {
       number = '< 0.01';
     } else {
       number = number.toFixed(2);
@@ -121,7 +125,9 @@ export class ObjectsFormatter {
 
   format(samples, sampleRate) {
     let number = samples / this.divider;
-    if (number < 0.01) {
+    if (number >= 0 && number < 0.01) {
+      number = '< 0.01';
+    } else if (number <= 0 && number > -0.01) {
       number = '< 0.01';
     } else {
       number = number.toFixed(2);

--- a/webapp/javascript/util/updateRequests.js
+++ b/webapp/javascript/util/updateRequests.js
@@ -42,6 +42,8 @@ export function buildDiffRenderURL(state, { from: fromOverride, until: untilOver
 
   const urlStr = buildRenderURL(state, from, until);
   const url = new URL(urlStr, location.origin);
+  url.pathname = '/render-diff'; // TODO: merge with buildRenderURL
+
   const params = url.searchParams;
   params.set('leftFrom', leftFrom);
   params.set('leftUntil', leftUntil);

--- a/webapp/javascript/util/updateRequests.js
+++ b/webapp/javascript/util/updateRequests.js
@@ -29,3 +29,18 @@ export function buildRenderURL(state, fromOverride=null, untilOverride=null, sid
 
   return url;
 }
+
+// TODO: merge buildRenderURL and buildDiffRenderURL
+export function buildDiffRenderURL(state, leftFrom=null, leftUntil=null, rightFrom=null, rightUntil=null) {
+  const urlStr = buildRenderURL(state, leftFrom, leftUntil);
+  const url = new URL(urlStr, location.origin);
+  const params = url.searchParams;
+  params.delete('from');
+  params.delete('until');
+  params.set('leftFrom', leftFrom);
+  params.set('leftUntil', leftUntil);
+  params.set('rightFrom', rightFrom);
+  params.set('rightUntil', rightUntil);
+
+  return url.toString();
+}

--- a/webapp/javascript/util/updateRequests.js
+++ b/webapp/javascript/util/updateRequests.js
@@ -31,18 +31,18 @@ export function buildRenderURL(state, fromOverride=null, untilOverride=null, sid
 }
 
 // TODO: merge buildRenderURL and buildDiffRenderURL
-export function buildDiffRenderURL(state, leftFromOverride=null, leftUntilOverride=null, rightFromOverride=null, rightUntilOverride=null) {
-  let { leftFrom, leftUntil, rightFrom, rightUntil } = state;
+export function buildDiffRenderURL(state, { from: fromOverride, until: untilOverride, leftFrom: leftFromOverride, leftUntil: leftUntilOverride, rightFrom: rightFromOverride, rightUntil: rightUntilOverride } = {}) {
+  let { from, until, leftFrom, leftUntil, rightFrom, rightUntil } = state;
+  from = fromOverride || from;
+  until = untilOverride || until;
   leftFrom = leftFromOverride || leftFrom;
   leftUntil = leftUntilOverride || leftUntil;
   rightFrom = rightFromOverride || rightFrom;
   rightUntil = rightUntilOverride || rightUntil;
 
-  const urlStr = buildRenderURL(state, leftFrom, leftUntil);
+  const urlStr = buildRenderURL(state, from, until);
   const url = new URL(urlStr, location.origin);
   const params = url.searchParams;
-  params.delete('from');
-  params.delete('until');
   params.set('leftFrom', leftFrom);
   params.set('leftUntil', leftUntil);
   params.set('rightFrom', rightFrom);

--- a/webapp/javascript/util/updateRequests.js
+++ b/webapp/javascript/util/updateRequests.js
@@ -31,7 +31,13 @@ export function buildRenderURL(state, fromOverride=null, untilOverride=null, sid
 }
 
 // TODO: merge buildRenderURL and buildDiffRenderURL
-export function buildDiffRenderURL(state, leftFrom=null, leftUntil=null, rightFrom=null, rightUntil=null) {
+export function buildDiffRenderURL(state, leftFromOverride=null, leftUntilOverride=null, rightFromOverride=null, rightUntilOverride=null) {
+  let { leftFrom, leftUntil, rightFrom, rightUntil } = state;
+  leftFrom = leftFromOverride || leftFrom;
+  leftUntil = leftUntilOverride || leftUntil;
+  rightFrom = rightFromOverride || rightFrom;
+  rightUntil = rightUntilOverride || rightUntil;
+
   const urlStr = buildRenderURL(state, leftFrom, leftUntil);
   const url = new URL(urlStr, location.origin);
   const params = url.searchParams;

--- a/webapp/sass/profile.scss
+++ b/webapp/sass/profile.scss
@@ -251,6 +251,10 @@ $pane-width: 6px;
       .flamegraph-legend-item {
         width: 35px;
         text-align: center;
+
+        &:first-child, &:last-child {
+          width: 40px;
+        }
       }
     }
 

--- a/webapp/sass/profile.scss
+++ b/webapp/sass/profile.scss
@@ -226,10 +226,32 @@ $pane-width: 6px;
     width: 50%;
 
     .flamegraph-header {
+      padding-bottom: 5px;
       display: flex;
       justify-content: space-between;
-      align-items: center;
-      padding-bottom: 5px;
+
+      .row {
+        display: flex;
+        justify-content: center;
+      }
+
+      .flamegraph-legend {
+        display: flex;
+        align-items: center;
+        font-size: 11px;
+        justify-content: center;
+        margin-bottom: 10px;
+      }
+
+      .flamegraph-legend-list {
+        display: flex;
+        justify-content: center;
+      }
+
+      .flamegraph-legend-item {
+        width: 35px;
+        text-align: center;
+      }
     }
 
     &.vertical-orientation {

--- a/webapp/sass/profile.scss
+++ b/webapp/sass/profile.scss
@@ -495,6 +495,10 @@ body,
       border-bottom-color: $active-color;
     }
   }
+
+  & + .viz-switch {
+    margin-left: 10px;
+  }
 }
 
 .sidebar-wrapper {

--- a/webapp/sass/profile.scss
+++ b/webapp/sass/profile.scss
@@ -243,6 +243,16 @@ $pane-width: 6px;
   }
 }
 
+.diff-instructions-wrapper {
+  display: flex;
+  gap: 30px;
+  padding-bottom: 10px;
+}
+
+.diff-instructions-wrapper-side {
+  flex: 1 1 0;
+}
+
 .left-instructions-wrapper {
   display: flex;
   width: 50%;


### PR DESCRIPTION
<img width="1217" src="https://user-images.githubusercontent.com/6618620/127475061-5d53398c-32d3-4049-9289-d7d108e026bc.png">

This PR implements diff rendering:
- [x] send request with new format: `single | double`
- [x] add adapters for different formats
- [x] render diff graph
- [x] render color as red/green (just work for now, will need a better calculation later)
- [x] render table with 3 options: self(left), self(right) ; total(left), total(right) ; self(diff), total(diff)
- [x] split API to `/render` and `/render-diff`
- [x] add tooltip
- [x] add color legend 

Depends: #288