### PR TITLE
frontend: fix sort function

### DIFF
--- a/webapp/javascript/components/FlameGraph/FlameGraphRenderer.jsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphRenderer.jsx
@@ -138,7 +138,7 @@ class FlameGraphRenderer extends React.Component {
     });
   };
 
-  updateSortBy(newSortBy) {
+  updateSortBy = (newSortBy) => {
     let dir = this.state.sortByDirection;
     if (this.state.sortBy === newSortBy) {
       dir = dir === "asc" ? "desc" : "asc";


### PR DESCRIPTION
@ruslanpascoal2 informed me that the sort functionality wasn't working, this PR fixes it

technical background info:
as the updateSortBy function was called indirectly
the 'this' was being undefined

there are couple different ways of solving this issue

1. binding (in the constructor), such as
this.updateSortBy = this.updateSortBy.bind(this)

2. declaring updateSortBy as an arrow function,
since arrow functions don't bind the 'this',
we end up using the class one

i've preferred to use 2) since we are already using it in othe places


@ruslanpascoal2 I think you can pick up this pr and add the cypress test referred to the sort