### PR TITLE
Protect diagnostic endpoints

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,32 +90,32 @@ type Server struct {
 	CacheTreeSize       int               `deprecated:"true"`
 
 	// TODO: remove skip: true when we enable these back
-	GoogleEnabled      bool   `deprecated:"true" def:"false" desc:"enables Google Oauth"`
-	GoogleClientID     string `deprecated:"true" def:"" desc:"client ID generated for Google API"`
-	GoogleClientSecret string `deprecated:"true" def:"" desc:"client secret generated for Google API"`
-	GoogleRedirectURL  string `deprecated:"true" def:"" desc:"url that google will redirect to after logging in. Has to be in form <pathToPyroscopeServer/auth/google/callback>"`
-	GoogleAuthURL      string `deprecated:"true" def:"https://accounts.google.com/o/oauth2/auth" desc:"auth url for Google API (usually present in credentials.json file)"`
-	GoogleTokenURL     string `deprecated:"true" def:"https://accounts.google.com/o/oauth2/token" desc:"token url for Google API (usually present in credentials.json file)"`
+	GoogleEnabled      bool   `json:"-" deprecated:"true" def:"false" desc:"enables Google Oauth"`
+	GoogleClientID     string `json:"-" deprecated:"true" def:"" desc:"client ID generated for Google API"`
+	GoogleClientSecret string `json:"-" deprecated:"true" def:"" desc:"client secret generated for Google API"`
+	GoogleRedirectURL  string `json:"-" deprecated:"true" def:"" desc:"url that google will redirect to after logging in. Has to be in form <pathToPyroscopeServer/auth/google/callback>"`
+	GoogleAuthURL      string `json:"-" deprecated:"true" def:"https://accounts.google.com/o/oauth2/auth" desc:"auth url for Google API (usually present in credentials.json file)"`
+	GoogleTokenURL     string `json:"-" deprecated:"true" def:"https://accounts.google.com/o/oauth2/token" desc:"token url for Google API (usually present in credentials.json file)"`
 
-	GitlabEnabled bool `deprecated:"true" def:"false" desc:"enables Gitlab Oauth"`
+	GitlabEnabled bool `json:"-" deprecated:"true" def:"false" desc:"enables Gitlab Oauth"`
 	// TODO: why is this one ApplicationID and not ClientID ?
-	GitlabApplicationID string `deprecated:"true" def:"" desc:"application ID generated for GitLab API"`
-	GitlabClientSecret  string `deprecated:"true" def:"" desc:"client secret generated for GitLab API"`
-	GitlabRedirectURL   string `deprecated:"true" def:"" desc:"url that gitlab will redirect to after logging in. Has to be in form <pathToPyroscopeServer/auth/gitlab/callback>"`
-	GitlabAuthURL       string `deprecated:"true" def:"https://gitlab.com/oauth/authorize" desc:"auth url for GitLab API (keep default for cloud, usually https://gitlab.mycompany.com/oauth/authorize for on-premise)"`
-	GitlabTokenURL      string `deprecated:"true" def:"https://gitlab.com/oauth/token" desc:"token url for GitLab API (keep default for cloud, usually https://gitlab.mycompany.com/oauth/token for on-premise)"`
-	GitlabAPIURL        string `deprecated:"true" def:"https://gitlab.com/api/v4/user" desc:"URL to gitlab API (keep default for cloud, usually https://gitlab.mycompany.com/api/v4/user for on-premise)"`
+	GitlabApplicationID string `json:"-" deprecated:"true" def:"" desc:"application ID generated for GitLab API"`
+	GitlabClientSecret  string `json:"-" deprecated:"true" def:"" desc:"client secret generated for GitLab API"`
+	GitlabRedirectURL   string `json:"-" deprecated:"true" def:"" desc:"url that gitlab will redirect to after logging in. Has to be in form <pathToPyroscopeServer/auth/gitlab/callback>"`
+	GitlabAuthURL       string `json:"-" deprecated:"true" def:"https://gitlab.com/oauth/authorize" desc:"auth url for GitLab API (keep default for cloud, usually https://gitlab.mycompany.com/oauth/authorize for on-premise)"`
+	GitlabTokenURL      string `json:"-" deprecated:"true" def:"https://gitlab.com/oauth/token" desc:"token url for GitLab API (keep default for cloud, usually https://gitlab.mycompany.com/oauth/token for on-premise)"`
+	GitlabAPIURL        string `json:"-" deprecated:"true" def:"https://gitlab.com/api/v4/user" desc:"URL to gitlab API (keep default for cloud, usually https://gitlab.mycompany.com/api/v4/user for on-premise)"`
 
-	GithubEnabled      bool   `deprecated:"true" def:"false" desc:"enables Github Oauth"`
-	GithubClientID     string `deprecated:"true" def:"" desc:"client ID generated for Github API"`
-	GithubClientSecret string `deprecated:"true" def:"" desc:"client secret generated for Github API"`
-	GithubRedirectURL  string `deprecated:"true" def:"" desc:"url that Github will redirect to after logging in. Has to be in form <pathToPyroscopeServer/auth/github/callback>"`
-	GithubAuthURL      string `deprecated:"true" def:"https://github.com/login/oauth/authorize" desc:"auth url for Github API"`
-	GithubTokenURL     string `deprecated:"true" def:"https://github.com/login/oauth/access_token" desc:"token url for Github API"`
+	GithubEnabled      bool   `json:"-" deprecated:"true" def:"false" desc:"enables Github Oauth"`
+	GithubClientID     string `json:"-" deprecated:"true" def:"" desc:"client ID generated for Github API"`
+	GithubClientSecret string `json:"-" deprecated:"true" def:"" desc:"client secret generated for Github API"`
+	GithubRedirectURL  string `json:"-" deprecated:"true" def:"" desc:"url that Github will redirect to after logging in. Has to be in form <pathToPyroscopeServer/auth/github/callback>"`
+	GithubAuthURL      string `json:"-" deprecated:"true" def:"https://github.com/login/oauth/authorize" desc:"auth url for Github API"`
+	GithubTokenURL     string `json:"-" deprecated:"true" def:"https://github.com/login/oauth/access_token" desc:"token url for Github API"`
 
 	// TODO: can we generate these automatically if it's empty?
-	JWTSecret                string `deprecated:"true" def:"" desc:"secret used to secure your JWT tokens"`
-	LoginMaximumLifetimeDays int    `deprecated:"true" def:"0" desc:"amount of days after which user will be logged out. 0 means non-expiring."`
+	JWTSecret                string `json:"-" deprecated:"true" def:"" desc:"secret used to secure your JWT tokens"`
+	LoginMaximumLifetimeDays int    `json:"-" deprecated:"true" def:"0" desc:"amount of days after which user will be logged out. 0 means non-expiring."`
 }
 
 type Convert struct {

--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -95,30 +95,33 @@ func (ctrl *Controller) mux() (http.Handler, error) {
 	addRoutes(mux, insecureRoutes, ctrl.drainMiddleware)
 
 	// Protected routes:
-	routes := []route{
+	protectedRoutes := []route{
 		{"/", ctrl.indexHandler()},
 		{"/render", ctrl.renderHandler},
 		{"/labels", ctrl.labelsHandler},
 		{"/label-values", ctrl.labelValuesHandler},
 	}
-	addRoutes(mux, routes, ctrl.drainMiddleware, ctrl.authMiddleware)
+	addRoutes(mux, protectedRoutes, ctrl.drainMiddleware, ctrl.authMiddleware)
 
-	// Diagnostic routes: not protected with auth, not drained.
-	addRoutes(mux, []route{
-		{"/healthz", ctrl.healthz},
-		{"/metrics", promhttp.Handler().ServeHTTP},
+	// Diagnostic secure routes: must be protected but not drained.
+	diagnosticSecureRoutes := []route{
 		{"/config", ctrl.configHandler},
 		{"/build", ctrl.buildHandler},
-	})
+	}
 	if !ctrl.config.DisablePprofEndpoint {
-		addRoutes(mux, []route{
+		diagnosticSecureRoutes = append(diagnosticSecureRoutes, []route{
 			{"/debug/pprof/", pprof.Index},
 			{"/debug/pprof/cmdline", pprof.Cmdline},
 			{"/debug/pprof/profile", pprof.Profile},
 			{"/debug/pprof/symbol", pprof.Symbol},
 			{"/debug/pprof/trace", pprof.Trace},
-		})
+		}...)
 	}
+	addRoutes(mux, diagnosticSecureRoutes, ctrl.authMiddleware)
+	addRoutes(mux, []route{
+		{"/metrics", promhttp.Handler().ServeHTTP},
+		{"/healthz", ctrl.healthz},
+	})
 
 	return mux, nil
 }


### PR DESCRIPTION
Allowing unauthentified users accessing /config and /build endpoints may be considered as a disclosure ([CWE-200](https://cwe.mitre.org/data/definitions/200.html)).

 - [x] Protect endpoints with authentication middleware.
 - [x] Hide sensitive configuration parameters from output.

I general, it may make sense to restrict access to /build and /config endpoint to only admin users (or connections from localhost).
