### PR TITLE
WIP: implement server for rendering diff

### DIFF
--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -311,10 +311,11 @@ func (ctrl *Controller) callbackRedirectHandler(getAccountInfoURL string, info *
 func (ctrl *Controller) indexHandler() http.HandlerFunc {
 	fs := http.FileServer(ctrl.dir)
 	return func(rw http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/" {
+		path := r.URL.Path
+		if path == "/" {
 			ctrl.statsInc("index")
 			ctrl.renderIndexPage(rw, r)
-		} else if r.URL.Path == "/comparison" {
+		} else if path == "/comparison" || path == "/comparison-diff" {
 			ctrl.statsInc("index")
 			ctrl.renderIndexPage(rw, r)
 		} else {

--- a/pkg/server/render.go
+++ b/pkg/server/render.go
@@ -5,13 +5,23 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
+	"sync"
+	"time"
 
 	"github.com/pyroscope-io/pyroscope/pkg/flameql"
 	"github.com/pyroscope-io/pyroscope/pkg/storage"
 	"github.com/pyroscope-io/pyroscope/pkg/storage/segment"
 	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
 	"github.com/pyroscope-io/pyroscope/pkg/util/attime"
+)
+
+type RenderFormat string
+
+const (
+	FormatSingle = "single"
+	FormatDouble = "double"
 )
 
 var (
@@ -39,20 +49,42 @@ func (ctrl *Controller) renderHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	out, err := ctrl.storage.Get(p.gi)
-	ctrl.statsInc("render")
-	if err != nil {
-		ctrl.writeInternalServerError(w, err, "failed to retrieve data")
-		return
+	var out *storage.GetOutput
+	var fs *tree.Flamebearer
+	var err error
+	var format RenderFormat
+
+	leftStartTime, leftEndTime, leftOK := parseRenderRangeParams(r.URL.Query(), "leftFrom", "leftUntil")
+	rghtStartTime, rghtEndTime, rghtOK := parseRenderRangeParams(r.URL.Query(), "rightFrom", "rightUntil")
+
+	if rghtOK || leftOK {
+		var leftOut, rghtOut *storage.GetOutput
+		leftOut, rghtOut, err = ctrl.loadDiffOutput(p.gi, leftStartTime, leftEndTime, rghtStartTime, rghtEndTime)
+		ctrl.statsInc("render")
+		if err != nil {
+			ctrl.writeInternalServerError(w, err, "failed to retrieve data")
+			return
+		}
+		out = leftOut // to be compatible with responding code
+		fs = tree.CombineToFlamebearerStruct(leftOut.Tree, rghtOut.Tree, p.maxNodes)
+		format = FormatDouble
+
+	} else {
+		out, err = ctrl.storage.Get(p.gi)
+		ctrl.statsInc("render")
+		if err != nil {
+			ctrl.writeInternalServerError(w, err, "failed to retrieve data")
+			return
+		}
+
+		// TODO: handle properly
+		if out == nil {
+			out = &storage.GetOutput{Tree: tree.New()}
+		}
+		fs = out.Tree.FlamebearerStruct(p.maxNodes)
+		format = FormatSingle
 	}
 
-	// TODO: handle properly
-	if out == nil {
-		out = &storage.GetOutput{Tree: tree.New()}
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	fs := out.Tree.FlamebearerStruct(p.maxNodes)
 	// TODO remove this duplication? We're already adding this to metadata
 	fs.SpyName = out.SpyName
 	fs.SampleRate = out.SampleRate
@@ -64,9 +96,11 @@ func (ctrl *Controller) renderHandler(w http.ResponseWriter, r *http.Request) {
 			"spyName":    out.SpyName,
 			"sampleRate": out.SampleRate,
 			"units":      out.Units,
+			"format":     format, // "single" | "double"
 		},
 	}
 
+	w.Header().Set("Content-Type", "application/json")
 	if err = json.NewEncoder(w).Encode(res); err != nil {
 		ctrl.writeJSONEncodeError(w, err)
 	}
@@ -105,4 +139,60 @@ func (ctrl *Controller) renderParametersFromRequest(r *http.Request, p *renderPa
 	p.gi.EndTime = attime.Parse(v.Get("until"))
 	p.format = v.Get("format")
 	return nil
+}
+
+func parseRenderRangeParams(v url.Values, from, until string) (startTime, endTime time.Time, ok bool) {
+	fromStr, untilStr := v.Get(from), v.Get(until)
+	startTime, endTime = attime.Parse(fromStr), attime.Parse(untilStr)
+	return startTime, endTime, fromStr != "" || untilStr != ""
+}
+
+func (ctrl *Controller) loadDiffOutput(
+	gi *storage.GetInput,
+	leftStartTime, leftEndTime time.Time,
+	rghtStartTime, rghtEndTime time.Time,
+) (*storage.GetOutput, *storage.GetOutput, error) {
+
+	var leftOut, rghtOut *storage.GetOutput
+	var leftErr, rghtErr error
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); leftOut, leftErr = ctrl.loadDiffOutputExec(gi, leftStartTime, leftEndTime) }()
+	go func() { defer wg.Done(); rghtOut, rghtErr = ctrl.loadDiffOutputExec(gi, rghtStartTime, rghtEndTime) }()
+	wg.Wait()
+
+	if leftErr != nil {
+		return nil, nil, leftErr
+	}
+	if rghtErr != nil {
+		return nil, nil, rghtErr
+	}
+	leftOut.Tree, rghtOut.Tree = combineTree(leftOut.Tree, rghtOut.Tree)
+	return leftOut, rghtOut, nil
+}
+
+func (ctrl *Controller) loadDiffOutputExec(gi *storage.GetInput, startTime, endTime time.Time) (_ *storage.GetOutput, _err error) {
+	defer func() {
+		rerr := recover()
+		if rerr != nil {
+			_err = fmt.Errorf("panic: %v", rerr)
+		}
+	}()
+
+	_gi := *gi // clone the struct
+	_gi.StartTime, _gi.EndTime = startTime, endTime
+	out, err := ctrl.storage.Get(&_gi)
+	if err != nil {
+		return nil, err
+	}
+	if out == nil {
+		// TODO: handle properly
+		return &storage.GetOutput{Tree: tree.New()}, nil
+	}
+	return out, nil
+}
+
+func combineTree(leftTree, rightTree *tree.Tree) (*tree.Tree, *tree.Tree) {
+	return tree.CombineTree(leftTree, rightTree)
 }

--- a/pkg/storage/tree/flamebearer.go
+++ b/pkg/storage/tree/flamebearer.go
@@ -91,13 +91,7 @@ func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 	}
 
 	// delta encoding
-	for _, l := range res.Levels {
-		prev := 0
-		for i := 0; i < len(l); i += 4 {
-			l[i] -= prev
-			prev += l[i] + l[i+1]
-		}
-	}
+	deltaEncoding(res.Levels, 0, 4)
 
 	// TODO: we used to drop the first level, because it's always an empty node
 	//   but that didn't work because flamebearer doesn't work with more
@@ -106,4 +100,14 @@ func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 	// 	res.Levels = res.Levels[1:]
 	// }
 	return &res
+}
+
+func deltaEncoding(levels [][]int, start, step int) {
+	for _, l := range levels {
+		prev := 0
+		for i := start; i < len(l); i += step {
+			l[i] -= prev
+			prev += l[i] + l[i+1]
+		}
+	}
 }

--- a/pkg/storage/tree/flamebearer.go
+++ b/pkg/storage/tree/flamebearer.go
@@ -1,5 +1,12 @@
 package tree
 
+type Format string
+
+const (
+	FormatSingle Format = "single"
+	FormatDouble Format = "double"
+)
+
 type Flamebearer struct {
 	Names    []string `json:"names"`
 	Levels   [][]int  `json:"levels"`
@@ -9,6 +16,7 @@ type Flamebearer struct {
 	SpyName    string `json:"spyName"`
 	SampleRate uint32 `json:"sampleRate"`
 	Units      string `json:"units"`
+	Format     Format `json:"format"`
 }
 
 func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
@@ -20,6 +28,7 @@ func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 		Levels:   [][]int{},
 		NumTicks: int(t.Samples()),
 		MaxSelf:  int(0),
+		Format:   FormatSingle,
 	}
 
 	nodes := []*treeNode{t.root}

--- a/pkg/storage/tree/treediff.go
+++ b/pkg/storage/tree/treediff.go
@@ -84,7 +84,7 @@ func CombineToFlamebearerStruct(leftTree, rightTree *Tree, maxNodes int) *Flameb
 	res := Flamebearer{
 		Names:    []string{},
 		Levels:   [][]int{},
-		NumTicks: int(leftTree.Samples()),
+		NumTicks: int(leftTree.Samples() + rightTree.Samples()),
 		MaxSelf:  int(0),
 	}
 

--- a/pkg/storage/tree/treediff.go
+++ b/pkg/storage/tree/treediff.go
@@ -86,6 +86,7 @@ func CombineToFlamebearerStruct(leftTree, rightTree *Tree, maxNodes int) *Flameb
 		Levels:   [][]int{},
 		NumTicks: int(leftTree.Samples() + rightTree.Samples()),
 		MaxSelf:  int(0),
+		Format:   FormatDouble,
 	}
 
 	leftNodes, xLeftOffsets := []*treeNode{leftTree.root}, []int{0}

