### PR TITLE
Revert "improve tree.Insert"

### DIFF
--- a/pkg/storage/tree/tree.go
+++ b/pkg/storage/tree/tree.go
@@ -136,25 +136,20 @@ func (n *treeNode) insert(targetLabel []byte) *treeNode {
 	return n.ChildrenNodes[i]
 }
 
-func (n *treeNode) insertChild(label []byte, value uint64) *treeNode {
-	n.Total += value
-	childNode := n.insert(label)
-	return childNode
-}
-
 func (t *Tree) Insert(key []byte, value uint64, _ ...bool) {
-	buf := make([]byte, len(key))
-	copy(buf, key)
+	// TODO: can optimize this, split is not necessary?
+	labels := bytes.Split(key, []byte(";"))
+	node := t.root
+	for _, l := range labels {
+		buf := make([]byte, len(l))
+		copy(buf, l)
+		l = buf
 
-	node, lastIdx := t.root, 0
-	for i, b := range buf {
-		if b == semicolon {
-			node = node.insertChild(buf[lastIdx:i], value)
-			lastIdx = i + 1
-		}
+		n := node.insert(l)
+
+		node.Total += value
+		node = n
 	}
-	node = node.insertChild(buf[lastIdx:], value)
-
 	node.Self += value
 	node.Total += value
 }


### PR DESCRIPTION
`v0.0.37` has a problem with memory consumption: some tree nodes are not garbage collected:

<img width="588" alt="image" src="https://user-images.githubusercontent.com/12090599/128880576-dd753edb-ffd5-4775-b07f-814223db7bb3.png">

This is more than 50% of available memory, which causes endless cache evictions (and consequent GC calls) with no results.

(pprof snapshot has been taken for a different time window)
```
(pprof) list wrap  
Total: 18.30GB
ROUTINE ======================== github.com/pyroscope-io/pyroscope/pkg/server.wrapConvertFunction.func1.1 in github.com/pyroscope-io/pyroscope/pkg/server/ingest.go
   16.10GB    16.10GB (flat, cum) 88.00% of Total
         .          .    132:
         .          .    133:func wrapConvertFunction(convertFunc func(r io.Reader, cb func(name []byte, val int)) error) func(io.Reader) (*tree.Tree, error) {
         .          .    134:	return func(r io.Reader) (*tree.Tree, error) {
         .          .    135:		t := tree.New()
         .          .    136:		if err := convertFunc(r, func(k []byte, v int) {
   16.10GB    16.10GB    137:			t.Insert(k, uint64(v))
         .          .    138:		}); err != nil {
         .          .    139:			return nil, err
         .          .    140:		}
         .          .    141:		return t, nil
         .          .    142:	}
(pprof) 
```

The problem is caused by the fact that at insertion we share the same byte buffer (underlying memory) for all labels. This is very wise from the performance respective but prevents GC from freeing such tightly coupled objects.

I've reverted the commit without any additional changes: right now `tree.Insert` does not seem to be the perfect candidate for optimisations.


