### PR TITLE
Golang profiler API

### DIFF
--- a/examples/golang/main.go
+++ b/examples/golang/main.go
@@ -17,15 +17,15 @@ func work(n int) {
 	// revive:enable:empty-block
 }
 
-func fastFunction(c context.Context) {
-	profiler.TagWrapper(c, profiler.Labels("function", "fast"), func(c context.Context) {
+func fastFunction(ctx context.Context) {
+	profiler.WithLabelsContext(ctx, profiler.Labels("function", "fast"), func(context.Context) {
 		work(20000000)
 	})
 }
 
-func slowFunction(c context.Context) {
+func slowFunction(ctx context.Context) {
 	// standard pprof.Do wrappers work as well
-	pprof.Do(c, pprof.Labels("function", "slow"), func(c context.Context) {
+	pprof.Do(ctx, pprof.Labels("function", "slow"), func(context.Context) {
 		work(80000000)
 	})
 }
@@ -35,10 +35,10 @@ func main() {
 		ApplicationName: "simple.golang.app",
 		ServerAddress:   "http://localhost:4040", // this will run inside docker-compose, hence `pyroscope` for hostname
 	})
-	profiler.TagWrapper(context.Background(), profiler.Labels("foo", "bar"), func(c context.Context) {
+	profiler.WithLabelsContext(context.Background(), profiler.Labels("foo", "bar"), func(ctx context.Context) {
 		for {
-			fastFunction(c)
-			slowFunction(c)
+			fastFunction(ctx)
+			slowFunction(ctx)
 		}
 	})
 }

--- a/examples/golang/main.go
+++ b/examples/golang/main.go
@@ -17,14 +17,16 @@ func work(n int) {
 	// revive:enable:empty-block
 }
 
-func fastFunction(ctx context.Context) {
-	profiler.WithLabelsContext(ctx, profiler.Labels("function", "fast"), func(context.Context) {
+func fastFunction() {
+	profiler.WithLabels(profiler.Labels{"function": "fast"}, func() {
 		work(20000000)
 	})
 }
 
-func slowFunction(ctx context.Context) {
-	// standard pprof.Do wrappers work as well
+func slowFunction() {
+	// Standard pprof.Do wrapper works as well. A context with
+	// the current labels can be retrieved via profiler.Context call:
+	ctx := profiler.Context(context.Background())
 	pprof.Do(ctx, pprof.Labels("function", "slow"), func(context.Context) {
 		work(80000000)
 	})
@@ -35,10 +37,10 @@ func main() {
 		ApplicationName: "simple.golang.app",
 		ServerAddress:   "http://localhost:4040", // this will run inside docker-compose, hence `pyroscope` for hostname
 	})
-	profiler.WithLabelsContext(context.Background(), profiler.Labels("foo", "bar"), func(ctx context.Context) {
+	profiler.WithLabels(profiler.Labels{"foo": "bar"}, func() {
 		for {
-			fastFunction(ctx)
-			slowFunction(ctx)
+			fastFunction()
+			slowFunction()
 		}
 	})
 }

--- a/pkg/agent/pprof/runtime.go
+++ b/pkg/agent/pprof/runtime.go
@@ -4,30 +4,23 @@
 
 package pprof
 
-import (
-	"runtime/pprof"
-	"unsafe"
-)
+import "unsafe"
 
 //go:linkname runtime_getProfLabel runtime/pprof.runtime_getProfLabel
 func runtime_getProfLabel() unsafe.Pointer
 
+//go:linkname runtime_setProfLabel runtime/pprof.runtime_setProfLabel
+func runtime_setProfLabel(unsafe.Pointer)
+
 // GetGoroutineLabels retrieves labels associated with the running goroutine.
 // The original labels order is not preserved.
-func GetGoroutineLabels() pprof.LabelSet {
-	var s pprof.LabelSet
-	p := (*map[string]string)(runtime_getProfLabel())
-	if p == nil {
-		return s
+func GetGoroutineLabels() map[string]string {
+	if p := (*map[string]string)(runtime_getProfLabel()); p != nil {
+		return *p
 	}
-	m := *p
-	if len(m) == 0 {
-		return s
-	}
-	l := make([]string, 0, len(m)*2)
-	for k, v := range m {
-		l = append(l, k)
-		l = append(l, v)
-	}
-	return pprof.Labels(l...)
+	return nil
+}
+
+func SetGoroutineLabels(m map[string]string) {
+	runtime_setProfLabel(unsafe.Pointer(&m))
 }

--- a/pkg/agent/pprof/runtime.go
+++ b/pkg/agent/pprof/runtime.go
@@ -1,0 +1,33 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pprof
+
+import (
+	"runtime/pprof"
+	"unsafe"
+)
+
+//go:linkname runtime_getProfLabel runtime/pprof.runtime_getProfLabel
+func runtime_getProfLabel() unsafe.Pointer
+
+// GetGoroutineLabels retrieves labels associated with the running goroutine.
+// The original labels order is not preserved.
+func GetGoroutineLabels() pprof.LabelSet {
+	var s pprof.LabelSet
+	p := (*map[string]string)(runtime_getProfLabel())
+	if p == nil {
+		return s
+	}
+	m := *p
+	if len(m) == 0 {
+		return s
+	}
+	l := make([]string, 0, len(m)*2)
+	for k, v := range m {
+		l = append(l, k)
+		l = append(l, v)
+	}
+	return pprof.Labels(l...)
+}

--- a/pkg/agent/profiler/profiler_test.go
+++ b/pkg/agent/profiler/profiler_test.go
@@ -1,0 +1,179 @@
+package profiler_test
+
+import (
+	"context"
+	gopprof "runtime/pprof"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/pyroscope-io/pyroscope/pkg/agent/pprof"
+	"github.com/pyroscope-io/pyroscope/pkg/agent/profiler"
+)
+
+var _ = Describe("WithLabels", func() {
+	RegisterFailHandler(Fail)
+
+	It("Propagates goroutine labels implicitly", func() {
+		c := make(chan struct{})
+		Expect(pprof.GetGoroutineLabels()).To(Equal(profiler.LabelSet{}))
+
+		profiler.WithLabels(profiler.Labels("foo", "bar"), func() {
+			expectLabels(profiler.Labels(
+				"foo", "bar",
+			))
+
+			profiler.WithLabels(profiler.Labels("baz", "qux"), func() {
+				go func() {
+					expectLabels(profiler.Labels(
+						"foo", "bar",
+						"baz", "qux",
+					))
+					close(c)
+				}()
+				<-c
+			})
+
+			expectLabels(profiler.Labels(
+				"foo", "bar",
+			))
+		})
+
+		Expect(pprof.GetGoroutineLabels()).To(Equal(profiler.LabelSet{}))
+	})
+})
+
+var _ = Describe("WithLabelsContext", func() {
+	RegisterFailHandler(Fail)
+
+	It("Propagates goroutine labels explicitly via context", func() {
+		c := make(chan struct{})
+		ctx := context.Background()
+		Expect(pprof.GetGoroutineLabels()).To(Equal(profiler.LabelSet{}))
+
+		profiler.WithLabelsContext(ctx, profiler.Labels("foo", "bar"), func(ctx context.Context) {
+			expectLabels(profiler.Labels(
+				"foo", "bar",
+			))
+
+			profiler.WithLabelsContext(ctx, profiler.Labels("baz", "qux"), func(ctx context.Context) {
+				go func() {
+					expectLabels(profiler.Labels(
+						"foo", "bar",
+						"baz", "qux",
+					))
+					close(c)
+				}()
+				<-c
+			})
+
+			expectLabels(profiler.Labels(
+				"foo", "bar",
+			))
+		})
+
+		Expect(pprof.GetGoroutineLabels()).To(Equal(profiler.LabelSet{}))
+	})
+})
+
+var _ = Describe("WithLabelsContext is interchangeable with pprof.Do", func() {
+	RegisterFailHandler(Fail)
+
+	It("Preserves API compatibility", func() {
+		ctx := context.Background()
+		Expect(pprof.GetGoroutineLabels()).To(Equal(profiler.LabelSet{}))
+
+		profiler.WithLabelsContext(ctx, profiler.Labels("foo", "bar"), func(ctx context.Context) {
+			expectLabels(profiler.Labels(
+				"foo", "bar",
+			))
+
+			gopprof.Do(ctx, profiler.Labels("baz", "qux"), func(ctx context.Context) {
+				expectLabels(profiler.Labels(
+					"foo", "bar",
+					"baz", "qux",
+				))
+
+				gopprof.Do(ctx, gopprof.Labels("zoo", "ooz"), func(ctx context.Context) {
+					expectLabels(profiler.Labels(
+						"foo", "bar",
+						"baz", "qux",
+						"zoo", "ooz",
+					))
+				})
+
+				profiler.WithLabelsContext(ctx, gopprof.Labels("zoo", "ooz"), func(ctx context.Context) {
+					expectLabels(profiler.Labels(
+						"foo", "bar",
+						"baz", "qux",
+						"zoo", "ooz",
+					))
+				})
+
+				expectLabels(profiler.Labels(
+					"foo", "bar",
+					"baz", "qux",
+				))
+			})
+
+			expectLabels(profiler.Labels(
+				"foo", "bar",
+			))
+		})
+
+		Expect(pprof.GetGoroutineLabels()).To(Equal(profiler.LabelSet{}))
+	})
+})
+
+var _ = Describe("WithLabels should not be used with WithLabelsContext and/or pprof.Do", func() {
+	RegisterFailHandler(Fail)
+
+	It("Does not propagate goroutine labels", func() {
+		ctx := context.Background()
+		Expect(pprof.GetGoroutineLabels()).To(Equal(profiler.LabelSet{}))
+
+		profiler.WithLabels(profiler.Labels("foo", "bar"), func() {
+			expectLabels(profiler.Labels(
+				"foo", "bar",
+			))
+
+			// The ctx is empty meaning that WithLabelsContext/pprof.Do
+			// remove/replace the current label set.
+
+			gopprof.Do(ctx, profiler.Labels("baz", "qux"), func(ctx context.Context) {
+				expectLabels(profiler.Labels(
+					// "foo", "bar",
+					"baz", "qux",
+				))
+			})
+
+			profiler.WithLabelsContext(ctx, gopprof.Labels("baz", "qux"), func(ctx context.Context) {
+				expectLabels(profiler.Labels(
+					// "foo", "bar",
+					"baz", "qux",
+				))
+			})
+
+			expectLabels(profiler.Labels(
+			// "foo", "bar",
+			))
+		})
+
+		Expect(pprof.GetGoroutineLabels()).To(Equal(profiler.LabelSet{}))
+	})
+})
+
+func expectLabels(labels profiler.LabelSet) {
+	Expect(labelsSlice(pprof.GetGoroutineLabels())).
+		To(ConsistOf(labelsSlice(labels)))
+}
+
+func labelsSlice(labels profiler.LabelSet) []string {
+	var s []string
+	ctx := gopprof.WithLabels(context.Background(), labels)
+	gopprof.ForLabels(ctx, func(k, v string) bool {
+		s = append(s, k+"="+v)
+		return true
+	})
+	return s
+}

--- a/pkg/agent/profiler/profiler_test.go
+++ b/pkg/agent/profiler/profiler_test.go
@@ -43,10 +43,43 @@ var _ = Describe("WithLabels", func() {
 	})
 })
 
+var _ = Describe("SetLabels", func() {
+	RegisterFailHandler(Fail)
+
+	It("Overrides goroutine labels explicitly", func() {
+		Expect(pprof.GetGoroutineLabels()).To(BeEmpty())
+
+		profiler.WithLabels(profiler.Labels{"foo": "bar"}, func() {
+			expectLabels(profiler.Labels{
+				"foo": "bar",
+			})
+
+			profiler.WithLabels(profiler.Labels{"baz": "qux"}, func() {
+				expectLabels(profiler.Labels{
+					"foo": "bar",
+					"baz": "qux",
+				})
+				profiler.SetLabels(profiler.Labels{
+					"zoo": "ooz",
+				})
+				expectLabels(profiler.Labels{
+					"zoo": "ooz",
+				})
+			})
+
+			expectLabels(profiler.Labels{
+				"foo": "bar",
+			})
+		})
+
+		Expect(pprof.GetGoroutineLabels()).To(BeEmpty())
+	})
+})
+
 var _ = Describe("Interoperability with runtime/pprof", func() {
 	RegisterFailHandler(Fail)
 
-	It("pprof.Do does not propagate goroutine labels implicitly", func() {
+	It("Does not propagate goroutine labels implicitly", func() {
 		ctx := context.Background()
 		Expect(pprof.GetGoroutineLabels()).To(BeEmpty())
 
@@ -71,7 +104,7 @@ var _ = Describe("Interoperability with runtime/pprof", func() {
 		Expect(pprof.GetGoroutineLabels()).To(BeEmpty())
 	})
 
-	It("Labels propagate via Context", func() {
+	It("Propagates goroutine labels explicitly via Context", func() {
 		ctx := context.Background()
 		Expect(pprof.GetGoroutineLabels()).To(BeEmpty())
 
@@ -103,39 +136,6 @@ var _ = Describe("Interoperability with runtime/pprof", func() {
 				expectLabels(profiler.Labels{
 					"foo": "bar",
 					"baz": "qux",
-				})
-			})
-
-			expectLabels(profiler.Labels{
-				"foo": "bar",
-			})
-		})
-
-		Expect(pprof.GetGoroutineLabels()).To(BeEmpty())
-	})
-})
-
-var _ = Describe("SetLabels", func() {
-	RegisterFailHandler(Fail)
-
-	It("Overrides goroutine labels implicitly", func() {
-		Expect(pprof.GetGoroutineLabels()).To(BeEmpty())
-
-		profiler.WithLabels(profiler.Labels{"foo": "bar"}, func() {
-			expectLabels(profiler.Labels{
-				"foo": "bar",
-			})
-
-			profiler.WithLabels(profiler.Labels{"baz": "qux"}, func() {
-				expectLabels(profiler.Labels{
-					"foo": "bar",
-					"baz": "qux",
-				})
-				profiler.SetLabels(profiler.Labels{
-					"zoo": "ooz",
-				})
-				expectLabels(profiler.Labels{
-					"zoo": "ooz",
 				})
 			})
 


### PR DESCRIPTION
Following the discussion, an example API that does propagate labels without a context:

```go
func WithLabels(LabelSet, func())

// WithLabelsContext is just a counterpart of pprof.Do.
func WithLabelsContext(context.Context, LabelSet, func(context.Context))
```

The problem is that this can not be used with `pprof.Do` due to the difference in semantics: `pprof.Do` (as well as `WithLabelsContext`) replaces existing label set, meanwhile `WithLabels` appends new labels to it: see tests for details. This discrepancy jeopardizes the very idea of "simple" API.

Althout, it could be mitigated with an additional call that would create a new context with the current labels:
```go
// Context creates a new context with labels of the current goroutine.
func Context() context.Context
```

```go
profiler.WithLabels(profiler.Labels("foo", "bar"), func() {
    pprof.Do(context.Background(), pprof.Labels("baz", "qux"), func(context.Context) {
        // Does not have foo=bar label.
    })
    pprof.Do(profiler.Context(), pprof.Labels("baz", "qux"), func(context.Context) {
        // Both foo=bar and baz=qux pairs are preserved.
    })
    profiler.WithLabelsContext(profiler.Context(), profiler.Labels("baz", "qux"), func(context.Context) {
        // Both foo=bar and baz=qux pairs are preserved.
    })
})
```

Not quite sure this complication really outweighs benefits of the simplification.