--- a/pkg/storage/tree/treediff.go
+++ b/pkg/storage/tree/treediff.go
@@ -1,0 +1,239 @@
+package tree
+
+import (
+	"bytes"
+
+	"github.com/pyroscope-io/pyroscope/pkg/structs/cappedarr"
+)
+
+// CombineTree aligns 2 trees by making them having the same structure with the
+// same number of nodes
+// TODO: create a new struct?
+func CombineTree(leftTree, rightTree *Tree) (*Tree, *Tree) {
+	leftTree.Lock()
+	defer leftTree.Unlock()
+	rightTree.Lock()
+	defer rightTree.Unlock()
+
+	leftNodes := []*treeNode{leftTree.root}
+	rghtNodes := []*treeNode{rightTree.root}
+
+	for len(leftNodes) > 0 {
+		left, rght := leftNodes[0], rghtNodes[0]
+		leftNodes, rghtNodes = leftNodes[1:], rghtNodes[1:]
+
+		left.ChildrenNodes, rght.ChildrenNodes = combineNodes(left.ChildrenNodes, rght.ChildrenNodes)
+		leftNodes = append(leftNodes, left.ChildrenNodes...)
+		rghtNodes = append(rghtNodes, rght.ChildrenNodes...)
+	}
+	return leftTree, rightTree
+}
+
+func combineNodes(leftNodes, rghtNodes []*treeNode) ([]*treeNode, []*treeNode) {
+	size := nextPow2(max(len(leftNodes), len(rghtNodes)))
+	leftResult := make([]*treeNode, 0, size)
+	rghtResult := make([]*treeNode, 0, size)
+
+	for len(leftNodes) != 0 && len(rghtNodes) != 0 {
+		left, rght := leftNodes[0], rghtNodes[0]
+		switch bytes.Compare(left.Name, rght.Name) {
+		case 0:
+			leftResult = append(leftResult, left)
+			rghtResult = append(rghtResult, rght)
+			leftNodes, rghtNodes = leftNodes[1:], rghtNodes[1:]
+		case -1:
+			leftResult = append(leftResult, left)
+			rghtResult = append(rghtResult, newNode(left.Name))
+			leftNodes = leftNodes[1:]
+		case 1:
+			leftResult = append(leftResult, newNode(rght.Name))
+			rghtResult = append(rghtResult, rght)
+			rghtNodes = rghtNodes[1:]
+		}
+	}
+	leftResult = append(leftResult, leftNodes...)
+	rghtResult = append(rghtResult, rghtNodes...)
+	for _, left := range leftNodes {
+		rghtResult = append(rghtResult, newNode(left.Name))
+	}
+	for _, rght := range rghtNodes {
+		leftResult = append(leftResult, newNode(rght.Name))
+	}
+	return leftResult, rghtResult
+}
+
+// CombineToFlamebearerStruct generates the Flamebearer struct from 2 trees.
+// They must be the response trees from CombineTree (i.e. all children nodes
+// must be the same length). The Flamebearer struct returned from this function
+// is different to the one returned from Tree.FlamebearerStruct(). It has the
+// following structure:
+//
+//     i+0 = x offset, left  tree
+//     i+1 = total   , left  tree
+//     i+2 = self    , left  tree
+//     i+3 = x offset, right tree
+//     i+4 = total   , right tree
+//     i+5 = self    , right tree
+//     i+6 = index in the names array
+func CombineToFlamebearerStruct(leftTree, rightTree *Tree, maxNodes int) *Flamebearer {
+	leftTree.RLock()
+	defer leftTree.RUnlock()
+	rightTree.RLock()
+	defer rightTree.RUnlock()
+
+	res := Flamebearer{
+		Names:    []string{},
+		Levels:   [][]int{},
+		NumTicks: int(leftTree.Samples()),
+		MaxSelf:  int(0),
+	}
+
+	leftNodes, xLeftOffsets := []*treeNode{leftTree.root}, []int{0}
+	rghtNodes, xRghtOffsets := []*treeNode{rightTree.root}, []int{0}
+	levels := []int{0}
+	minVal := combineMinValues(leftTree, rightTree, maxNodes)
+	nameLocationCache := map[string]int{}
+
+	for len(leftNodes) > 0 {
+		left, rght := leftNodes[0], rghtNodes[0]
+		leftNodes, rghtNodes = leftNodes[1:], rghtNodes[1:]
+
+		xLeftOffset, xRghtOffset := xLeftOffsets[0], xRghtOffsets[0]
+		xLeftOffsets, xRghtOffsets = xLeftOffsets[1:], xRghtOffsets[1:]
+
+		level := levels[0]
+		levels = levels[1:]
+
+		// both left.Name and rght.Name must be the same
+		name := string(left.Name)
+		if left.Total >= minVal || rght.Total >= minVal || name == "other" {
+			i, ok := nameLocationCache[name]
+			if !ok {
+				i = len(res.Names)
+				nameLocationCache[name] = i
+				if i == 0 {
+					name = "total"
+				}
+				res.Names = append(res.Names, name)
+			}
+
+			if level == len(res.Levels) {
+				res.Levels = append(res.Levels, []int{})
+			}
+			res.MaxSelf = max(res.MaxSelf, int(left.Self))
+			res.MaxSelf = max(res.MaxSelf, int(rght.Self))
+
+			// i+0 = x offset, left  tree
+			// i+1 = total   , left  tree
+			// i+2 = self    , left  tree
+			// i+3 = x offset, right tree
+			// i+4 = total   , right tree
+			// i+5 = self    , right tree
+			// i+6 = index in the names array
+			values := []int{
+				xLeftOffset, int(left.Total), int(left.Self),
+				xRghtOffset, int(rght.Total), int(rght.Self),
+				i,
+			}
+			res.Levels[level] = append(values, res.Levels[level]...)
+
+			xLeftOffset += int(left.Self)
+			xRghtOffset += int(rght.Self)
+			otherLeftTotal, otherRghtTotal := uint64(0), uint64(0)
+
+			// both left and right must have the same number of children nodes
+			for ni := range left.ChildrenNodes {
+				leftNode, rghtNode := left.ChildrenNodes[ni], rght.ChildrenNodes[ni]
+				if leftNode.Total >= minVal || rghtNode.Total >= minVal {
+					levels = append([]int{level + 1}, levels...)
+					xLeftOffsets = append([]int{xLeftOffset}, xLeftOffsets...)
+					xRghtOffsets = append([]int{xRghtOffset}, xRghtOffsets...)
+					leftNodes = append([]*treeNode{leftNode}, leftNodes...)
+					rghtNodes = append([]*treeNode{rghtNode}, rghtNodes...)
+					xLeftOffset += int(leftNode.Total)
+					xRghtOffset += int(rghtNode.Total)
+				} else {
+					otherLeftTotal += leftNode.Total
+					otherRghtTotal += rghtNode.Total
+				}
+			}
+			if otherLeftTotal != 0 || otherRghtTotal != 0 {
+				{
+					leftNode := &treeNode{
+						Name:  jsonableSlice("other"),
+						Total: otherLeftTotal,
+						Self:  otherLeftTotal,
+					}
+					levels = append([]int{level + 1}, levels...)
+					xLeftOffsets = append([]int{xLeftOffset}, xLeftOffsets...)
+					leftNodes = append([]*treeNode{leftNode}, leftNodes...)
+					xLeftOffset += int(leftNode.Total)
+				}
+				{
+					rghtNode := &treeNode{
+						Name:  jsonableSlice("other"),
+						Total: otherRghtTotal,
+						Self:  otherRghtTotal,
+					}
+					levels = append([]int{level + 1}, levels...)
+					xRghtOffsets = append([]int{xRghtOffset}, xRghtOffsets...)
+					rghtNodes = append([]*treeNode{rghtNode}, rghtNodes...)
+					xRghtOffset += int(rghtNode.Total)
+				}
+			}
+		}
+	}
+
+	// delta encoding
+	deltaEncoding(res.Levels, 0, 7)
+	deltaEncoding(res.Levels, 3, 7)
+	return &res
+}
+
+func combineMinValues(leftTree, rightTree *Tree, maxNodes int) uint64 {
+	c := cappedarr.New(maxNodes)
+	combineIterateWithCum(leftTree, rightTree, func(left uint64, right uint64) bool {
+		return c.Push(maxUint64(left, right))
+	})
+	return c.MinValue()
+}
+
+// iterate both trees, both trees must be returned from CombineTree
+func combineIterateWithCum(leftTree, rightTree *Tree, cb func(uint64, uint64) bool) {
+	leftNodes, rghtNodes := []*treeNode{leftTree.root}, []*treeNode{rightTree.root}
+	i := 0
+	for len(leftNodes) > 0 {
+		leftNode, rghtNode := leftNodes[0], rghtNodes[0]
+		leftNodes, rghtNodes = leftNodes[1:], rghtNodes[1:]
+		i++
+		if cb(leftNode.Total, rghtNode.Total) {
+			leftNodes = append(leftNode.ChildrenNodes, leftNodes...)
+			rghtNodes = append(rghtNode.ChildrenNodes, rghtNodes...)
+		}
+	}
+}
+
+func maxUint64(a, b uint64) uint64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func nextPow2(a int) int {
+	a--
+	a |= a >> 1
+	a |= a >> 2
+	a |= a >> 4
+	a |= a >> 8
+	a |= a >> 16
+	a++
+	return a
+}

