### PR TITLE
Bump go version to 1.17.0

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.3'
+          go-version: '^1.17.0'
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:

--- a/.github/workflows/tests-go.yml
+++ b/.github/workflows/tests-go.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.3'
+          go-version: '^1.17.0'
       - name: Cache go mod directories
         uses: actions/cache@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,10 +102,6 @@ COPY webapp/assets.go ./webapp/assets.go
 COPY scripts ./scripts
 
 RUN EMBEDDED_ASSETS_DEPS="" EXTRA_LDFLAGS="-linkmode external -extldflags '-static'" make build-release
-RUN make build-rbspy-static-library
-RUN make build-pyspy-static-library
-RUN make build-phpspy-static-library
-
 
 #      _        _   _        _ _ _
 #     | |      | | (_)      | (_) |
@@ -115,15 +111,21 @@ RUN make build-phpspy-static-library
 # |___/\__\__,_|\__|_|\___| |_|_|_.__/|___/
 
 
+FROM go-builder AS go-libs-builder
+
+RUN make build-rbspy-static-library
+RUN make build-pyspy-static-library
+RUN make build-phpspy-static-library
+
 FROM scratch AS lib-exporter
 
-COPY --from=go-builder /opt/pyroscope/out/libpyroscope.phpspy.a /
-COPY --from=go-builder /opt/pyroscope/third_party/phpspy/libphpspy.a /
-COPY --from=go-builder /opt/pyroscope/out/libpyroscope.phpspy.h /
-COPY --from=go-builder /opt/pyroscope/out/libpyroscope.pyspy.a /
-COPY --from=go-builder /opt/pyroscope/out/libpyroscope.pyspy.h /
-COPY --from=go-builder /opt/pyroscope/out/libpyroscope.rbspy.a /
-COPY --from=go-builder /opt/pyroscope/out/libpyroscope.rbspy.h /
+COPY --from=go-libs-builder /opt/pyroscope/out/libpyroscope.phpspy.a /
+COPY --from=go-libs-builder /opt/pyroscope/third_party/phpspy/libphpspy.a /
+COPY --from=go-libs-builder /opt/pyroscope/out/libpyroscope.phpspy.h /
+COPY --from=go-libs-builder /opt/pyroscope/out/libpyroscope.pyspy.a /
+COPY --from=go-libs-builder /opt/pyroscope/out/libpyroscope.pyspy.h /
+COPY --from=go-libs-builder /opt/pyroscope/out/libpyroscope.rbspy.a /
+COPY --from=go-libs-builder /opt/pyroscope/out/libpyroscope.rbspy.h /
 COPY --from=rust-builder /opt/rustdeps/librustdeps.a /
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,9 @@ RUN apk update &&\
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN /root/.cargo/bin/rustup target add $(uname -m)-unknown-linux-musl
 
-RUN wget https://github.com/libunwind/libunwind/releases/download/v1.3.1/libunwind-1.3.1.tar.gz && \
-    tar -zxf libunwind-1.3.1.tar.gz && \
-    cd libunwind-1.3.1/ && \
+RUN wget https://github.com/libunwind/libunwind/releases/download/v1.5/libunwind-1.5.0.tar.gz && \
+    tar -zxf libunwind-1.5.0.tar.gz && \
+    cd libunwind-1.5.0/ && \
     ./configure --with-pic --disable-minidebuginfo --enable-ptrace --disable-tests --disable-documentation && make && make install
 
 COPY third_party/rustdeps /opt/rustdeps

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # | |  | |_| \__ \ |_
 # |_|   \__,_|___/\__|
 
-FROM alpine:3.12 as rust-builder
+FROM alpine:3.13 as rust-builder
 
 RUN apk update &&\
     apk add --no-cache git gcc g++ make build-base openssl-dev musl musl-dev curl
@@ -47,7 +47,7 @@ RUN make build-phpspy-dependencies
 # | (_| \__ \__ \  __/ |_\__ \
 #  \__,_|___/___/\___|\__|___/
 
-FROM node:14.15.1-alpine3.12 as js-builder
+FROM node:14.15.5-alpine3.13 as js-builder
 
 RUN apk add --no-cache make
 
@@ -70,7 +70,7 @@ RUN EXTRA_METADATA=$EXTRA_METADATA make assets-release
 #   __/ |                     __/ |
 #  |___/                     |___/
 
