### PR TITLE
Enable dotnetspy for macos build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ALL_SPIES = ebpfspy,rbspy,pyspy,dotnetspy,debugspy
 ifeq ("$(OS)", "Linux")
 	ENABLED_SPIES ?= ebpfspy,rbspy,pyspy,phpspy,dotnetspy
 else
-	ENABLED_SPIES ?= rbspy,pyspy
+	ENABLED_SPIES ?= rbspy,pyspy,dotnetspy
 endif
 
 ifeq ("$(OS)", "Linux")


### PR DESCRIPTION
Currently, dotnetspy is only enabled on linux and windows, although there are no OS-specific dependencies. This PR enables dotnetspy for macos.