### PR TITLE
reduces bundle size

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  transformIgnorePatterns: []
+};

--- a/webapp/javascript/components/CustomDatePicker.jsx
+++ b/webapp/javascript/components/CustomDatePicker.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import moment from "moment";
+// we import moment/src/moment instead of moment because we don't want to load locales
+import moment from "moment/src/moment";
 import { useSelector } from "react-redux";
 import DatePicker from "react-datepicker";
 import { readableRange, formatAsOBject } from "../util/formatDate";

--- a/webapp/javascript/components/DateRangePicker.jsx
+++ b/webapp/javascript/components/DateRangePicker.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faClock } from "@fortawesome/free-solid-svg-icons";
+import { faClock } from "@fortawesome/free-solid-svg-icons/faClock";
 import OutsideClickHandler from "react-outside-click-handler";
 import CustomDatePicker from "./CustomDatePicker";
 import { setDateRange } from "../redux/actions";

--- a/webapp/javascript/components/DownloadButton.jsx
+++ b/webapp/javascript/components/DownloadButton.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faDownload } from "@fortawesome/free-solid-svg-icons";
+import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload";
 
 function RefreshButton(props) {
   const { renderURL } = props;

--- a/webapp/javascript/components/Footer.jsx
+++ b/webapp/javascript/components/Footer.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faDownload } from "@fortawesome/free-solid-svg-icons";
+import { faDownload } from "@fortawesome/free-solid-svg-icons/faDownload";
 import { version } from "../../../package.json";
 
 const START_YEAR = 2020;

--- a/webapp/javascript/components/Notifications.jsx
+++ b/webapp/javascript/components/Notifications.jsx
@@ -7,7 +7,7 @@ import Modal from "react-modal";
 import clsx from "clsx";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons/faExclamationTriangle";
 
 function Notifications(props) {
   const { notificationText } = window;

--- a/webapp/javascript/components/ProfilerHeader.jsx
+++ b/webapp/javascript/components/ProfilerHeader.jsx
@@ -1,14 +1,12 @@
 import React from "react";
 import clsx from "clsx";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faAlignLeft,
-  faBars,
-  faColumns,
-  faIcicles,
-  faListUl,
-  faTable,
-} from "@fortawesome/free-solid-svg-icons";
+import { faAlignLeft } from "@fortawesome/free-solid-svg-icons/faAlignLeft";
+import { faBars } from "@fortawesome/free-solid-svg-icons/faBars";
+import { faColumns } from "@fortawesome/free-solid-svg-icons/faColumns";
+import { faIcicles } from "@fortawesome/free-solid-svg-icons/faIcicles";
+import { faListUl } from "@fortawesome/free-solid-svg-icons/faListUl";
+import { faTable } from "@fortawesome/free-solid-svg-icons/faTable";
 import { FitModes } from "../util/fitMode"
 
 export default function ProfilerHeader({

--- a/webapp/javascript/components/RefreshButton.jsx
+++ b/webapp/javascript/components/RefreshButton.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useDispatch } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSyncAlt } from "@fortawesome/free-solid-svg-icons";
+import { faSyncAlt } from "@fortawesome/free-solid-svg-icons/faSyncAlt";
 import { refresh } from "../redux/actions";
 
 function RefreshButton() {

--- a/webapp/javascript/components/Sidebar.jsx
+++ b/webapp/javascript/components/Sidebar.jsx
@@ -7,16 +7,14 @@ import Modal from "react-modal";
 import clsx from "clsx";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faFileAlt,
-  faKeyboard,
-  faColumns,
-  faBell,
-  faSignOutAlt,
-  faChartBar,
-} from "@fortawesome/free-solid-svg-icons";
+import { faFileAlt } from "@fortawesome/free-solid-svg-icons/faFileAlt";
+import { faKeyboard } from "@fortawesome/free-solid-svg-icons/faKeyboard";
+import { faColumns } from "@fortawesome/free-solid-svg-icons/faColumns";
+import { faBell } from "@fortawesome/free-solid-svg-icons/faBell";
+import { faSignOutAlt } from "@fortawesome/free-solid-svg-icons/faSignOutAlt";
+import { faChartBar } from "@fortawesome/free-solid-svg-icons/faChartBar";
 import { faWindowMaximize } from "@fortawesome/free-regular-svg-icons";
-import { faGithub } from "@fortawesome/free-brands-svg-icons";
+import { faGithub } from "@fortawesome/free-brands-svg-icons/faGithub";
 import ShortcutsModal from "./ShortcutsModal";
 import SlackIcon from "./SlackIcon";
 

--- a/webapp/javascript/components/ZoomOutButton.jsx
+++ b/webapp/javascript/components/ZoomOutButton.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faSearchMinus } from "@fortawesome/free-solid-svg-icons";
+import { faSearchMinus } from "@fortawesome/free-solid-svg-icons/faSearchMinus";
 import { setDateRange } from "../redux/actions";
 
 function ZoomOutButton(props) {

--- a/webapp/javascript/redux/store.js
+++ b/webapp/javascript/redux/store.js
@@ -1,5 +1,4 @@
 import thunkMiddleware from "redux-thunk";
-import promiseMiddleware from "redux-promise";
 
 import { createStore, applyMiddleware } from "redux";
 import { composeWithDevTools } from "redux-devtools-extension";
@@ -23,7 +22,7 @@ import {
 import { parseLabels, encodeLabels } from "../util/key";
 
 const enhancer = composeWithDevTools(
-  applyMiddleware(thunkMiddleware, promiseMiddleware)
+  applyMiddleware(thunkMiddleware)
   // updateUrl(["from", "until", "labels"]),
   // persistState(["from", "until", "labels"]),
 );

--- a/webapp/javascript/util/formatDate.js
+++ b/webapp/javascript/util/formatDate.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
-import moment from "moment";
+// we import moment/src/moment instead of moment because we don't want to load locales
+import moment from "moment/src/moment";
 
 const multiplierMapping = {
   s: "second",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2850,15 +2850,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.0.0.tgz#5259f7c30e35e278f1bdc2a4d91230b37cad981e"
   integrity sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==
 
-caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001097:
-  version "1.0.30001107"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001107.tgz#809360df7a5b3458f627aa46b0f6ed6d5239da9a"
-  integrity sha512-86rCH+G8onCmdN4VZzJet5uPELII59cUzDphko3thQFgAQG1RNa+sVLDoALIhRYmflo5iSIzWY3vu1XTWtNMQQ==
-
-caniuse-lite@^1.0.30001251:
-  version "1.0.30001251"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
-  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
+caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001097, caniuse-lite@^1.0.30001251:
+  version "1.0.30001252"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz"
+  integrity sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==
 
 canvg@^3.0.6:
   version "3.0.7"


### PR DESCRIPTION
Before: 546.1 KB
After: 471.44 KB

^ these are gzipped production numbers from webpack bundle analyzer

This is what it currently looks like:
![Screen Shot 2021-08-31 at 1 27 26 AM](https://user-images.githubusercontent.com/662636/131469240-e0d22757-ea12-4b17-9822-a0d2aa706648.png)