-FROM golang:1.16.3-alpine3.12 as go-builder
+FROM golang:1.17.0-alpine3.13 as go-builder
 
 RUN apk add --no-cache make git zstd gcc g++ libc-dev musl-dev bash
 RUN apk upgrade binutils
@@ -132,7 +132,7 @@ COPY --from=go-builder /opt/pyroscope/third_party/rustdeps/target/release/librus
 #                                           __/ |
 #                                          |___/
 
-FROM alpine:3.12
+FROM alpine:3.13
 
 LABEL maintainer="Pyroscope team <hello@pyroscope.io>"
 

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,4 +1,4 @@
-FROM golang:1.16.4-alpine3.12 as go-builder
+FROM golang:1.17.0-alpine3.13 as go-builder
 
 RUN apk add --no-cache make git zstd gcc g++ libc-dev musl-dev bash mingw-w64-gcc
 

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,6 @@ endif
 
 .PHONY: build
 build: ## Builds the binary
-	go mod tidy
 	$(GOBUILD) -tags "$(GO_TAGS)" -ldflags "$(EXTRA_LDFLAGS) $(shell scripts/generate-build-flags.sh)" -o ./bin/pyroscope ./cmd/pyroscope
 
 .PHONY: build-release

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ endif
 
 .PHONY: build
 build: ## Builds the binary
+	go mod tidy
 	$(GOBUILD) -tags "$(GO_TAGS)" -ldflags "$(EXTRA_LDFLAGS) $(shell scripts/generate-build-flags.sh)" -o ./bin/pyroscope ./cmd/pyroscope
 
 .PHONY: build-release

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,10 @@
 module github.com/pyroscope-io/pyroscope
 
-go 1.17
+// we do use go1.17 for building pyroscope binaries
+// but we don't use any go1.17 specific features
+// so for maximum compatibility we only require go1.16 for this module
+// I think it would make sense to upgrade to 1.17 when it's more mainstream
+go 1.16
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pyroscope-io/pyroscope
 
-go 1.16
+go 1.17
 
 require (
 	github.com/StackExchange/wmi v0.0.0-20210224194228-fe8f1750fd46 // indirect
@@ -31,7 +31,6 @@ require (
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/kyoh86/richgo v0.3.3
 	github.com/kyoh86/xdg v1.2.0 // indirect
-	github.com/markbates/pkger v0.17.1
 	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/mattn/goreman v0.3.5
 	github.com/mgechev/revive v1.0.3
@@ -40,7 +39,6 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.16.2
 	github.com/onsi/gomega v1.12.0
-	github.com/peterbourgon/ff/v3 v3.0.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.29.0
 	github.com/pyroscope-io/dotnetdiag v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -117,9 +117,9 @@ github.com/deadcheat/gonch v0.0.0-20180528124129-c2ff7a019863/go.mod h1:/5mH3gAu
 github.com/dgraph-io/badger/v2 v2.2007.2 h1:EjjK0KqwaFMlPin1ajhP943VPENHJdEz1KLIegjaI3k=
 github.com/dgraph-io/badger/v2 v2.2007.2/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
@@ -165,8 +165,6 @@ github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GO
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
-github.com/gobuffalo/here v0.6.0 h1:hYrd0a6gDmWxBM4TnrGw8mQg24iSVoIkHEk7FodQcBI=
-github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
@@ -327,8 +325,6 @@ github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgx
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
-github.com/markbates/pkger v0.17.1 h1:/MKEtWqtc0mZvu9OinB9UzVN9iYCwLWuyUv4Bw+PCno=
-github.com/markbates/pkger v0.17.1/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQDXbLhiuI=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -395,8 +391,6 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.6.0/go.mod h1:5N711Q9dKgbdkxHL+MEfF31hpT7l0S0s/t2kKREewys=
 github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5dSQ=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/peterbourgon/ff/v3 v3.0.0 h1:eQzEmNahuOjQXfuegsKQTSTDbf4dNvr/eNLrmJhiH7M=
-github.com/peterbourgon/ff/v3 v3.0.0/go.mod h1:UILIFjRH5a/ar8TjXYLTkIvSvekZqPm5Eb/qbGk6CT0=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -916,7 +910,6 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=


### PR DESCRIPTION
**Not ready for merge:**
1. There is no official Golang 1.17 image for alpine-3.12;
2. There is a problem with building libunwind-1.3.1 on alpine > 3.12;
3. Updating libunwind to the latest version (1.5.0) breaks rustdeps build.