--- a/pkg/storage/tree/treediff_test.go
+++ b/pkg/storage/tree/treediff_test.go
@@ -1,0 +1,137 @@
+package tree
+
+import (
+	"fmt"
+	"math/rand"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// StringWithEmpty is used for testing only, hence declared in this file. It's
+// different to String() as it includes nodes with zero value.
+func (t *Tree) StringWithEmpty() string {
+	t.RLock()
+	defer t.RUnlock()
+
+	res := ""
+	t.iterate(func(k []byte, v uint64) {
+		if len(k) >= 2 {
+			res += fmt.Sprintf("%q %d\n", k[2:], v)
+		}
+	})
+	return res
+}
+
+var _ = Describe("tree package", func() {
+	Context("diff", func() {
+		Context("similar trees", func() {
+			treeA := New()
+			treeA.Insert([]byte("a;b"), uint64(1))
+			treeA.Insert([]byte("a;c"), uint64(2))
+			It("properly sets up tree A", func() {
+				Expect(treeA.StringWithEmpty()).To(Equal(treeStr(`"a" 0|"a;b" 1|"a;c" 2|`)))
+			})
+
+			treeB := New()
+			treeB.Insert([]byte("a;b"), uint64(4))
+			treeB.Insert([]byte("a;c"), uint64(8))
+			It("properly sets up tree B", func() {
+				Expect(treeB.StringWithEmpty()).To(Equal(treeStr(`"a" 0|"a;b" 4|"a;c" 8|`)))
+			})
+
+			It("properly combine trees", func() {
+				CombineTree(treeA, treeB)
+
+				Expect(treeA.StringWithEmpty()).To(Equal(treeStr(`"a" 0|"a;b" 1|"a;c" 2|`)))
+				Expect(treeB.StringWithEmpty()).To(Equal(treeStr(`"a" 0|"a;b" 4|"a;c" 8|`)))
+			})
+
+			It("properly combine trees to flamebearer", func() {
+				f := CombineToFlamebearerStruct(treeA, treeB, 1024)
+
+				Expect(f.Names).To(ConsistOf("total", "a", "b", "c"))
+				Expect(f.Levels).To(Equal([][]int{
+					// i+0 = x offset, left  tree
+					// i+1 = total   , left  tree
+					// i+2 = self    , left  tree
+					// i+3 = x offset, right tree
+					// i+4 = total   , right tree
+					// i+5 = self    , right tree
+					// i+6 = index in the names array
+					{0, 3, 0, 0, 12, 0, 0},
+					{0, 3, 0, 0, 12, 0, 1},
+					{0, 1, 1, 0, 4, 4, 3, 0, 2, 2, 0, 8, 8, 2},
+				}))
+				Expect(f.NumTicks).To(Equal(3))
+				Expect(f.MaxSelf).To(Equal(8))
+			})
+		})
+
+		Context("tree with an extra node", func() {
+			treeA := New()
+			treeA.Insert([]byte("a;b"), uint64(1))
+			treeA.Insert([]byte("a;c"), uint64(2))
+			treeA.Insert([]byte("a;e"), uint64(3))
+			It("properly sets up tree A", func() {
+				Expect(treeA.StringWithEmpty()).To(Equal(treeStr(`"a" 0|"a;b" 1|"a;c" 2|"a;e" 3|`)))
+			})
+
+			treeB := New()
+			treeB.Insert([]byte("a;b"), uint64(4))
+			treeB.Insert([]byte("a;d"), uint64(8))
+			treeB.Insert([]byte("a;e"), uint64(12))
+			It("properly sets up tree B", func() {
+				Expect(treeB.StringWithEmpty()).To(Equal(treeStr(`"a" 0|"a;b" 4|"a;d" 8|"a;e" 12|`)))
+			})
+
+			It("properly combine trees", func() {
+				CombineTree(treeA, treeB)
+
+				expectedA := `"a" 0|"a;b" 1|"a;c" 2|"a;d" 0|"a;e" 3|`
+				expectedB := `"a" 0|"a;b" 4|"a;c" 0|"a;d" 8|"a;e" 12|`
+				Expect(treeA.StringWithEmpty()).To(Equal(treeStr(expectedA)))
+				Expect(treeB.StringWithEmpty()).To(Equal(treeStr(expectedB)))
+			})
+
+			It("properly combine trees to flamebearer", func() {
+				f := CombineToFlamebearerStruct(treeA, treeB, 1024)
+
+				Expect(f.Names).To(ConsistOf("total", "a", "b", "c", "d", "e"))
+				Expect(f.Levels).To(Equal([][]int{
+					// i+0 = x offset, left  tree
+					// i+1 = total   , left  tree
+					// i+2 = self    , left  tree
+					// i+3 = x offset, right tree
+					// i+4 = total   , right tree
+					// i+5 = self    , right tree
+					// i+6 = index in the names array
+					{0, 6, 0, 0, 24, 0, 0}, // total
+					{0, 6, 0, 0, 24, 0, 1}, //    a
+					{
+						0, 1, 1, 0, 4, 4, 5, //   e
+						0, 2, 2, 0, 0, 0, 4, //   d
+						0, 0, 0, 0, 8, 8, 3, //   c
+						0, 3, 3, 0, 12, 12, 2, // b
+					},
+				}))
+				Expect(f.NumTicks).To(Equal(6))
+				Expect(f.MaxSelf).To(Equal(12))
+			})
+		})
+
+		Context("tree with many nodes", func() {
+			It("groups nodes into a new \"other\" node", func() {
+				treeA, treeB := New(), New()
+				r := rand.New(rand.NewSource(123))
+				for i := 0; i < 2048; i++ {
+					treeA.Insert([]byte(fmt.Sprintf("foo;bar%d", i)), uint64(r.Intn(4000)))
+					treeB.Insert([]byte(fmt.Sprintf("foo;bar%d", i)), uint64(r.Intn(4000)))
+				}
+
+				f := CombineToFlamebearerStruct(treeA, treeB, 10)
+				Expect(f.Names).To(ContainElement("other"))
+			})
+		})
+	})
+})

--- a/pkg/storage/tree/treediff_test.go
+++ b/pkg/storage/tree/treediff_test.go
@@ -63,7 +63,7 @@ var _ = Describe("tree package", func() {
 					{0, 3, 0, 0, 12, 0, 1},
 					{0, 1, 1, 0, 4, 4, 3, 0, 2, 2, 0, 8, 8, 2},
 				}))
