### PR TITLE
Fix sidebar getting out of sync

### DIFF
--- a/webapp/javascript/components/Sidebar.jsx
+++ b/webapp/javascript/components/Sidebar.jsx
@@ -91,6 +91,16 @@ function Sidebar(props) {
 
     // console.log('history: ', history.location.pathname);
     setState({ currentRoute: history.location.pathname });
+
+    function updatePath(location, action) {
+      setState({ currentRoute: location.pathname });
+    }
+
+    const removeupdatePath = history.listen(updatePath);
+
+    return () => {
+      removeupdatePath();
+    };
   }, []);
 
   return (

--- a/webapp/javascript/components/Sidebar.spec.tsx
+++ b/webapp/javascript/components/Sidebar.spec.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { ShortcutProvider } from 'react-keybind';
+import Sidebar from './Sidebar';
+import history from '../util/history';
+
+jest.mock('react-redux', () => ({
+  connect: () => (Component: any) => Component,
+}));
+
+describe('Sidebar', () => {
+  it('Successfully changes location when clicked', () => {
+    render(
+      <ShortcutProvider>
+        <Sidebar />
+      </ShortcutProvider>
+    );
+    const singleView = screen.getByTestId('sidebar-root');
+    const comparisonView = screen.getByTestId('sidebar-comparison');
+    expect(singleView).toHaveClass('active-route');
+    expect(comparisonView).not.toHaveClass('active-route');
+    fireEvent.click(comparisonView);
+    expect(singleView).not.toHaveClass('active-route');
+    expect(comparisonView).toHaveClass('active-route');
+    fireEvent.click(singleView);
+    expect(singleView).toHaveClass('active-route');
+    expect(comparisonView).not.toHaveClass('active-route');
+  });
+  it('Successfully changes location when it changes externally', () => {
+    // Replace the listener implementation with a mock.
+    let registeredListener;
+    history.listen = (fn) => {
+      registeredListener = fn;
+      return () => {};
+    };
+
+    render(
+      <ShortcutProvider>
+        <Sidebar />
+      </ShortcutProvider>
+    );
+    expect(registeredListener).not.toBeUndefined();
+    const singleView = screen.getByTestId('sidebar-root');
+    const comparisonView = screen.getByTestId('sidebar-comparison');
+    fireEvent.click(comparisonView);
+    fireEvent.click(singleView);
+    expect(singleView).toHaveClass('active-route');
+    expect(comparisonView).not.toHaveClass('active-route');
+
+    // Changes the location on the history object
+    act(() => {
+      registeredListener({ pathname: '/comparison' });
+    });
+    expect(singleView).not.toHaveClass('active-route');
+    expect(comparisonView).toHaveClass('active-route');
+  });
+});


### PR DESCRIPTION
This can happen if the location changes without using the sidebar (pressing back/next in browser).

The sidebar component will now subscribe to changes.

closes https://github.com/pyroscope-io/pyroscope/issues/320.