### PR TITLE
Canvas performance

### DIFF
--- a/webapp/javascript/components/ProfilerTable.jsx
+++ b/webapp/javascript/components/ProfilerTable.jsx
@@ -206,175 +206,171 @@ function Table({
   );
 }
 
-function TableBody({
-  flamebearer,
-  sortBy,
-  sortByDirection,
-  viewDiff,
-  fitMode,
-}) {
-  const { numTicks, maxSelf, sampleRate, spyName, units } = flamebearer;
+const TableBody = React.memo(
+  ({ flamebearer, sortBy, sortByDirection, viewDiff, fitMode }) => {
+    const { numTicks, maxSelf, sampleRate, spyName, units } = flamebearer;
 
-  const table = generateTable(flamebearer).sort((a, b) => b.total - a.total);
+    const table = generateTable(flamebearer).sort((a, b) => b.total - a.total);
 
-  const m = sortByDirection === 'asc' ? 1 : -1;
-  let sorted;
-  if (sortBy === 'name') {
-    sorted = table.sort((a, b) => m * a[sortBy].localeCompare(b[sortBy]));
-  } else {
-    sorted = table.sort((a, b) => m * (a[sortBy] - b[sortBy]));
-  }
+    const m = sortByDirection === 'asc' ? 1 : -1;
+    let sorted;
+    if (sortBy === 'name') {
+      sorted = table.sort((a, b) => m * a[sortBy].localeCompare(b[sortBy]));
+    } else {
+      sorted = table.sort((a, b) => m * (a[sortBy] - b[sortBy]));
+    }
 
-  // The problem is that when you switch apps or time-range and the function
-  //   names stay the same it leads to an issue where rows don't get re-rendered
-  // So we force a rerender each time.
-  const renderID = Math.random();
+    // The problem is that when you switch apps or time-range and the function
+    //   names stay the same it leads to an issue where rows don't get re-rendered
+    // So we force a rerender each time.
+    const renderID = Math.random();
 
-  const formatter = getFormatter(numTicks, sampleRate, units);
+    const formatter = getFormatter(numTicks, sampleRate, units);
 
-  const nameCell = (x, style) => (
-    <td>
-      <span className="color-reference" style={style} />
-      <div
-        className="symbol-name"
-        title={x.name}
-        style={fitIntoTableCell(fitMode)}
-      >
-        {x.name}
-      </div>
-    </td>
-  );
+    const nameCell = (x, style) => (
+      <td>
+        <span className="color-reference" style={style} />
+        <div
+          className="symbol-name"
+          title={x.name}
+          style={fitIntoTableCell(fitMode)}
+        >
+          {x.name}
+        </div>
+      </td>
+    );
 
-  const renderRow = !viewDiff ? (
-    (x, color, style) => (
-      <tr key={x.name + renderID}>
-        {nameCell(x, style)}
-        <td style={backgroundImageStyle(x.self, maxSelf, color)}>
-          {/* <span>{ formatPercent(x.self / numTicks) }</span>
+    const renderRow = !viewDiff ? (
+      (x, color, style) => (
+        <tr key={x.name + renderID}>
+          {nameCell(x, style)}
+          <td style={backgroundImageStyle(x.self, maxSelf, color)}>
+            {/* <span>{ formatPercent(x.self / numTicks) }</span>
       &nbsp;
       <span>{ shortNumber(x.self) }</span>
       &nbsp; */}
-          <span title={formatter.format(x.self, sampleRate)}>
-            {formatter.format(x.self, sampleRate)}
-          </span>
-        </td>
-        <td style={backgroundImageStyle(x.total, numTicks, color)}>
-          {/* <span>{ formatPercent(x.total / numTicks) }</span>
+            <span title={formatter.format(x.self, sampleRate)}>
+              {formatter.format(x.self, sampleRate)}
+            </span>
+          </td>
+          <td style={backgroundImageStyle(x.total, numTicks, color)}>
+            {/* <span>{ formatPercent(x.total / numTicks) }</span>
       &nbsp;
       <span>{ shortNumber(x.total) }</span>
       &nbsp; */}
-          <span title={formatter.format(x.total, sampleRate)}>
-            {formatter.format(x.total, sampleRate)}
-          </span>
-        </td>
-      </tr>
-    )
-  ) : viewDiff === 'self' ? (
-    (x, color, style) => (
-      <tr key={x.name + renderID}>
-        {nameCell(x, style)}
-        {/* NOTE: it seems React does not understand multiple backgrounds, have to workaround:  */}
-        {/*   The `style` prop expects a mapping from style properties to values, not a string. */}
-        <td
-          STYLE={backgroundImageDiffStyle(
-            x.selfLeft,
-            x.selfRght,
-            maxSelf,
-            color,
-            'L'
-          )}
-        >
-          <span title={formatter.format(x.selfLeft, sampleRate)}>
-            {formatter.format(x.selfLeft, sampleRate)}
-          </span>
-        </td>
-        <td
-          STYLE={backgroundImageDiffStyle(
-            x.selfLeft,
-            x.selfRght,
-            maxSelf,
-            color,
-            'R'
-          )}
-        >
-          <span title={formatter.format(x.selfRght, sampleRate)}>
-            {formatter.format(x.selfRght, sampleRate)}
-          </span>
-        </td>
-      </tr>
-    )
-  ) : viewDiff === 'total' ? (
-    (x, color, style) => (
-      <tr key={x.name + renderID}>
-        {nameCell(x, style)}
-        <td
-          STYLE={backgroundImageDiffStyle(
-            x.totalLeft,
-            x.totalRght,
-            numTicks / 2,
-            color,
-            'L'
-          )}
-        >
-          <span title={formatter.format(x.totalLeft, sampleRate)}>
-            {formatter.format(x.totalLeft, sampleRate)}
-          </span>
-        </td>
-        <td
-          STYLE={backgroundImageDiffStyle(
-            x.totalLeft,
-            x.totalRght,
-            numTicks / 2,
-            color,
-            'R'
-          )}
-        >
-          <span title={formatter.format(x.totalRght, sampleRate)}>
-            {formatter.format(x.totalRght, sampleRate)}
-          </span>
-        </td>
-      </tr>
-    )
-  ) : viewDiff === 'diff' ? (
-    (x, color, style) => (
-      <tr key={x.name + renderID}>
-        {nameCell(x, style)}
-        <td
-          STYLE={backgroundImageDiffStyle(
-            x.selfLeft,
-            x.selfRght,
-            maxSelf,
-            defaultColor
-          )}
-        >
-          <span title={formatter.format(x.selfDiff, sampleRate)}>
-            {formatter.format(x.selfDiff, sampleRate)}
-          </span>
-        </td>
-        <td
-          STYLE={backgroundImageDiffStyle(
-            x.totalLeft,
-            x.totalRght,
-            numTicks / 2,
-            color
-          )}
-        >
-          <span title={formatter.format(x.totalDiff, sampleRate)}>
-            {formatter.format(x.totalDiff, sampleRate)}
-          </span>
-        </td>
-      </tr>
-    )
-  ) : (
-    <div>invalid</div>
-  );
+            <span title={formatter.format(x.total, sampleRate)}>
+              {formatter.format(x.total, sampleRate)}
+            </span>
+          </td>
+        </tr>
+      )
+    ) : viewDiff === 'self' ? (
+      (x, color, style) => (
+        <tr key={x.name + renderID}>
+          {nameCell(x, style)}
+          {/* NOTE: it seems React does not understand multiple backgrounds, have to workaround:  */}
+          {/*   The `style` prop expects a mapping from style properties to values, not a string. */}
+          <td
+            STYLE={backgroundImageDiffStyle(
+              x.selfLeft,
+              x.selfRght,
+              maxSelf,
+              color,
+              'L'
+            )}
+          >
+            <span title={formatter.format(x.selfLeft, sampleRate)}>
+              {formatter.format(x.selfLeft, sampleRate)}
+            </span>
+          </td>
+          <td
+            STYLE={backgroundImageDiffStyle(
+              x.selfLeft,
+              x.selfRght,
+              maxSelf,
+              color,
+              'R'
+            )}
+          >
+            <span title={formatter.format(x.selfRght, sampleRate)}>
+              {formatter.format(x.selfRght, sampleRate)}
+            </span>
+          </td>
+        </tr>
+      )
+    ) : viewDiff === 'total' ? (
+      (x, color, style) => (
+        <tr key={x.name + renderID}>
+          {nameCell(x, style)}
+          <td
+            STYLE={backgroundImageDiffStyle(
+              x.totalLeft,
+              x.totalRght,
+              numTicks / 2,
+              color,
+              'L'
+            )}
+          >
+            <span title={formatter.format(x.totalLeft, sampleRate)}>
+              {formatter.format(x.totalLeft, sampleRate)}
+            </span>
+          </td>
+          <td
+            STYLE={backgroundImageDiffStyle(
+              x.totalLeft,
+              x.totalRght,
+              numTicks / 2,
+              color,
+              'R'
+            )}
+          >
+            <span title={formatter.format(x.totalRght, sampleRate)}>
+              {formatter.format(x.totalRght, sampleRate)}
+            </span>
+          </td>
+        </tr>
+      )
+    ) : viewDiff === 'diff' ? (
+      (x, color, style) => (
+        <tr key={x.name + renderID}>
+          {nameCell(x, style)}
+          <td
+            STYLE={backgroundImageDiffStyle(
+              x.selfLeft,
+              x.selfRght,
+              maxSelf,
+              defaultColor
+            )}
+          >
+            <span title={formatter.format(x.selfDiff, sampleRate)}>
+              {formatter.format(x.selfDiff, sampleRate)}
+            </span>
+          </td>
+          <td
+            STYLE={backgroundImageDiffStyle(
+              x.totalLeft,
+              x.totalRght,
+              numTicks / 2,
+              color
+            )}
+          >
+            <span title={formatter.format(x.totalDiff, sampleRate)}>
+              {formatter.format(x.totalDiff, sampleRate)}
+            </span>
+          </td>
+        </tr>
+      )
+    ) : (
+      <div>invalid</div>
+    );
 
-  return sorted.map((x) => {
-    const pn = getPackageNameFromStackTrace(spyName, x.name);
-    const color = viewDiff ? defaultColor : colorBasedOnPackageName(pn, 1);
-    const style = {
-      backgroundColor: color,
-    };
-    return renderRow(x, color, style);
-  });
-}
+    return sorted.map((x) => {
+      const pn = getPackageNameFromStackTrace(spyName, x.name);
+      const color = viewDiff ? defaultColor : colorBasedOnPackageName(pn, 1);
+      const style = {
+        backgroundColor: color,
+      };
+      return renderRow(x, color, style);
+    });
+  }
+);


