### PR TITLE
scripts/decode-resp: update script for format double

### DIFF
--- a/scripts/decode-resp/decode.go
+++ b/scripts/decode-resp/decode.go
@@ -12,9 +12,10 @@ type Input struct {
 }
 
 type InputMetadata struct {
-	SpyName    string `json:"spyName"`
-	SampleRate uint32 `json:"sampleRate"`
-	Units      string `json:"units"`
+	SpyName    string      `json:"spyName"`
+	SampleRate uint32      `json:"sampleRate"`
+	Units      string      `json:"units"`
+	Format     tree.Format `json:"format"`
 }
 
 type Output struct {
@@ -25,26 +26,68 @@ type OutputFlamebearer struct {
 	Levels [][]OutputItem `json:"levels"`
 }
 
-type OutputItem struct {
-	Name  string `json:"name"`
-	Total int    `json:"total"`
-	Self  int    `json:"self"`
+type OutputItem interface{}
+
+type OutputItemSingle struct {
+	Row    int    `json:"_row"`
+	Col    int    `json:"_col"`
+	Name   string `json:"name"`
+	Total  int    `json:"total"`
+	Self   int    `json:"self"`
+	Offset int    `json:"offset"`
+}
+
+type OutputItemDouble struct {
+	Row        int    `json:"_row"`
+	Col        int    `json:"_col"`
+	Name       string `json:"name"`
+	LeftSelf   int    `json:"left_self"`
+	LeftTotal  int    `json:"left_total"`
+	LeftOffset int    `json:"left_offset"`
+	RghtSelf   int    `json:"right_self"`
+	RghtTotal  int    `json:"right_total"`
+	RghtOffset int    `json:"right_offset"`
 }
 
 func decodeLevels(in *Input) *Output {
 	names, levels := in.Flamebearer.Names, in.Flamebearer.Levels
 	outLevels := make([][]OutputItem, 0, len(levels))
+	isSingle := in.Flamebearer.Format != tree.FormatDouble
 
-	for _, row := range levels {
-		offset := 0
+	step := 4
+	if !isSingle {
+		step = 7
+	}
+
+	for rowIdx, row := range levels {
+		offsetLeft, offsetRght := 0, 0
 		outRow := make([]OutputItem, 0, len(row))
 
-		for i, N := 0, len(row); i < N; i += 4 {
-			offset += row[i]
-			outItem := OutputItem{
-				Name:  names[row[i+3]],
-				Total: offset + row[i+1],
-				Self:  row[i+2],
+		for i, N := 0, len(row); i < N; i += step {
+			var outItem OutputItem
+			if isSingle {
+				offsetLeft += row[i+0]
+				outItem = OutputItemSingle{
+					Row: rowIdx, Col: i / step,
+					Offset: offsetLeft,
+					Total:  row[i+1],
+					Self:   row[i+2],
+					Name:   names[row[i+3]],
+				}
+
+			} else {
+				offsetLeft += row[i+0]
+				offsetRght += row[i+3]
+				outItem = OutputItemDouble{
+					Row: rowIdx, Col: i / step,
+					LeftOffset: offsetLeft,
+					LeftTotal:  row[i+1],
+					LeftSelf:   row[i+2],
+					RghtOffset: offsetRght,
+					RghtTotal:  row[i+4],
+					RghtSelf:   row[i+6],
+					Name:       names[row[i+6]],
+				}
 			}
 			outRow = append(outRow, outItem)
 		}

--- a/scripts/decode-resp/decode_test.go
+++ b/scripts/decode-resp/decode_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
@@ -17,7 +18,7 @@ var _ = Describe("Decode", func() {
 			levels := [][]int{
 				{0, 3, 0, 0},             // total
 				{0, 3, 0, 1},             // a
-				{0, 1, 1, 3, 2, 0, 2, 2}, // b, c
+				{0, 1, 1, 3, 2, 2, 2, 2}, // b, c
 			}
 			in := &Input{
 				Flamebearer: &tree.Flamebearer{
@@ -32,33 +33,46 @@ var _ = Describe("Decode", func() {
     "levels": [
       [
         {
+          "_row": 0,
+          "_col": 0,
           "name": "total",
           "total": 3,
-          "self": 0
+          "self": 0,
+          "offset": 0
         }
       ],
       [
         {
+          "_row": 1,
+          "_col": 0,
           "name": "a",
           "total": 3,
-          "self": 0
+          "self": 0,
+          "offset": 0
         }
       ],
       [
         {
+          "_row": 2,
+          "_col": 0,
           "name": "c",
           "total": 1,
-          "self": 1
+          "self": 1,
+          "offset": 0
         },
         {
+          "_row": 2,
+          "_col": 1,
           "name": "b",
           "total": 2,
-          "self": 2
+          "self": 2,
+          "offset": 2
         }
       ]
     ]
   }
 }`
+			fmt.Println(outJson)
 			Expect(outJson).To(Equal(expected))
 		})
 	})


### PR DESCRIPTION
This PR updates scripts/decode-resp for decoding response with `format: double`.