### PR TITLE
support taking screenshot of dashboard with rows

### DIFF
--- a/benchmark/.gitattributes
+++ b/benchmark/.gitattributes
@@ -1,0 +1,1 @@
+monitoring/gen/* linguist-generated

--- a/benchmark/internal/cireport/screenshotter_test.go
+++ b/benchmark/internal/cireport/screenshotter_test.go
@@ -13,7 +13,7 @@ import (
 
 var _ = Describe("screenshotter", func() {
 
-	FContext("AllPanels", func() {
+	Context("AllPanels", func() {
 		var ts *httptest.Server
 		var s cireport.GrafanaScreenshotter
 		var ctx context.Context

--- a/benchmark/internal/cireport/screenshotter_test.go
+++ b/benchmark/internal/cireport/screenshotter_test.go
@@ -1,0 +1,125 @@
+package cireport_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pyroscope-io/pyroscope/benchmark/internal/cireport"
+)
+
+var _ = Describe("screenshotter", func() {
+
+	FContext("AllPanels", func() {
+		var ts *httptest.Server
+		var s cireport.GrafanaScreenshotter
+		var ctx context.Context
+
+		BeforeEach(func() {
+			ts = createFakeGrafanaServer()
+			ctx = context.Background()
+			s = cireport.GrafanaScreenshotter{
+				GrafanaURL:     ts.URL,
+				TimeoutSeconds: 10,
+			}
+		})
+
+		AfterEach(func() {
+			ts.Close()
+		})
+
+		It("should handle dashboards with no rows", func() {
+			panels, err := s.AllPanels(ctx, "dashboard-without-rows", 0, 0)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(panels).To(HaveLen(2))
+		})
+
+		It("should handle dashboards with rows", func() {
+			panels, err := s.AllPanels(ctx, "dashboard-with-rows", 0, 0)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(panels).To(HaveLen(3))
+		})
+
+		It("should handle dashboards panels nested into rows", func() {
+			panels, err := s.AllPanels(ctx, "dashboard-with-panels-nested-into-rows", 0, 0)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(panels).To(HaveLen(4))
+		})
+	})
+})
+
+func createFakeGrafanaServer() *httptest.Server {
+	const DashWithoutRows = `
+{
+	"dashboard": {
+		"panels": [
+			{ "id": 0, "title": "my-title" },
+			{ "id": 0, "title": "my-title" }
+		]
+	}
+}`
+	const DashWithRows = `
+{
+	"dashboard": {
+		"panels": [
+			{ "id": 0, "title": "my-title" },
+			{ "id": 0, "title": "my-title", "type": "row" },
+			{ "id": 0, "title": "my-title" },
+			{ "id": 0, "title": "my-title", "type": "row" },
+			{ "id": 0, "title": "my-title" }
+		]
+	}
+}`
+
+	const DashWithPanelsNestedIntoRow = `
+{
+	"dashboard": {
+		"rows": [
+		{
+			"panels": [
+				{ "id": 0, "title": "my-title" },
+				{ "id": 0, "title": "my-title" },
+				{ "id": 0, "title": "my-title" }
+			]
+		},
+		{
+			"panels": [
+				{ "id": 0, "title": "my-title" }
+			]
+		}]
+	}
+}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/dashboards/uid/dashboard-without-rows":
+			fmt.Fprintln(w, DashWithoutRows)
+
+		case "/api/dashboards/uid/dashboard-with-rows":
+			fmt.Fprintln(w, DashWithRows)
+
+		case "/api/dashboards/uid/dashboard-with-panels-nested-into-rows":
+			fmt.Fprintln(w, DashWithPanelsNestedIntoRow)
+
+		case "/render/d-solo/dashboard-without-rows":
+			fmt.Fprintln(w, ``)
+
+		case "/render/d-solo/dashboard-with-rows":
+			fmt.Fprintln(w, ``)
+
+		case "/render/d-solo/dashboard-with-panels-nested-into-rows":
+			fmt.Fprintln(w, ``)
+
+		default:
+			panic("invalid url " + r.URL.String())
+		}
+	}))
+
+	return ts
+}

--- a/monitoring/benchmark-pr.jsonnet
+++ b/monitoring/benchmark-pr.jsonnet
@@ -2,10 +2,8 @@ local grafana = import 'grafonnet/grafana.libsonnet';
 
 local width = 12;
 local height = 10;
-// Dashboard to be used by PRs
-// IMPORTANT!
-// Don't add rows, since that will mess up the json parsing
-// in the golang code
+
+// Dashboard to be used by Server benchmark PRs
 grafana.dashboard.new(
   'Pyroscope Server PR Dashboard',
   tags=['pyroscope'],
@@ -22,130 +20,99 @@ grafana.dashboard.new(
     hide='hidden', // anything other than '' and 'label works
   )
 )
-.addPanel(
-  grafana.graphPanel.new(
-    'Throughput',
-    datasource='$PROMETHEUS_DS',
+.addRow(
+  grafana.row.new(
+    title='Benchmark',
   )
-  .addTarget(grafana.prometheus.target('rate(pyroscope_http_request_duration_seconds_count{handler="/ingest"}[5m])')),
-  gridPos={
-    x: width * 0,
-    y: height * 0,
-    w: width,
-    h: height,
-  }
-)
-.addPanel(
-  grafana.graphPanel.new(
-    'Disk Usage',
-    datasource='$PROMETHEUS_DS',
-    format='bytes',
-    legend_values='true',
-    legend_rightSide='true',
-    legend_alignAsTable='true',
-    legend_current='true',
-    legend_sort='current',
-    legend_sortDesc=true,
-  )
-  .addTarget(
-    grafana.prometheus.target(
-      'sum(pyroscope_storage_disk_bytes) by (instance)',
-      legendFormat='total {{ instance }}',
+  .addPanel(
+    grafana.graphPanel.new(
+      'Throughput',
+      datasource='$PROMETHEUS_DS',
     )
-  ),
-  gridPos={
-    x: width * 1,
-    y: height * 0,
-    w: width,
-    h: height,
-  }
-)
-.addPanel(
-  grafana.graphPanel.new(
-    'Memory',
-    datasource='$PROMETHEUS_DS',
-    format='bytes',
-    legend_values='true',
-    legend_rightSide='true',
-    legend_alignAsTable='true',
-    legend_current=true,
-    legend_max=true,
-    legend_sort='current',
-    legend_sortDesc=true,
-    logBase1Y=2,
+    .addTarget(grafana.prometheus.target('rate(pyroscope_http_request_duration_seconds_count{handler="/ingest"}[5m])')),
   )
-  .addTarget(
-    grafana.prometheus.target(
-      'pyroscope_storage_evictions_alloc_bytes',
-      legendFormat='heap size {{ instance  }}',
+  .addPanel(
+    grafana.graphPanel.new(
+      'Disk Usage',
+      datasource='$PROMETHEUS_DS',
+      format='bytes',
+      legend_values='true',
+      legend_rightSide='true',
+      legend_alignAsTable='true',
+      legend_current='true',
+      legend_sort='current',
+      legend_sortDesc=true,
+    )
+    .addTarget(
+      grafana.prometheus.target(
+        'sum(pyroscope_storage_disk_bytes) by (instance)',
+        legendFormat='total {{ instance }}',
+      )
     ),
   )
-  .addTarget(
-    grafana.prometheus.target(
-      'pyroscope_storage_evictions_total_mem_bytes',
-      legendFormat='total memory {{ instance }}',
+  .addPanel(
+    grafana.graphPanel.new(
+      'Memory',
+      datasource='$PROMETHEUS_DS',
+      format='bytes',
+      legend_values='true',
+      legend_rightSide='true',
+      legend_alignAsTable='true',
+      legend_current=true,
+      legend_max=true,
+      legend_sort='current',
+      legend_sortDesc=true,
+      logBase1Y=2,
+    )
+    .addTarget(
+      grafana.prometheus.target(
+        'pyroscope_storage_evictions_alloc_bytes',
+        legendFormat='heap size {{ instance  }}',
+      ),
+    )
+    .addTarget(
+      grafana.prometheus.target(
+        'pyroscope_storage_evictions_total_mem_bytes',
+        legendFormat='total memory {{ instance }}',
+      ),
     ),
-  ),
-  gridPos={
-    x: width * 0,
-    y: height * 1,
-    w: width,
-    h: height,
-  }
-)
-.addPanel(
-  grafana.graphPanel.new(
-    'Upload Errors (Total)',
-    datasource='$PROMETHEUS_DS',
-    span=4,
   )
-  .addTarget(
-    grafana.prometheus.target(
-      'pyroscope_benchmark_upload_errors{}',
+  .addPanel(
+    grafana.graphPanel.new(
+      'Upload Errors (Total)',
+      datasource='$PROMETHEUS_DS',
+      span=4,
     )
-  ),
-  gridPos={
-    x: width * 1,
-    y: height * 1,
-    w: width,
-    h: height,
-  }
-)
-.addPanel(
-  grafana.graphPanel.new(
-    'Successful Uploads (Total)',
-    datasource='$PROMETHEUS_DS',
-    span=4,
+    .addTarget(
+      grafana.prometheus.target(
+        'pyroscope_benchmark_upload_errors{}',
+      )
+    ),
   )
-  .addTarget(
-    grafana.prometheus.target(
-      'pyroscope_benchmark_successful_uploads{}',
+  .addPanel(
+    grafana.graphPanel.new(
+      'Successful Uploads (Total)',
+      datasource='$PROMETHEUS_DS',
+      span=4,
     )
-  ),
-  gridPos={
-    x: width * 0,
-    y: height * 2,
-    w: width,
-    h: height,
-  }
-)
-.addPanel(
-  grafana.graphPanel.new(
-    'CPU Utilization',
-    datasource='$PROMETHEUS_DS',
-    format='percent',
-    min='0',
-    max='100',
+    .addTarget(
+      grafana.prometheus.target(
+        'pyroscope_benchmark_successful_uploads{}',
+      )
+    ),
   )
-  .addTarget(
-    grafana.prometheus.target(
-      'pyroscope_cpu_utilization',
+  .addPanel(
+    grafana.graphPanel.new(
+      'CPU Utilization',
+      datasource='$PROMETHEUS_DS',
+      format='percent',
+      min='0',
+      max='100',
     )
-  ),
-  gridPos={
-    x: width * 1,
-    y: height * 2,
-    w: width,
-    h: height,
-  }
+    .addTarget(
+      grafana.prometheus.target(
+        'pyroscope_cpu_utilization',
+      )
+    )
+  )
 )

--- a/monitoring/gen/benchmark-pr.json
+++ b/monitoring/gen/benchmark-pr.json
@@ -10,533 +10,515 @@
    "hideControls": false,
    "id": null,
    "links": [ ],
-   "panels": [
+   "refresh": "5s",
+   "rows": [
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$PROMETHEUS_DS",
-         "fill": 1,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 0,
-            "y": 0
-         },
-         "id": 2,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
-         },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
-         "targets": [
+         "collapse": false,
+         "collapsed": false,
+         "panels": [
             {
-               "expr": "rate(pyroscope_http_request_duration_seconds_count{handler=\"/ingest\"}[5m])",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "A"
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 2,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(pyroscope_http_request_duration_seconds_count{handler=\"/ingest\"}[5m])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Throughput",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 3,
+               "legend": {
+                  "alignAsTable": "true",
+                  "avg": false,
+                  "current": "true",
+                  "max": false,
+                  "min": false,
+                  "rightSide": "true",
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": "true"
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(pyroscope_storage_disk_bytes) by (instance)",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "total {{ instance }}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Disk Usage",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 4,
+               "legend": {
+                  "alignAsTable": "true",
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": "true",
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": "true"
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_storage_evictions_alloc_bytes",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "heap size {{ instance  }}",
+                     "refId": "A"
+                  },
+                  {
+                     "expr": "pyroscope_storage_evictions_total_mem_bytes",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "total memory {{ instance }}",
+                     "refId": "B"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 2,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 5,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_benchmark_upload_errors{}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Upload Errors (Total)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 6,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "span": 4,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_benchmark_successful_uploads{}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Successful Uploads (Total)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "short",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$PROMETHEUS_DS",
+               "fill": 1,
+               "fillGradient": 0,
+               "gridPos": { },
+               "id": 7,
+               "legend": {
+                  "alignAsTable": false,
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "total": false,
+                  "values": false
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "pyroscope_cpu_utilization",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU Utilization",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 0,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "percent",
+                     "label": null,
+                     "logBase": 1,
+                     "max": "100",
+                     "min": "0",
+                     "show": true
+                  },
+                  {
+                     "format": "percent",
+                     "label": null,
+                     "logBase": 1,
+                     "max": "100",
+                     "min": "0",
+                     "show": true
+                  }
+               ]
             }
          ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Throughput",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$PROMETHEUS_DS",
-         "fill": 1,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 12,
-            "y": 0
-         },
-         "id": 3,
-         "legend": {
-            "alignAsTable": "true",
-            "avg": false,
-            "current": "true",
-            "max": false,
-            "min": false,
-            "rightSide": "true",
-            "show": true,
-            "sideWidth": null,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": "true"
-         },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
          "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
-         "targets": [
-            {
-               "expr": "sum(pyroscope_storage_disk_bytes) by (instance)",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "total {{ instance }}",
-               "refId": "A"
-            }
-         ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Disk Usage",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "bytes",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "bytes",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$PROMETHEUS_DS",
-         "fill": 1,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 0,
-            "y": 10
-         },
-         "id": 4,
-         "legend": {
-            "alignAsTable": "true",
-            "avg": false,
-            "current": true,
-            "max": true,
-            "min": false,
-            "rightSide": "true",
-            "show": true,
-            "sideWidth": null,
-            "sort": "current",
-            "sortDesc": true,
-            "total": false,
-            "values": "true"
-         },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
-         "targets": [
-            {
-               "expr": "pyroscope_storage_evictions_alloc_bytes",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "heap size {{ instance  }}",
-               "refId": "A"
-            },
-            {
-               "expr": "pyroscope_storage_evictions_total_mem_bytes",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "total memory {{ instance }}",
-               "refId": "B"
-            }
-         ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Memory",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "bytes",
-               "label": null,
-               "logBase": 2,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "bytes",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$PROMETHEUS_DS",
-         "fill": 1,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 12,
-            "y": 10
-         },
-         "id": 5,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
-         },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 4,
-         "stack": false,
-         "steppedLine": false,
-         "targets": [
-            {
-               "expr": "pyroscope_benchmark_upload_errors{}",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "A"
-            }
-         ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Upload Errors (Total)",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$PROMETHEUS_DS",
-         "fill": 1,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 0,
-            "y": 20
-         },
-         "id": 6,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
-         },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "span": 4,
-         "stack": false,
-         "steppedLine": false,
-         "targets": [
-            {
-               "expr": "pyroscope_benchmark_successful_uploads{}",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "A"
-            }
-         ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Successful Uploads (Total)",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "$PROMETHEUS_DS",
-         "fill": 1,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 10,
-            "w": 12,
-            "x": 12,
-            "y": 20
-         },
-         "id": 7,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
-         },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
-         "targets": [
-            {
-               "expr": "pyroscope_cpu_utilization",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "A"
-            }
-         ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "CPU Utilization",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "percent",
-               "label": null,
-               "logBase": 1,
-               "max": "100",
-               "min": "0",
-               "show": true
-            },
-            {
-               "format": "percent",
-               "label": null,
-               "logBase": 1,
-               "max": "100",
-               "min": "0",
-               "show": true
-            }
-         ]
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Benchmark",
+         "titleSize": "h6",
+         "type": "row"
       }
    ],
-   "refresh": "5s",
-   "rows": [ ],
    "schemaVersion": 14,
    "style": "dark",
    "tags": [


### PR DESCRIPTION
previously we assumed the dashboard we are taking screenshots doesn't have any rows

that, however, makes generating it with jsonnet a bit difficult (see the `gridPos` math below)

in this pr we support dashboards with rows, which then allow us to just add panels to a row and they will be placed correctly 