### PR TITLE
fix race conditions that were crashing cypress tests

### DIFF
--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/index.jsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/index.jsx
@@ -546,7 +546,10 @@ class FlameGraph extends React.Component {
   render = () => {
     const { ExportData } = this.props;
     const dataUnavailable =
-      !this.props.flamebearer || this.props.flamebearer.names.length <= 1;
+      !this.props.flamebearer ||
+      (this.props.flamebearer &&
+       this.props.flamebearer.names.length <= 1);
+
     return (
       <>
         <div

--- a/webapp/javascript/components/FlameGraph/FlameGraphRenderer.jsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphRenderer.jsx
@@ -233,7 +233,11 @@ class FlameGraphRenderer extends React.Component {
       </div>
     );
     const dataExists =
-      this.state.view !== "table" || this.state.flamebearer.names.length <= 1;
+      this.state.view !== "table" || (
+        this.state.flamebearer &&
+        this.state.flamebearer.names.length <= 1
+      );
+
     const flameGraphPane =
       this.state.flamebearer && dataExists ? (
         <Graph


### PR DESCRIPTION
cypress tests were flaky due to a race condition (eg
https://github.com/pyroscope-io/pyroscope/actions/runs/1219594752)

just added checks to not access an unitialized variable