### PR TITLE
Improve text when there is no data available

### DIFF
--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/Header.tsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/Header.tsx
@@ -28,7 +28,9 @@ export default function Header({
               role="heading"
               aria-level={2}
             >
-              Frame width represents {unitsToFlamegraphTitle[units]}
+              {unitsToFlamegraphTitle[units] && (
+                <>Frame width represents {unitsToFlamegraphTitle[units]}</>
+              )}
             </div>
           </div>
         );

--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/canvas.module.css
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/canvas.module.css
@@ -1,3 +1,13 @@
 .hover {
   cursor: pointer;
 }
+
+.error {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  position: relative;
+  padding: 60px 0;
+}

--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/index.spec.tsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/index.spec.tsx
@@ -248,4 +248,26 @@ describe('FlamegraphComponent', () => {
       expect(screen.getByText('ExportData')).toBeInTheDocument();
     });
   });
+
+  it('render a message when there is no data to show', () => {
+    const onZoom = jest.fn();
+    const onReset = jest.fn();
+    const isDirty = jest.fn();
+    const onFocusOnNode = jest.fn();
+    render(
+      <FlamegraphComponent
+        fitMode="HEAD"
+        zoom={Option.none()}
+        focusedNode={Option.none()}
+        highlightQuery=""
+        onZoom={onZoom}
+        onFocusOnNode={onFocusOnNode}
+        onReset={onReset}
+        isDirty={isDirty}
+        flamebearer={TestData.empty}
+        ExportData={ExportData}
+      />
+    );
+    screen.getByText(/No profiling data available/);
+  });
 });

--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/index.tsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/index.tsx
@@ -174,6 +174,9 @@ export default function FlameGraphComponent(props: FlamegraphProps) {
     }
   }, [flamegraph]);
 
+  const dataUnavailable =
+    !flamebearer || (flamebearer && flamebearer.names.length <= 1);
+
   return (
     <>
       <div
@@ -188,7 +191,18 @@ export default function FlameGraphComponent(props: FlamegraphProps) {
           ExportData={ExportData}
         />
 
-        <div>
+        {dataUnavailable ? (
+          <div className="error-message">
+            <span>
+              No profiling data available for this application / time range.
+            </span>
+          </div>
+        ) : null}
+        <div
+          style={{
+            opacity: dataUnavailable ? 0 : 1,
+          }}
+        >
           <canvas
             height="0"
             data-testid="flamegraph-canvas"

--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/index.tsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/index.tsx
@@ -192,7 +192,7 @@ export default function FlameGraphComponent(props: FlamegraphProps) {
         />
 
         {dataUnavailable ? (
-          <div className="error-message">
+          <div className={styles.error}>
             <span>
               No profiling data available for this application / time range.
             </span>

--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/styles.css
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/styles.css
@@ -71,16 +71,6 @@ THIS SOFTWARE.
   width: 40px;
 }
 
-.error-message {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  position: relative;
-  padding: 60px 0;
-}
-
 .flamegraph-tooltip {
   max-width: 80%;
 

--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/testData.ts
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/testData.ts
@@ -1,6 +1,15 @@
 import { Units } from '@utils/format';
 
 const TestData = {
+  empty: {
+    names: [],
+    levels: [],
+    numTicks: 0,
+    sampleRate: 0,
+    units: Units.Samples,
+    spyName: '',
+    format: 'single' as const,
+  },
   SimpleTree: {
     topLevel: 0,
     rangeMin: 0,


### PR DESCRIPTION
If the selected application or range does not have data to show, we'll render a message saying so. Additionally, we won't show the "Frame width represents" text if there's nothing to show.

closes https://github.com/pyroscope-io/pyroscope/issues/483

<img width="1207" alt="image" src="https://user-images.githubusercontent.com/22270042/139588296-3758875e-e668-4d38-92bb-a8519d9ba154.png">
