### PR TITLE
profiler: add support for dynamic tags

### DIFF
--- a/pkg/agent/profiler/profiler.go
+++ b/pkg/agent/profiler/profiler.go
@@ -88,3 +88,36 @@ func (p *Profiler) Stop() error {
 	p.session.Stop()
 	return nil
 }
+
+// Tag - Adds tags to the current profiler session.
+func (p *Profiler) Tag(tags map[string]string) error {
+	err := p.session.SetTags(tags)
+	if err != nil {
+		return fmt.Errorf("tag: %w", err)
+	}
+	return nil
+}
+
+// TagWrapper - wrap the given function with the provided tags.
+func (p *Profiler) TagWrapper(tags map[string]string, cb func()) error {
+	err := p.Tag(tags)
+	if err != nil {
+		return err
+	}
+	cb()
+	var tagKeys []string
+	for key := range tags {
+		tagKeys = append(tagKeys, key)
+	}
+	err = p.RemoveTags(tagKeys...)
+	return err
+}
+
+// RemoveTags - remove the given tags from the profiling session.
+func (p *Profiler) RemoveTags(tags ...string) error {
+	err := p.session.RemoveTags(tags...)
+	if err != nil {
+		return fmt.Errorf("remove tag: %w", err)
+	}
+	return nil
+}

--- a/pkg/agent/session.go
+++ b/pkg/agent/session.go
@@ -282,12 +282,30 @@ func (ps *ProfileSession) initializeTries() {
 		}
 	}
 }
-func (ps *ProfileSession) SetTag(key, val string) error {
-	newName, err := mergeTagsWithAppName(ps.appName, map[string]string{key: val})
+
+// SetTags - add new tags to the session.
+func (ps *ProfileSession) SetTags(tags map[string]string) error {
+	newName, err := mergeTagsWithAppName(ps.appName, tags)
 	if err != nil {
 		return err
 	}
-
+	return ps.ChangeName(newName)
+}
+// SetTag - add a new tag to the session.
+func (ps *ProfileSession) SetTag(key, val string) error {
+	return ps.SetTags(map[string]string{key: val})
+}
+// RemoveTags - remove tags from the session.
+func (ps *ProfileSession) RemoveTags(keys ...string) error {
+	removals := make(map[string]string)
+	for _, key := range keys {
+		// 'Adding' a key with an empty string triggers a key removal.
+		removals[key] = ""
+	}
+	newName, err := mergeTagsWithAppName(ps.appName, removals)
+	if err != nil {
+		return err
+	}
 	return ps.ChangeName(newName)
 }
 

--- a/pkg/agent/session_test.go
+++ b/pkg/agent/session_test.go
@@ -55,6 +55,7 @@ var _ = Describe("agent.Session", func() {
 				Expect(val).To(BeNumerically("~", 11, 2))
 			})
 			close(done)
+			Expect(u.uploads[0].Name).To(Equal("test-app.cpu{}"))
 		})
 
 		When("tags specified", func() {
@@ -153,7 +154,7 @@ var _ = Describe("agent.Session", func() {
 				s.Stop()
 
 				Expect(u.uploads).To(HaveLen(3))
-				Expect(u.uploads[0].Name).To(Equal("test-app.cpu"))
+				Expect(u.uploads[0].Name).To(Equal("test-app.cpu{}"))
 			})
 		})
 	})

--- a/pkg/agent/session_test.go
+++ b/pkg/agent/session_test.go
@@ -89,4 +89,72 @@ var _ = Describe("agent.Session", func() {
 			})
 		})
 	})
+	Describe("Session", func() {
+		When("tags added", func() {
+			It("name ", func() {
+				u := &upstreamMock{}
+				uploadRate := 200 * time.Millisecond
+				c := &SessionConfig{
+					Upstream:         u,
+					AppName:          "test-app",
+					ProfilingTypes:   []spy.ProfileType{spy.ProfileCPU},
+					SpyName:          "debugspy",
+					SampleRate:       100,
+					UploadRate:       uploadRate,
+					Pid:              os.Getpid(),
+					WithSubprocesses: true,
+					Tags: map[string]string{
+						"foo": "bar",
+						"baz": "qux",
+					},
+				}
+
+				s, _ := NewSession(c, logrus.StandardLogger())
+				now := time.Now()
+				time.Sleep(now.Truncate(uploadRate).Add(uploadRate + 10*time.Millisecond).Sub(now))
+				err := s.Start()
+				Expect(err).ToNot(HaveOccurred())
+				s.SetTags(map[string]string{"bar": "xxx"})
+				time.Sleep(500 * time.Millisecond)
+				s.Stop()
+
+				Expect(u.uploads).To(HaveLen(3))
+				Expect(u.uploads[0].Name).To(Equal("test-app.cpu{bar=xxx,baz=qux,foo=bar}"))
+			})
+		})
+		When("tags removed", func() {
+			It("name ", func() {
+				u := &upstreamMock{}
+				uploadRate := 200 * time.Millisecond
+				c := &SessionConfig{
+					Upstream:         u,
+					AppName:          "test-app{bar=xxx}",
+					ProfilingTypes:   []spy.ProfileType{spy.ProfileCPU},
+					SpyName:          "debugspy",
+					SampleRate:       100,
+					UploadRate:       uploadRate,
+					Pid:              os.Getpid(),
+					WithSubprocesses: true,
+					Tags: map[string]string{
+						"foo": "bar",
+					},
+				}
+
+				s, _ := NewSession(c, logrus.StandardLogger())
+				now := time.Now()
+				time.Sleep(now.Truncate(uploadRate).Add(uploadRate + 10*time.Millisecond).Sub(now))
+				err := s.Start()
+				Expect(err).ToNot(HaveOccurred())
+				err = s.RemoveTags("bar")
+				Expect(err).ToNot(HaveOccurred())
+				err = s.RemoveTags("foo")
+				Expect(err).ToNot(HaveOccurred())
+				time.Sleep(500 * time.Millisecond)
+				s.Stop()
+
+				Expect(u.uploads).To(HaveLen(3))
+				Expect(u.uploads[0].Name).To(Equal("test-app.cpu"))
+			})
+		})
+	})
 })


### PR DESCRIPTION
For #433 

The issue mentions adding tests but I was a little unsure about the best way to add tests to the `profiler` because of the `upstream` instantiation. I added a couple of unit tests to the `session` which the profiler wraps instead but happy to revisit tests if y'all have some guidance on the best way to test the profiler