### PR DESCRIPTION
This PR builds upon https://github.com/pyroscope-io/pyroscope/pull/480 (ie after that is merged I will rebase this one)

It improves flamegraph rendering performance by memoizing the table (on the left).

For illustration (With CPU throttling of 4x):

Before:
![4x-slowdown-before-improvement](https://user-images.githubusercontent.com/6951209/139539116-3cfc3c6c-62c0-48ca-97b6-19a83551d2b8.gif)

After:
![4x-slowdown-after-improvement](https://user-images.githubusercontent.com/6951209/139539128-0de4ca5a-8e1a-4ce6-8c4f-6cf59e89701a.gif)

`performance.measure` between the moment we click and after the canvas is rendered:

(With 4x throttling)

Before:
```
0: 2114.0999999940395
1: 2020
2: 2100.2000000029802
3: 2009.2000000029802
4: 2045.7999999970198
```
After:
```
0: 207.5
1: 142.40000000596046
2: 158.90000000596046
3: 154.59999999403954
4: 106.70000000298023
```


(Without CPU throttling):
```
1: 508.79999999701977
2: 510.20000000298023
3: 495.5
4: 498
5: 493.59999999403954
6: 673.0999999940395
7: 561.5
8: 488.3999999910593
9: 491.29999999701977
10: 512.8000000119209
```

```
0: 45.8999999910593
1: 38.70000000298023
2: 39.3999999910593
3: 27.299999997019768
4: 61.599999994039536
5: 22.19999998807907
6: 50.5
7: 29.30000001192093
8: 50.8999999910593
9: 36.69999998807907
10: 54.3999999910593
``` 

a decrease of ~ 91%