### PR TITLE
Benchmark dashboard

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.15.6
 WORKDIR /go/src/app
 
 COPY go.mod go.sum ./
-RUN go get -d ./
+RUN go mod download
 
 COPY ./pkg pkg
 COPY ./benchmark benchmark

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -32,6 +32,6 @@ Edit `run-parameters.env` file to change the parameters of the benchmark run.
 
 ## Browsing results
 
-To view results open [http://localhost:8080/d/65gjqY3Mk/main?orgId=1](http://localhost:8080/d/65gjqY3Mk/main?orgId=1).
+To view results open [http://localhost:8080/d/tsWRL6ReZQkirFirmyvnWX1akHXJeHT8I8emjGJo/main?orgId=1](http://localhost:8080/d/tsWRL6ReZQkirFirmyvnWX1akHXJeHT8I8emjGJo/main?orgId=1).
 
 You will also be able to see screenshots of the runs in `./runs` directory

--- a/benchmark/docker-compose.yml
+++ b/benchmark/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - ./prometheus:/etc/prometheus/
       - data-prometheus:/prometheus
     ports:
-      - 9091:9090
+      - 9090:9090
 
   grafana:
     image: grafana/grafana:7.5.7

--- a/benchmark/docker-compose.yml
+++ b/benchmark/docker-compose.yml
@@ -33,13 +33,14 @@ services:
       - ./prometheus:/etc/prometheus/
       - data-prometheus:/prometheus
     ports:
-      - 9090:9090
+      - 9091:9090
 
   grafana:
     image: grafana/grafana:7.5.7
     volumes:
       - ./grafana-provisioning:/etc/grafana/provisioning
       - ./grafana/grafana.ini:/etc/grafana/grafana.ini
+      - ../monitoring/gen/benchmark-dashboard.json:/etc/grafana/provisioning/dashboards/benchmark-dashboard.json
     ports:
       - 8080:3000
 

--- a/benchmark/grafana-provisioning/datasources/prometheus.yml
+++ b/benchmark/grafana-provisioning/datasources/prometheus.yml
@@ -1,6 +1,6 @@
 ---
 datasources:
-  - name: Prometheus
+  - name: prometheus
     # <string, required> datasource type. Required
     type: prometheus
     # <string, required> access mode. proxy or direct (Server or Browser in the UI). Required

--- a/benchmark/start.sh
+++ b/benchmark/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -x
 set -e
 
 ../scripts/generate-git-info.sh > git-info.env
@@ -8,6 +9,7 @@ echo "building containers..."
 
 source ./run-parameters.env
 export PYROSCOPE_CPUS PYROSCOPE_MEMORY
+export DOCKER_BUILDKIT=1
 
 docker-compose build
 

--- a/benchmark/start.sh
+++ b/benchmark/start.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -x
 set -e
 
 ../scripts/generate-git-info.sh > git-info.env

--- a/examples/grafana-integration/docker-compose.yml
+++ b/examples/grafana-integration/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - 3000:3000
 
   pyroscope:
-    image: "pyroscope/pyroscope-dev:main"
+    image: "pyroscope/pyroscope:latest"
     ports:
       - 4040:4040
     command:

--- a/examples/grafana-integration/docker-compose.yml
+++ b/examples/grafana-integration/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     image: grafana/grafana:8.1.1
     volumes:
       - ./grafana-provisioning:/etc/grafana/provisioning
+      - ../../monitoring/gen/dashboard.json:/etc/grafana/provisioning/dashboards/dashboard.json
       - ./grafana/grafana.ini:/etc/grafana/grafana.ini
       - ./grafana/home.json:/default-dashboard.json
     environment:
@@ -18,7 +19,7 @@ services:
       - 3000:3000
 
   pyroscope:
-    image: "pyroscope/pyroscope:latest"
+    image: "pyroscope/pyroscope-dev:main"
     ports:
       - 4040:4040
     command:

--- a/monitoring/Makefile
+++ b/monitoring/Makefile
@@ -1,5 +1,10 @@
+all: dashboard benchmark-dashboard
+
 dashboard:
-	jsonnet -J vendor dashboard.jsonnet | tee dashboard.json
+	jsonnet -J vendor dashboard.jsonnet | tee gen/dashboard.json
+
+benchmark-dashboard:
+	jsonnet -J vendor benchmark.jsonnet | tee gen/benchmark-dashboard.json
 
 .PHONY: init
 init:

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -7,9 +7,9 @@
 make init
 ```
 
-3. (Re)Generate the dashboard
+3. (Re)Generate the dashboards
 ```
-make dashboard
+make
 ```
 
 # Development
@@ -18,10 +18,11 @@ make dashboard
 Run the [grafana-integration](../examples/grafana-integration) example docker-compose then copy the generated dashboard there:
 
 ```
-make dashboard && \
-  cp dashboard.json ../examples/grafana-integration/grafana-provisioning/dashboards/ \
-  docker-compose -f ../examples/grafana-integration/docker-compose.yml up -d --force-recreate grafana
+make && docker-compose -f ../examples/grafana-integration/docker-compose.yml up -d --force-recreate grafana
 ```
+
+# Warnings
+* If you ever rename the dashboard path, don't forget to update the references (see all the docker-compose.yaml)
 
 # References
 

--- a/monitoring/benchmark.jsonnet
+++ b/monitoring/benchmark.jsonnet
@@ -1,4 +1,8 @@
 local config = import 'config.libsonnet';
 local dashboard = import './lib/dashboard.libsonnet';
 
-(config + dashboard).dashboard
+(config + dashboard + {
+  _config+:: {
+    benchmark: true,
+  }
+}).dashboard

--- a/monitoring/config.libsonnet
+++ b/monitoring/config.libsonnet
@@ -1,0 +1,7 @@
+{
+  _config+:: {
+    selector: 'instance="$instance"',
+    // whether to add additional benchmark fields or not
+    benchmark: false,
+  }
+}

--- a/monitoring/gen/benchmark-dashboard.json
+++ b/monitoring/gen/benchmark-dashboard.json
@@ -4,14 +4,349 @@
    "annotations": {
       "list": [ ]
    },
-   "editable": false,
+   "editable": "true",
    "gnetId": null,
    "graphTooltip": 0,
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "refresh": "",
+   "refresh": "5s",
    "rows": [
+      {
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 2,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_benchmark{}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Benchmark",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 3,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_run_progress{}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Run Progress",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 4,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 2,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_upload_errors{}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Upload Errors",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 5,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 2,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_successful_uploads{}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Upload Errors",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Benchmark",
+         "titleSize": "h6",
+         "type": "row"
+      },
       {
          "collapse": false,
          "collapsed": false,
@@ -21,7 +356,7 @@
                "datasource": "$PROMETHEUS_DS",
                "gridPos": { },
                "height": 10,
-               "id": 2,
+               "id": 6,
                "links": [ ],
                "span": 12,
                "styles": [
@@ -93,7 +428,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 3,
+               "id": 7,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -173,7 +508,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 4,
+               "id": 8,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -253,7 +588,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 5,
+               "id": 9,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -333,7 +668,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 6,
+               "id": 10,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -387,7 +722,7 @@
                },
                "yaxes": [
                   {
-                     "format": "short",
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -395,7 +730,7 @@
                      "show": true
                   },
                   {
-                     "format": "short",
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -413,7 +748,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 7,
+               "id": 11,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -506,7 +841,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 8,
+               "id": 12,
                "legend": {
                   "alignAsTable": "true",
                   "avg": false,
@@ -595,7 +930,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 9,
+               "id": 13,
                "legend": {
                   "alignAsTable": "true",
                   "avg": false,
@@ -677,7 +1012,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 10,
+               "id": 14,
                "legend": {
                   "alignAsTable": "true",
                   "avg": false,
@@ -766,7 +1101,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 11,
+               "id": 15,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -853,7 +1188,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 12,
+               "id": 16,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -947,7 +1282,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 13,
+               "id": 17,
                "legend": {
                   "alignAsTable": "true",
                   "avg": false,
@@ -1036,7 +1371,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 14,
+               "id": 18,
                "legend": {
                   "alignAsTable": "true",
                   "avg": false,
@@ -1125,7 +1460,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 15,
+               "id": 19,
                "legend": {
                   "alignAsTable": "true",
                   "avg": false,
@@ -1227,7 +1562,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 16,
+               "id": 20,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1356,7 +1691,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 17,
+               "id": 21,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1464,7 +1799,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 18,
+               "id": 22,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1551,7 +1886,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 19,
+               "id": 23,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1631,7 +1966,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 20,
+               "id": 24,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1711,7 +2046,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 21,
+               "id": 25,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1791,7 +2126,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 22,
+               "id": 26,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1871,7 +2206,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 23,
+               "id": 27,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1951,7 +2286,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 24,
+               "id": 28,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2031,7 +2366,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 25,
+               "id": 29,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2128,8 +2463,8 @@
       "list": [
          {
             "current": {
-               "text": "",
-               "value": ""
+               "text": "prometheus",
+               "value": "prometheus"
             },
             "hide": 2,
             "label": null,
@@ -2151,7 +2486,7 @@
             "name": "instance",
             "options": [ ],
             "query": "label_values(pyroscope_build_info, instance)",
-            "refresh": 0,
+            "refresh": 2,
             "regex": "",
             "sort": 0,
             "tagValuesQuery": "",

--- a/monitoring/gen/benchmark-dashboard.json
+++ b/monitoring/gen/benchmark-dashboard.json
@@ -236,7 +236,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Upload Errors",
+               "title": "Upload Errors (Total)",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -317,7 +317,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Successfull Uploads",
+               "title": "Successful Uploads (Total)",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -1562,8 +1562,8 @@
          "type": "row"
       },
       {
-         "collapse": true,
-         "collapsed": true,
+         "collapse": false,
+         "collapsed": false,
          "panels": [
             {
                "aliasColors": { },

--- a/monitoring/gen/benchmark-dashboard.json
+++ b/monitoring/gen/benchmark-dashboard.json
@@ -17,84 +17,14 @@
          "collapsed": false,
          "panels": [
             {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "$PROMETHEUS_DS",
-               "fill": 1,
-               "fillGradient": 0,
+               "content": "<iframe style=\"border:none; width:100%; height: 100%;\" src=\"http://localhost:8081/summary\">",
+               "datasource": null,
                "gridPos": { },
                "id": 2,
-               "legend": {
-                  "alignAsTable": false,
-                  "avg": false,
-                  "current": false,
-                  "max": false,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "total": false,
-                  "values": false
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "pyroscope_benchmark{}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Benchmark",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 0,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "format": "short",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
+               "mode": "markdown",
+               "span": 2,
+               "title": "",
+               "type": "text"
             },
             {
                "aliasColors": { },
@@ -129,21 +59,22 @@
                "repeat": null,
                "seriesOverrides": [ ],
                "spaceLength": 10,
+               "span": 2,
                "stack": false,
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "pyroscope_run_progress{}",
+                     "expr": "pyroscope_benchmark{}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "",
+                     "legendFormat": "{{ __name__ }}",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Run Progress",
+               "title": "Benchmark",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -162,16 +93,16 @@
                      "format": "short",
                      "label": null,
                      "logBase": 1,
-                     "max": null,
-                     "min": null,
+                     "max": 1,
+                     "min": 0,
                      "show": true
                   },
                   {
                      "format": "short",
                      "label": null,
                      "logBase": 1,
-                     "max": null,
-                     "min": null,
+                     "max": 1,
+                     "min": 0,
                      "show": true
                   }
                ]
@@ -214,17 +145,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "pyroscope_upload_errors{}",
+                     "expr": "pyroscope_run_progress{}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "",
+                     "legendFormat": "{{ __name__ }}",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Upload Errors",
+               "title": "Run Progress",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -295,10 +226,10 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "pyroscope_successful_uploads{}",
+                     "expr": "pyroscope_upload_errors{}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "",
+                     "legendFormat": "{{ __name__ }}",
                      "refId": "A"
                   }
                ],
@@ -306,6 +237,87 @@
                "timeFrom": null,
                "timeShift": null,
                "title": "Upload Errors",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 6,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 2,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_successful_uploads{}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Successfull Uploads",
                "tooltip": {
                   "shared": true,
                   "sort": 0,
@@ -356,7 +368,7 @@
                "datasource": "$PROMETHEUS_DS",
                "gridPos": { },
                "height": 10,
-               "id": 6,
+               "id": 7,
                "links": [ ],
                "span": 12,
                "styles": [
@@ -428,7 +440,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 7,
+               "id": 8,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -508,7 +520,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 8,
+               "id": 9,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -588,7 +600,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 9,
+               "id": 10,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -668,7 +680,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 10,
+               "id": 11,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -748,7 +760,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 11,
+               "id": 12,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -841,7 +853,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 12,
+               "id": 13,
                "legend": {
                   "alignAsTable": "true",
                   "avg": false,
@@ -930,7 +942,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 13,
+               "id": 14,
                "legend": {
                   "alignAsTable": "true",
                   "avg": false,
@@ -1012,7 +1024,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 14,
+               "id": 15,
                "legend": {
                   "alignAsTable": "true",
                   "avg": false,
@@ -1101,7 +1113,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 15,
+               "id": 16,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1188,7 +1200,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 16,
+               "id": 17,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1282,7 +1294,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 17,
+               "id": 18,
                "legend": {
                   "alignAsTable": "true",
                   "avg": false,
@@ -1371,7 +1383,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 18,
+               "id": 19,
                "legend": {
                   "alignAsTable": "true",
                   "avg": false,
@@ -1460,7 +1472,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 19,
+               "id": 20,
                "legend": {
                   "alignAsTable": "true",
                   "avg": false,
@@ -1562,7 +1574,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 20,
+               "id": 21,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1691,7 +1703,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 21,
+               "id": 22,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1799,7 +1811,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 22,
+               "id": 23,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1886,7 +1898,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 23,
+               "id": 24,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -1966,7 +1978,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 24,
+               "id": 25,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2046,7 +2058,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 25,
+               "id": 26,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2126,7 +2138,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 26,
+               "id": 27,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2206,7 +2218,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 27,
+               "id": 28,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2286,7 +2298,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 28,
+               "id": 29,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,
@@ -2366,7 +2378,7 @@
                "fill": 1,
                "fillGradient": 0,
                "gridPos": { },
-               "id": 29,
+               "id": 30,
                "legend": {
                   "alignAsTable": false,
                   "avg": false,

--- a/monitoring/gen/dashboard.json
+++ b/monitoring/gen/dashboard.json
@@ -1,0 +1,2198 @@
+{
+   "__inputs": [ ],
+   "__requires": [ ],
+   "annotations": {
+      "list": [ ]
+   },
+   "editable": "true",
+   "gnetId": null,
+   "graphTooltip": 0,
+   "hideControls": false,
+   "id": null,
+   "links": [ ],
+   "refresh": "",
+   "rows": [
+      {
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
+            {
+               "columns": [ ],
+               "datasource": "$PROMETHEUS_DS",
+               "gridPos": { },
+               "height": 10,
+               "id": 2,
+               "links": [ ],
+               "span": 12,
+               "styles": [
+                  {
+                     "alias": "__name__",
+                     "pattern": "__name__",
+                     "type": "hidden"
+                  },
+                  {
+                     "alias": "Time",
+                     "pattern": "Time",
+                     "type": "hidden"
+                  },
+                  {
+                     "alias": "instance",
+                     "pattern": "instance",
+                     "type": "hidden"
+                  },
+                  {
+                     "alias": "Value",
+                     "pattern": "Value",
+                     "type": "hidden"
+                  },
+                  {
+                     "alias": "job",
+                     "pattern": "job",
+                     "type": "hidden"
+                  },
+                  {
+                     "alias": "use_embedded_assets",
+                     "pattern": "use_embedded_assets",
+                     "type": "hidden"
+                  }
+               ],
+               "targets": [
+                  {
+                     "expr": "pyroscope_build_info{instance=\"$instance\"}",
+                     "format": "table",
+                     "instant": true,
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "",
+               "type": "table"
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Meta",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 3,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.99,\n  sum(rate(pyroscope_http_request_duration_seconds_bucket{\n    instance=\"$instance\",\n    handler!=\"/metrics\",\n    handler!=\"/healthz\"\n  }[$__rate_interval]))\n  by (le, handler)\n)\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ handler }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Request Latency P99",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "seconds",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "seconds",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 4,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(pyroscope_http_request_duration_seconds_count\n{instance=\"$instance\", code=~\"5..\", handler!=\"/metrics\", handler!=\"/healthz\"}[$__rate_interval])) by (handler)\n/\nsum(rate(pyroscope_http_request_duration_seconds_count{instance=\"$instance\", handler!=\"/metrics\", handler!=\"/healthz\"}[$__rate_interval])) by (handler)\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ handler }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Error Rate",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 5,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(pyroscope_http_request_duration_seconds_count{instance=\"$instance\", handler!=\"/metrics\", handler!=\"/healthz\"}[$__rate_interval])) by (handler)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ handler }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Throughput",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 6,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.95, sum(rate(pyroscope_http_response_size_bytes_bucket{instance=\"$instance\", handler!=\"/metrics\", handler!=\"/healthz\"}[$__rate_interval])) by (le, handler))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ handler }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Response Size P99",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 7,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": false,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_cpu_utilization{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU Utilization",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percent",
+                     "label": null,
+                     "logBase": 1,
+                     "max": "100",
+                     "min": "0",
+                     "show": true
+                  },
+                  {
+                     "format": "percent",
+                     "label": null,
+                     "logBase": 1,
+                     "max": "100",
+                     "min": "0",
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "General",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 8,
+               "legend": {
+                  "alignAsTable": "true",
+                  "avg": false,
+                  "current": "true",
+                  "max": false,
+                  "min": false,
+                  "rightSide": "true",
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": "true"
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum without(name) (rate(pyroscope_storage_cache_hits_total[$__rate_interval]))\n/\nsum without(name) (rate(pyroscope_storage_cache_reads_total[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Hits",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "sum without(name) (rate(pyroscope_storage_cache_misses_total[$__rate_interval]))\n/\nsum without(name)(rate(pyroscope_storage_cache_reads_total[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Misses",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Cache Hit/Misses",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 9,
+               "legend": {
+                  "alignAsTable": "true",
+                  "avg": false,
+                  "current": "true",
+                  "max": false,
+                  "min": false,
+                  "rightSide": "true",
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": "true"
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(pyroscope_storage_cache_hits_total[$__rate_interval])\n/\nrate(pyroscope_storage_cache_reads_total[$__rate_interval])\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ name }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Cache Hit Ratio",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 10,
+               "legend": {
+                  "alignAsTable": "true",
+                  "avg": false,
+                  "current": "true",
+                  "max": false,
+                  "min": false,
+                  "rightSide": "true",
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": "true"
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum without(name) (rate(pyroscope_storage_cache_persisted_total[$__rate_interval]))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "(rate(pyroscope_storage_cache_persisted_total[$__rate_interval]))",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ name }}",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rate of items persisted from cache to disk",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 11,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(pyroscope_storage_reads_total[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Reads",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "rate(pyroscope_storage_writes_total[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Writes",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Storage Reads/Writes",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 12,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": "true"
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "histogram_quantile(0.9, pyroscope_storage_evictions_duration_seconds_bucket)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "evictions",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.9, pyroscope_storage_writeback_duration_seconds_bucket)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "write-back",
+                     "refId": "B"
+                  },
+                  {
+                     "expr": "histogram_quantile(0.9, pyroscope_storage_retention_duration_seconds_bucket)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "retention",
+                     "refId": "C"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Periodic tasks",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "seconds",
+                     "label": null,
+                     "logBase": 2,
+                     "max": "10",
+                     "min": "0.001",
+                     "show": true
+                  },
+                  {
+                     "format": "seconds",
+                     "label": null,
+                     "logBase": 1,
+                     "max": "10",
+                     "min": "0.001",
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 13,
+               "legend": {
+                  "alignAsTable": "true",
+                  "avg": false,
+                  "current": "true",
+                  "max": false,
+                  "min": false,
+                  "rightSide": "true",
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": "true"
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_storage_disk_bytes",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ name }}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "sum without(name)(pyroscope_disk_bytes)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "total",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Disk Usage",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 14,
+               "legend": {
+                  "alignAsTable": "true",
+                  "avg": false,
+                  "current": "true",
+                  "max": false,
+                  "min": false,
+                  "rightSide": "true",
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": "true"
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_storage_cache_size",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ name }}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "sum without(name)(pyroscope_storage_cache_size)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "total",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Cache Size (number of items)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 15,
+               "legend": {
+                  "alignAsTable": "true",
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": "true",
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": "true"
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_storage_evictions_alloc_bytes",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "heap size",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "pyroscope_storage_evictions_total_mem_bytes",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "total memory",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Cache Size (Approximation)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 2,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Storage",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 16,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "go_memstats_mspan_inuse_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "go_memstats_mspan_sys_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "B"
+                  },
+                  {
+                     "expr": "go_memstats_mcache_inuse_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "C"
+                  },
+                  {
+                     "expr": "go_memstats_mcache_sys_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "D"
+                  },
+                  {
+                     "expr": "go_memstats_buck_hash_sys_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "E"
+                  },
+                  {
+                     "expr": "go_memstats_gc_sys_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "F"
+                  },
+                  {
+                     "expr": "go_memstats_other_sys_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "G"
+                  },
+                  {
+                     "expr": "go_memstats_next_gc_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "H"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Memory Off-heap",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 17,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "go_memstats_heap_alloc_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "go_memstats_heap_sys_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "B"
+                  },
+                  {
+                     "expr": "go_memstats_heap_idle_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "C"
+                  },
+                  {
+                     "expr": "go_memstats_heap_inuse_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "D"
+                  },
+                  {
+                     "expr": "go_memstats_heap_released_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "E"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Memory In Heap",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 18,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "go_memstats_stack_inuse_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "go_memstats_stack_sys_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Memory In Stack",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "decbytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "decbytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 19,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "go_memstats_sys_bytes{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total Used Memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "decbytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "decbytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 20,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": false,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "go_memstats_mallocs_total{instance=\"$instance\"} - go_memstats_frees_total{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Number of Live Objects",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 21,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": false,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(go_memstats_mallocs_total{instance=\"$instance\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rate of Objects Allocated",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 22,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": false,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(go_memstats_alloc_bytes_total{instance=\"$instance\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Rates of Allocation",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "Bps",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "Bps",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 23,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": false,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "go_goroutines{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Goroutines",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 24,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": false,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "go_gc_duration_seconds{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "GC duration quantile",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 25,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "process_open_fds{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "process_max_fds{instance=\"$instance\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{ __name__ }}",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "File descriptors",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Go",
+         "titleSize": "h6",
+         "type": "row"
+      }
+   ],
+   "schemaVersion": 14,
+   "style": "dark",
+   "tags": [
+      "pyroscope"
+   ],
+   "templating": {
+      "list": [
+         {
+            "current": {
+               "text": "prometheus",
+               "value": "prometheus"
+            },
+            "hide": 2,
+            "label": null,
+            "name": "PROMETHEUS_DS",
+            "options": [ ],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "type": "datasource"
+         },
+         {
+            "allValue": null,
+            "current": { },
+            "datasource": "$PROMETHEUS_DS",
+            "hide": 0,
+            "includeAll": false,
+            "label": "instance",
+            "multi": false,
+            "name": "instance",
+            "options": [ ],
+            "query": "label_values(pyroscope_build_info, instance)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
+   },
+   "time": {
+      "from": "now-1h",
+      "to": "now"
+   },
+   "timepicker": {
+      "refresh_intervals": [
+         "5s",
+         "10s",
+         "30s",
+         "1m",
+         "5m",
+         "15m",
+         "30m",
+         "1h",
+         "2h",
+         "1d"
+      ],
+      "time_options": [
+         "5m",
+         "15m",
+         "1h",
+         "6h",
+         "12h",
+         "24h",
+         "2d",
+         "7d",
+         "30d"
+      ]
+   },
+   "timezone": "browser",
+   "title": "Pyroscope Server",
+   "uid": "tsWRL6ReZQkirFirmyvnWX1akHXJeHT8I8emjGJo",
+   "version": 0
+}

--- a/monitoring/lib/dashboard.libsonnet
+++ b/monitoring/lib/dashboard.libsonnet
@@ -20,11 +20,18 @@ local grafana = import 'grafonnet/grafana.libsonnet';
         title='Benchmark',
       )
       .addPanel(
+        grafana.text.new(
+          content= "<iframe style=\"border:none; width:100%; height: 100%;\" src=\"http://localhost:8081/summary\">",
+          span=2,
+        )
+      )
+      .addPanel(
         grafana.graphPanel.new(
           'Benchmark',
           datasource='$PROMETHEUS_DS',
           min=0,
           max=1,
+          span=2,
         )
         .addTarget(
           grafana.prometheus.target(
@@ -37,6 +44,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
         grafana.graphPanel.new(
           'Run Progress',
           datasource='$PROMETHEUS_DS',
+          span=2,
         )
         .addTarget(
           grafana.prometheus.target(
@@ -47,7 +55,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
       )
       .addPanel(
         grafana.graphPanel.new(
-          'Upload Errors',
+          'Upload Errors (Total)',
           datasource='$PROMETHEUS_DS',
           span=2,
         )
@@ -60,7 +68,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
       )
       .addPanel(
         grafana.graphPanel.new(
-          'Upload Errors',
+          'Successful Uploads (Total)',
           datasource='$PROMETHEUS_DS',
           span=2,
         )
@@ -425,7 +433,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
     .addRow(
       grafana.row.new(
         title='Go',
-        collapse=true,
+        collapse=if $._config.benchmark then false else true,
       )
       .addPanel(
         grafana.graphPanel.new(

--- a/monitoring/lib/dashboard.libsonnet
+++ b/monitoring/lib/dashboard.libsonnet
@@ -1,0 +1,601 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+
+
+{
+  dashboard:
+    local d = grafana.dashboard.new(
+      'Pyroscope Server',
+      tags=['pyroscope'],
+      time_from='now-1h',
+      uid='tsWRL6ReZQkirFirmyvnWX1akHXJeHT8I8emjGJo',
+      editable='true',
+      refresh = if $._config.benchmark then '5s' else '',
+    );
+
+    // conditionally add a benchmark rowat the top if appropriate
+    local dashboard = if $._config.benchmark then
+      d
+      .addRow(
+      grafana.row.new(
+        title='Benchmark',
+      )
+      .addPanel(
+        grafana.graphPanel.new(
+          'Benchmark',
+          datasource='$PROMETHEUS_DS',
+          min=0,
+          max=1,
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'pyroscope_benchmark{}',
+            legendFormat='{{ __name__ }}',
+          )
+        )
+      )
+      .addPanel(
+        grafana.graphPanel.new(
+          'Run Progress',
+          datasource='$PROMETHEUS_DS',
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'pyroscope_run_progress{}',
+            legendFormat='{{ __name__ }}',
+          )
+        )
+      )
+      .addPanel(
+        grafana.graphPanel.new(
+          'Upload Errors',
+          datasource='$PROMETHEUS_DS',
+          span=2,
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'pyroscope_upload_errors{}',
+            legendFormat='{{ __name__ }}',
+          )
+        )
+      )
+      .addPanel(
+        grafana.graphPanel.new(
+          'Upload Errors',
+          datasource='$PROMETHEUS_DS',
+          span=2,
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'pyroscope_successful_uploads{}',
+            legendFormat='{{ __name__ }}',
+          )
+        )
+      )
+    )
+    else d;
+
+    dashboard
+    .addTemplate(
+      grafana.template.datasource(
+        name='PROMETHEUS_DS',
+        query='prometheus',
+        current='prometheus',
+        hide='hidden',  // anything other than '' and 'label works
+      )
+    )
+    .addTemplate(
+      grafana.template.new(
+        'instance',
+        '$PROMETHEUS_DS',
+        'label_values(pyroscope_build_info, instance)',
+        // otherwise the variable may be unpopulated
+        // eg. when prometheus/grafana/pyroscope are started at the same time
+        refresh='time', 
+        label='instance',
+      )
+    )
+
+    .addRow(
+      grafana.row.new(
+        title='Meta',
+      )
+      .addPanel(
+        grafana.tablePanel.new(
+          title='',
+          datasource='$PROMETHEUS_DS',
+          span=12,
+          height=10,
+        )
+        // they don't provide any value
+        .hideColumn("__name__")
+        .hideColumn("Time")
+        .hideColumn("instance")
+        .hideColumn("Value")
+        .hideColumn("job")
+
+        // somewhat useful but preferred to be hidden
+        // to make the table cleaner
+        .hideColumn("use_embedded_assets")
+        .addTarget(
+          grafana.prometheus.target(
+            'pyroscope_build_info{%s}' % $._config.selector,
+            instant=true,
+            format='table',
+          )
+        )
+      )
+    )
+
+
+    // Only useful when running benchmark
+
+
+    .addRow(
+      grafana.row.new(
+        title='General',
+      )
+      .addPanel(
+        grafana.graphPanel.new(
+          'Request Latency P99',
+          datasource='$PROMETHEUS_DS',
+          format='seconds',
+        )
+        .addTarget(grafana.prometheus.target(|||
+            histogram_quantile(0.99,
+              sum(rate(pyroscope_http_request_duration_seconds_bucket{
+                instance="$instance",
+                handler!="/metrics",
+                handler!="/healthz"
+              }[$__rate_interval]))
+              by (le, handler)
+            )
+          |||,
+          legendFormat='{{ handler }}',
+        ))
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Error Rate',
+          datasource='$PROMETHEUS_DS',
+        )
+        .addTarget(grafana.prometheus.target(|||
+          sum(rate(pyroscope_http_request_duration_seconds_count
+          {instance="$instance", code=~"5..", handler!="/metrics", handler!="/healthz"}[$__rate_interval])) by (handler)
+          /
+          sum(rate(pyroscope_http_request_duration_seconds_count{instance="$instance", handler!="/metrics", handler!="/healthz"}[$__rate_interval])) by (handler)
+        |||,
+          legendFormat='{{ handler }}',
+        ))
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Throughput',
+          datasource='$PROMETHEUS_DS',
+        )
+        .addTarget(grafana.prometheus.target('sum(rate(pyroscope_http_request_duration_seconds_count{instance="$instance", handler!="/metrics", handler!="/healthz"}[$__rate_interval])) by (handler)',
+          legendFormat='{{ handler }}',
+        ))
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Response Size P99',
+          datasource='$PROMETHEUS_DS',
+          format='bytes',
+        )
+        .addTarget(grafana.prometheus.target('histogram_quantile(0.95, sum(rate(pyroscope_http_response_size_bytes_bucket{instance="$instance", handler!="/metrics", handler!="/healthz"}[$__rate_interval])) by (le, handler))',
+          legendFormat='{{ handler }}',
+        ))
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'CPU Utilization',
+          datasource='$PROMETHEUS_DS',
+          format='percent',
+          min='0',
+          max='100',
+          legend_show=false,
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'pyroscope_cpu_utilization{instance="$instance"}',
+          )
+        )
+      )
+
+    )
+
+
+    .addRow(
+      grafana.row.new(
+        title='Storage',
+      )
+      .addPanel(
+        grafana.graphPanel.new(
+          'Cache Hit/Misses',
+          datasource='$PROMETHEUS_DS',
+          legend_values='true',
+          legend_rightSide='true',
+          legend_alignAsTable='true',
+          legend_current='true',
+          legend_sort='current',
+          legend_sortDesc=true,
+          format='percentunit',
+        )
+        .addTarget(
+          grafana.prometheus.target(|||
+            sum without(name) (rate(pyroscope_storage_cache_hits_total[$__rate_interval]))
+            /
+            sum without(name) (rate(pyroscope_storage_cache_reads_total[$__rate_interval]))
+          |||,
+            legendFormat='Hits',
+          )
+        )
+        .addTarget(
+          grafana.prometheus.target(|||
+            sum without(name) (rate(pyroscope_storage_cache_misses_total[$__rate_interval]))
+            /
+            sum without(name)(rate(pyroscope_storage_cache_reads_total[$__rate_interval]))
+          |||,
+            legendFormat='Misses',
+          )
+        )
+      )
+      .addPanel(
+        grafana.graphPanel.new(
+          'Cache Hit Ratio',
+          datasource='$PROMETHEUS_DS',
+          legend_values='true',
+          legend_rightSide='true',
+          legend_alignAsTable='true',
+          legend_current='true',
+          legend_sort='current',
+          legend_sortDesc=true,
+          format='percentunit',
+        )
+        .addTarget(
+          grafana.prometheus.target(|||
+            rate(pyroscope_storage_cache_hits_total[$__rate_interval])
+            /
+            rate(pyroscope_storage_cache_reads_total[$__rate_interval])
+          |||,
+            legendFormat='{{ name }}',
+          )
+        )
+      )
+      .addPanel(
+        grafana.graphPanel.new(
+          'Rate of items persisted from cache to disk',
+          datasource='$PROMETHEUS_DS',
+          legend_values='true',
+          legend_rightSide='true',
+          legend_alignAsTable='true',
+          legend_current='true',
+          legend_sort='current',
+          legend_sortDesc=true,
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            // ignore the name
+            'sum without(name) (rate(pyroscope_storage_cache_persisted_total[$__rate_interval]))',
+            legendFormat="Total",
+          )
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            '(rate(pyroscope_storage_cache_persisted_total[$__rate_interval]))',
+            legendFormat="{{ name }}",
+          )
+        )
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Storage Reads/Writes',
+          datasource='$PROMETHEUS_DS',
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'rate(pyroscope_storage_reads_total[$__rate_interval])',
+            legendFormat="Reads",
+          )
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'rate(pyroscope_storage_writes_total[$__rate_interval])',
+            legendFormat="Writes",
+          )
+        )
+      )
+      .addPanel(
+        grafana.graphPanel.new(
+          'Periodic tasks',
+          datasource='$PROMETHEUS_DS',
+          legend_values='true',
+          format='seconds',
+          min='0.001', // as as the bucket minimum
+          max='10', // same as the maximum bucket
+          logBase1Y=2,
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'histogram_quantile(0.9, pyroscope_storage_evictions_duration_seconds_bucket)',
+            legendFormat='evictions',
+          ),
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'histogram_quantile(0.9, pyroscope_storage_writeback_duration_seconds_bucket)',
+            legendFormat='write-back',
+          ),
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'histogram_quantile(0.9, pyroscope_storage_retention_duration_seconds_bucket)',
+            legendFormat='retention',
+          ),
+        )
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Disk Usage',
+          datasource='$PROMETHEUS_DS',
+          format='bytes',
+          legend_values='true',
+          legend_rightSide='true',
+          legend_alignAsTable='true',
+          legend_current='true',
+          legend_sort='current',
+          legend_sortDesc=true,
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'pyroscope_storage_disk_bytes',
+            legendFormat='{{ name }}',
+          ),
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'sum without(name)(pyroscope_disk_bytes)',
+            legendFormat='total',
+          ),
+        )
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Cache Size (number of items)',
+          datasource='$PROMETHEUS_DS',
+          legend_values='true',
+          legend_rightSide='true',
+          legend_alignAsTable='true',
+          legend_current='true',
+          legend_sort='current',
+          legend_sortDesc=true,
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'pyroscope_storage_cache_size',
+            legendFormat='{{ name }}',
+          ),
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'sum without(name)(pyroscope_storage_cache_size)',
+            legendFormat='total',
+          ),
+        )
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Cache Size (Approximation)',
+          datasource='$PROMETHEUS_DS',
+          format='bytes',
+          legend_values='true',
+          legend_rightSide='true',
+          legend_alignAsTable='true',
+          legend_current=true,
+          legend_max=true,
+          legend_sort='current',
+          legend_sortDesc=true,
+          logBase1Y=2,
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'pyroscope_storage_evictions_alloc_bytes',
+            legendFormat='heap size',
+          ),
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'pyroscope_storage_evictions_total_mem_bytes',
+            legendFormat='total memory',
+          ),
+        )
+      )
+    )
+
+    // inspired by
+    // https://github.com/aukhatov/grafana-dashboards/blob/master/Go%20Metrics-1567509764849.json
+    .addRow(
+      grafana.row.new(
+        title='Go',
+        collapse=true,
+      )
+      .addPanel(
+        grafana.graphPanel.new(
+          'Memory Off-heap',
+          datasource='$PROMETHEUS_DS',
+          format='bytes',
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'go_memstats_mspan_inuse_bytes{instance="$instance"}',
+            legendFormat='{{ __name__ }}',
+          )
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'go_memstats_mspan_sys_bytes{instance="$instance"}',
+            legendFormat='{{ __name__ }}',
+          )
+        )
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_mcache_inuse_bytes{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_mcache_sys_bytes{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_buck_hash_sys_bytes{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_gc_sys_bytes{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_other_sys_bytes{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_next_gc_bytes{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Memory In Heap',
+          datasource='$PROMETHEUS_DS',
+          format='bytes',
+        )
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_heap_alloc_bytes{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_heap_sys_bytes{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_heap_idle_bytes{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_heap_inuse_bytes{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_heap_released_bytes{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+      )
+
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Memory In Stack',
+          datasource='$PROMETHEUS_DS',
+          format='decbytes',
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'go_memstats_stack_inuse_bytes{instance="$instance"}',
+            legendFormat='{{ __name__ }}',
+          )
+        )
+        .addTarget(
+          grafana.prometheus.target(
+            'go_memstats_stack_sys_bytes{instance="$instance"}',
+            legendFormat='{{ __name__ }}',
+          )
+        )
+      )
+
+
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Total Used Memory',
+          datasource='$PROMETHEUS_DS',
+          format='decbytes',
+        )
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_sys_bytes{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+      )
+
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Number of Live Objects',
+          datasource='$PROMETHEUS_DS',
+          legend_show=false,
+        )
+        .addTarget(grafana.prometheus.target(
+          'go_memstats_mallocs_total{instance="$instance"} - go_memstats_frees_total{instance="$instance"}'
+        ))
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Rate of Objects Allocated',
+          datasource='$PROMETHEUS_DS',
+          legend_show=false,
+        )
+        .addTarget(grafana.prometheus.target('rate(go_memstats_mallocs_total{instance="$instance"}[$__rate_interval])'))
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Rates of Allocation',
+          datasource='$PROMETHEUS_DS',
+          format="Bps",
+          legend_show=false,
+        )
+        .addTarget(grafana.prometheus.target('rate(go_memstats_alloc_bytes_total{instance="$instance"}[$__rate_interval])'))
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'Goroutines',
+          datasource='$PROMETHEUS_DS',
+          legend_show=false,
+        )
+        .addTarget(grafana.prometheus.target('go_goroutines{instance="$instance"}'))
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'GC duration quantile',
+          datasource='$PROMETHEUS_DS',
+          legend_show=false,
+        )
+        .addTarget(grafana.prometheus.target('go_gc_duration_seconds{instance="$instance"}'))
+      )
+
+      .addPanel(
+        grafana.graphPanel.new(
+          'File descriptors',
+          datasource='$PROMETHEUS_DS',
+        )
+        .addTarget(grafana.prometheus.target(
+          'process_open_fds{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+        .addTarget(grafana.prometheus.target(
+          'process_max_fds{instance="$instance"}',
+          legendFormat='{{ __name__ }}',
+        ))
+      )
+    )
+}


### PR DESCRIPTION
Creates a benchmark dashboard based on the user facing one.
The only difference so far is an additional row at the top with benchmark metrics:
![Screenshot from 2021-08-24 18-43-08](https://user-images.githubusercontent.com/6951209/130695687-8c2c4bbe-1767-4cdd-9cc9-2f82c147effc.png)

Plus updates `examples/grafana-integration`, although it's not currently functional, since it refers to the `pyroscope:latest` docker image, which doesn't contain the new metric names yet.