-				Expect(f.NumTicks).To(Equal(3))
+				Expect(f.NumTicks).To(Equal(15))
 				Expect(f.MaxSelf).To(Equal(8))
 			})
 		})
@@ -115,7 +115,7 @@ var _ = Describe("tree package", func() {
 						0, 3, 3, 0, 12, 12, 2, // b
 					},
 				}))
-				Expect(f.NumTicks).To(Equal(6))
+				Expect(f.NumTicks).To(Equal(30))
 				Expect(f.MaxSelf).To(Equal(12))
 			})
 		})

--- a/webapp/javascript/components/ComparisonDiffApp.jsx
+++ b/webapp/javascript/components/ComparisonDiffApp.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from "react";
+import { connect } from "react-redux";
+import { bindActionCreators } from "redux";
+import FlameGraphRenderer from "./FlameGraphRenderer";
+import Header from "./Header";
+import Footer from "./Footer";
+import TimelineChartWrapper from "./TimelineChartWrapper";
+import { buildRenderURL } from "../util/updateRequests";
+import { fetchNames, fetchTimeline } from "../redux/actions";
+
+function ComparisonDiffApp(props) {
+  const { actions, renderURL } = props;
+  const prevPropsRef = useRef();
+
+  useEffect(() => {
+    if (prevPropsRef.renderURL !== renderURL) {
+      actions.fetchTimeline(renderURL);
+    }
+  }, [renderURL]);
+
+  return (
+    <div className="pyroscope-app">
+      <div className="main-wrapper">
+        <Header />
+        <TimelineChartWrapper id="timeline-chart-diff" viewSide="both" />
+        <FlameGraphRenderer viewType="diff" />
+      </div>
+      <Footer />
+    </div>
+  );
+}
+
+const mapStateToProps = (state) => ({
+  ...state,
+  renderURL: buildRenderURL(state),
+});
+
+const mapDispatchToProps = (dispatch) => ({
+  actions: bindActionCreators(
+    {
+      fetchTimeline,
+      fetchNames,
+    },
+    dispatch
+  ),
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ComparisonDiffApp);

--- a/webapp/javascript/components/FlameGraphRenderer.jsx
+++ b/webapp/javascript/components/FlameGraphRenderer.jsx
@@ -18,7 +18,7 @@
 // This component is based on flamebearer project
 //   https://github.com/mapbox/flamebearer
 
-import React from "react";
+import React, { Fragment } from "react";
 import { connect } from "react-redux";
 
 import clsx from "clsx";
@@ -349,9 +349,9 @@ class FlameGraphRenderer extends React.Component {
             barIndex + numBarTicks === level[j + 3] &&
             level[j + 4] * this.pxPerTick <= COLLAPSE_THRESHOLD &&
             nodeIsInQuery ===
-              ((this.query && names[level[j + 5]].indexOf(this.query) >= 0) ||
-                false)
-          ) {
+            ((this.query && names[level[j + 5]].indexOf(this.query) >= 0) ||
+              false)
+            ) {
             j += 4;
             numBarTicks += level[j + 1];
           }
@@ -512,9 +512,6 @@ class FlameGraphRenderer extends React.Component {
       ? [this.props.timeline.map((x) => [x[0], x[1] === 0 ? null : x[1] - 1])]
       : [];
 
-    let instructionsText = this.props.viewType === "double" ? `Select ${this.props.viewSide} time range` : null;
-    let instructionsClassName = this.props.viewType === "double" ? `${this.props.viewSide}-instructions` : null;
-
     return (
       <div className={clsx("canvas-renderer", { "double": this.props.viewType === "double" })}>
 
@@ -526,17 +523,36 @@ class FlameGraphRenderer extends React.Component {
             updateView={this.updateView}
             resetStyle={this.state.resetStyle}
           />
-          <div className={`${instructionsClassName}-wrapper`}>
-            <span className={`${instructionsClassName}-text`}>{instructionsText}</span>
-          </div>
           {
-            this.props.viewType === "double" ?
-              <TimelineChartWrapper
-                key={`timeline-chart-${this.props.viewSide}`}
-                id={`timeline-chart-${this.props.viewSide}`}
-                viewSide={this.props.viewSide}
-              /> :
-              null
+            this.props.viewType === "double"
+              ? <Fragment>
+                <InstructionText {...this.props}/>
+                <TimelineChartWrapper
+                  key={`timeline-chart-${this.props.viewSide}`}
+                  id={`timeline-chart-${this.props.viewSide}`}
+                  viewSide={this.props.viewSide}
+                />
+              </Fragment>
+              : this.props.viewType === "diff"
+              ? <div className="diff-instructions-wrapper">
+                <div className="diff-instructions-wrapper-side">
+                  <InstructionText {...this.props} viewSide="left"/>
+                  <TimelineChartWrapper
+                    key={`timeline-chart-left`}
+                    id={`timeline-chart-left`}
+                    viewSide="left"
+                  />
+                </div>
+                <div className="diff-instructions-wrapper-side">
+                  <InstructionText {...this.props} viewSide="right"/>
+                  <TimelineChartWrapper
+                    key={`timeline-chart-right`}
+                    id={`timeline-chart-right`}
+                    viewSide="right"
+                  />
+                </div>
+              </div>
+              : null
           }
           <div className={clsx("flamegraph-container panes-wrapper", { "vertical-orientation": this.props.viewType === "double" })}>
             {
@@ -571,7 +587,19 @@ class FlameGraphRenderer extends React.Component {
         </div>
       </div>
     )
+  }
 }
+
+function InstructionText(props) {
+  const {viewType, viewSide} = props;
+  let instructionsText = viewType === "double" || viewType === "diff" ? `Select ${viewSide} time range` : null;
+  let instructionsClassName = viewType === "double" || viewType === "diff" ? `${viewSide}-instructions` : null;
+
+  return (
+    <div className={`${instructionsClassName}-wrapper`}>
+      <span className={`${instructionsClassName}-text`}>{instructionsText}</span>
+    </div>
+  )
 }
 
 const mapStateToProps = (state) => ({

--- a/webapp/javascript/components/Sidebar.jsx
+++ b/webapp/javascript/components/Sidebar.jsx
@@ -13,6 +13,7 @@ import {
   faColumns,
   faBell,
   faSignOutAlt,
+  faChartBar,
 } from "@fortawesome/free-solid-svg-icons";
 import { faWindowMaximize } from "@fortawesome/free-regular-svg-icons";
 import { faGithub } from "@fortawesome/free-brands-svg-icons";
@@ -115,6 +116,17 @@ function Sidebar(props) {
           onClick={() => updateRoute("/comparison")}
         >
           <FontAwesomeIcon icon={faColumns} />
+        </button>
+      </SidebarItem>
+      <SidebarItem tooltipText="Diff View">
+        <button
+          className={clsx({
+            "active-route": state.currentRoute === "/comparison-diff",
+          })}
+          type="button"
+          onClick={() => updateRoute("/comparison-diff")}
+        >
+          <FontAwesomeIcon icon={faChartBar} />
         </button>
       </SidebarItem>
       <SidebarItem tooltipText="Alerts - Coming Soon">

--- a/webapp/javascript/index.jsx
+++ b/webapp/javascript/index.jsx
@@ -9,6 +9,7 @@ import store from "./redux/store";
 
 import PyroscopeApp from "./components/PyroscopeApp";
 import ComparisonApp from "./components/ComparisonApp";
+import ComparisonDiffApp from "./components/ComparisonDiffApp";
 import Sidebar from "./components/Sidebar";
 
 import history from "./util/history";
@@ -33,6 +34,9 @@ ReactDOM.render(
           </Route>
           <Route path="/comparison">
             <ComparisonApp />
+          </Route>
+          <Route path="/comparison-diff">
+            <ComparisonDiffApp />
           </Route>
         </Switch>
       </ShortcutProvider>

--- a/webapp/sass/profile.scss
+++ b/webapp/sass/profile.scss
@@ -243,6 +243,16 @@ $pane-width: 6px;
   }
 }
 
+.diff-instructions-wrapper {
+  display: flex;
+  gap: 30px;
+  padding-bottom: 10px;
+}
+
+.diff-instructions-wrapper-side {
+  flex: 1 1 0;
+}
+
 .left-instructions-wrapper {
   display: flex;
   width: 50%;


### PR DESCRIPTION
This PR supports 2 formats for render URL, which allows responding combined data for rendering diff:

#### format: single
- URL: `/render?from=...&until=...`
- Response:
  - add `"format": "single"` to `flamebearer` and `metadata`
  - `levels`: x_offset, total, self, name_index

```
{
  "flamebearer": {
    "format": "single",
    "names": [ ... ]
    "levels": [ i, ..., i+3 ]
    // ....
  },
  "metadata": {
    "format": "single",
    // ....
  },
  "timeline": { ... }
}
```

#### format: double
- URL: `/render?left=...&until=...&leftFrom=...&leftUntil=...&rightFrom=...&rightUntil=...`
- Response:
  - add `"format": "double"` to `flamebearer` and `metadata`
  - `levels`: left_x_offset, left_total, left_self, right_x_offset, right_total, right_self, name_index

```
{
  "flamebearer": {
    "format": "double",
    "names": [ ... ]
    "levels": [ i, ..., i+6 ]
    // ...
  },
  "metadata": {
    "format": "double",
     // ...
  },
  "timeline": { ... }
}
```

Depends: #288