### PR TITLE
Handle BadgerDB panic

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"sort"
 	"sync"
 	"time"
@@ -65,10 +66,9 @@ type Storage struct {
 	wg   sync.WaitGroup
 }
 
-func (s *Storage) newBadger(name string) (*badger.DB, error) {
+func (s *Storage) newBadger(name string) (db *badger.DB, err error) {
 	badgerPath := filepath.Join(s.config.StoragePath, name)
-	err := os.MkdirAll(badgerPath, 0o755)
-	if err != nil {
+	if err = os.MkdirAll(badgerPath, 0o755); err != nil {
 		return nil, err
 	}
 	badgerOptions := badger.DefaultOptions(badgerPath)
@@ -81,7 +81,17 @@ func (s *Storage) newBadger(name string) (*badger.DB, error) {
 		badgerLevel = l
 	}
 	badgerOptions = badgerOptions.WithLogger(badgerLogger{name: name, logLevel: badgerLevel})
-	db, err := badger.Open(badgerOptions)
+	defer func() {
+		if r := recover(); r != nil {
+			// BadgerDB may panic because of file system access permissions. In particular,
+			// if is running in kubernetes with incorrect/unset fsGroup security context:
+			// https://github.com/pyroscope-io/pyroscope/issues/350.
+			err = fmt.Errorf("failed to open database\n\n"+
+				"Please make sure Pyroscope Server has write access permissions to %s directory.\n\n"+
+				"Recovered from panic: %v\n%v", badgerPath, r, string(debug.Stack()))
+		}
+	}()
+	db, err = badger.Open(badgerOptions)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Please refer to:
 1. https://github.com/pyroscope-io/pyroscope/issues/350
 2. https://github.com/pyroscope-io/helm-chart/pull/25

It may make sense to check if the server is running in kubernetes and show more relevant message. For example, saying that the most probable cause of the failure is incorrect `fsGroup` value.