### PR TITLE
build: optimizes dockerfile, cuts docker image size in half

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -164,8 +164,7 @@ RUN mkdir -p \
         "/etc/pyroscope"
 
 COPY scripts/packages/server.yml "/etc/pyroscope/server.yml"
-COPY --from=go-builder /opt/pyroscope/bin/pyroscope /usr/bin/pyroscope
-RUN chmod 777 /usr/bin/pyroscope
+COPY --from=go-builder --chmod=0777 /opt/pyroscope/bin/pyroscope /usr/bin/pyroscope
 
 USER pyroscope
 EXPOSE 4040/tcp


### PR DESCRIPTION
TL;DR: I used @docker-slim (shout out to @kcq) on our docker image and I found out that `RUN chmod 777 /usr/bin/pyroscope` actually creates a copy of `/usr/bin/pyroscope`, resulting in the file appearing twice in the image. This PR fixes that.

### Longer explanation

I ran `docker-slim xray pyroscope/pyroscope:latest` (full log [here](https://gist.github.com/petethepig/01ec229ea9b41d6e4cd238c93ba39fbf)) and it showed `/usr/bin/pyroscope` twice:
```
...
cmd=xray info=layer.objects.top.start
A: mode=-rwxr-xr-x size.human='48 MB' size.bytes=48150592 uid=0 gid=0 mtime='2021-10-19T05:09:21Z' H=[A:6/M:7] '/usr/bin/pyroscope'
cmd=xray info=layer.end
...
cmd=xray info=layer.start
M: mode=-rwxrwxrwx size.human='48 MB' size.bytes=48150592 uid=0 gid=0 mtime='2021-10-19T05:09:21Z' H=[A:6/M:7] '/usr/bin/pyroscope'
...
```

So I added `--chmod=0777` to `COPY` command and now there's only one entry for the binary.


