### PR TITLE
Fix CPU check

### DIFF
--- a/pkg/util/debug/cpu.go
+++ b/pkg/util/debug/cpu.go
@@ -8,7 +8,7 @@ import (
 
 func CPUUsage(interval time.Duration) map[string]interface{} {
 	cpuVal, err := cpu.Percent(interval, false)
-	if err != nil {
+	if err != nil || len(cpuVal) == 0 {
 		return map[string]interface{}{}
 	}
 


### PR DESCRIPTION
On Linux, if there are no file descriptors available, the call returns an empty slice, which results in server crash.