### PR TITLE
Fix reset view

### DIFF
--- a/cypress/fixtures/simple-golang-app-cpu.json
+++ b/cypress/fixtures/simple-golang-app-cpu.json
@@ -1,0 +1,74 @@
+{
+  "flamebearer": {
+    "names": [
+      "total",
+      "runtime.main",
+      "main.slowFunction",
+      "main.work",
+      "main.main",
+      "main.fastFunction"
+    ],
+    "levels": [
+      [
+        0,
+        988,
+        0,
+        0
+      ],
+      [
+        0,
+        988,
+        0,
+        1
+      ],
+      [
+        0,
+        214,
+        0,
+        5,
+        0,
+        3,
+        2,
+        4,
+        0,
+        771,
+        0,
+        2
+      ],
+      [
+        0,
+        214,
+        214,
+        3,
+        2,
+        1,
+        1,
+        5,
+        0,
+        771,
+        771,
+        3
+      ]
+    ],
+    "numTicks": 988,
+    "maxSelf": 771,
+    "spyName": "gospy",
+    "sampleRate": 100,
+    "units": "samples",
+    "format": "single"
+  },
+  "metadata": {
+    "format": "single",
+    "sampleRate": 100,
+    "spyName": "gospy",
+    "units": "samples"
+  },
+  "timeline": {
+    "startTime": 1632335270,
+    "samples": [
+      989
+    ],
+    "durationDelta": 10
+  }
+}
+

--- a/cypress/integration/basic.ts
+++ b/cypress/integration/basic.ts
@@ -149,5 +149,19 @@ describe('basic test', () => {
       })
   });
 
+  it('validates "Reset View" works', () => {
+    cy.intercept('**/render*', {
+      fixture: 'simple-golang-app-cpu.json',
+    }).as('render')
+
+    cy.visit('/')
+
+    cy.findByTestId('reset-view').should('not.be.visible');
+    cy.findByTestId('flamegraph-canvas')
+      .click(0, BAR_HEIGHT)
+    cy.findByTestId('reset-view').should('be.visible');
+    cy.findByTestId('reset-view').click();
+    cy.findByTestId('reset-view').should('not.be.visible');
+  });
 })
     

--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/index.jsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/index.jsx
@@ -518,7 +518,8 @@ class FlameGraph extends React.Component {
       this.rangeMin = 0;
       this.rangeMax = 1;
     }
-    this.updateResetStyle();
+
+    this.props.onZoom(this.selectedLevel);
   }
 
   // binary search of a block in a stack level

--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/index.jsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/index.jsx
@@ -42,7 +42,7 @@ import {
   diffColorRed,
 } from "./color";
 
-import "./styles.css";
+//import "./styles.css";
 
 import { fitToCanvasRect } from "../../../util/fitMode";
 
@@ -104,6 +104,7 @@ const COLLAPSE_THRESHOLD = 5;
 const LABEL_THRESHOLD = 20;
 const HIGHLIGHT_NODE_COLOR = "#48CE73"; // green
 const GAP = 0.5;
+export const BAR_HEIGHT = PX_PER_LEVEL - GAP;
 
 const unitsToFlamegraphTitle = {
   objects: "amount of objects in RAM per function",
@@ -345,7 +346,7 @@ class FlameGraph extends React.Component {
         }
         // ticks are samples
         const sw = numBarTicks * this.pxPerTick - (collapsed ? 0 : GAP);
-        const sh = PX_PER_LEVEL - GAP;
+        const sh = BAR_HEIGHT;
 
         // if (x < -1 || x + sw > this.graphWidth + 1 || sw < HIDE_THRESHOLD) continue;
 

--- a/webapp/javascript/components/FlameGraph/FlameGraphRenderer.jsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphRenderer.jsx
@@ -49,6 +49,10 @@ class FlameGraphRenderer extends React.Component {
       fitMode: props.fitMode ? props.fitMode : "HEAD",
       flamebearer: null,
     };
+
+    // generally not a good idea
+    // but we need to access the graph's reset function
+    this.graphRef = React.createRef();
   }
 
   componentDidMount() {
@@ -109,21 +113,13 @@ class FlameGraphRenderer extends React.Component {
     });
   };
 
-  updateResetStyle = () => {
-    // const emptyQuery = this.query === "";
-    const topLevelSelected = this.selectedLevel === 0;
-    this.setState({
-      resetStyle: { visibility: topLevelSelected ? "hidden" : "visible" },
-    });
-  };
-
   handleSearchChange = (e) => {
     this.query = e.target.value;
     this.updateResetStyle();
   };
 
   reset = () => {
-    this.updateZoom(0, 0);
+    this.graphRef.current.reset();
   };
 
   updateView = (newView) => {
@@ -169,6 +165,13 @@ class FlameGraphRenderer extends React.Component {
       this.rangeMax = 1;
     }
     this.updateResetStyle();
+  }
+
+  onZoom = (selectedLevel) => {
+    const topLevelSelected = selectedLevel === 0;
+    this.setState({
+      resetStyle: { visibility: topLevelSelected ? "hidden" : "visible" },
+    });
   }
 
   parseFormat(format) {
@@ -242,6 +245,7 @@ class FlameGraphRenderer extends React.Component {
       this.state.flamebearer && dataExists ? (
         <Graph
           key="flamegraph-pane"
+          ref={this.graphRef}
           flamebearer={this.state.flamebearer}
           format={this.parseFormat(this.state.flamebearer.format)}
           view={this.state.view}
@@ -249,6 +253,7 @@ class FlameGraphRenderer extends React.Component {
           label={this.props.query}
           fitMode={this.state.fitMode}
           viewType={this.props.viewType}
+          onZoom={this.onZoom}
         />
       ) : null;
 

--- a/webapp/javascript/components/ProfilerHeader.jsx
+++ b/webapp/javascript/components/ProfilerHeader.jsx
@@ -42,6 +42,7 @@ export default function ProfilerHeader({
         type="button"
         className={clsx("btn")}
         style={resetStyle}
+        data-testid="reset-view"
         id="reset"
         onClick={reset}
       >


### PR DESCRIPTION
The "Reset View" button wasn't working properly. This PR fixes it

![image](https://user-images.githubusercontent.com/6951209/134407123-d0297898-c7e3-423d-be85-5c2e65c9f5cd.png)

Also added a simple test that clicks on the flamegraph, so maybe we could move that to a bigger test that tests the drill effect and whatnot.

@ruslanpascoal2 I've created a new fixture based on real profiling data (the go example), I think it's best to use this one from now on, since it makes testing easier since you have real, consistent data to base on (for example the previous `render.json` file produces a broken flamegraph).
