### PR TITLE
Make sidebar links

### DIFF
--- a/webapp/__tests__/ShortcutsModal.spec.js
+++ b/webapp/__tests__/ShortcutsModal.spec.js
@@ -7,6 +7,7 @@ import { ShortcutProvider } from 'react-keybind';
 
 import ShortcutsModal from '../javascript/components/ShortcutsModal';
 import Sidebar from '../javascript/components/Sidebar';
+import { MemoryRouter } from 'react-router';
 
 const mockStore = configureMockStore();
 configure({ adapter: new Adapter() });
@@ -18,7 +19,9 @@ describe('ShortcutsModal', () => {
     const wrapper = mount(
       <Provider store={store}>
         <ShortcutProvider>
-          <Sidebar />
+          <MemoryRouter>
+            <Sidebar />
+          </MemoryRouter>
         </ShortcutProvider>
       </Provider>
     );

--- a/webapp/javascript/components/Sidebar.jsx
+++ b/webapp/javascript/components/Sidebar.jsx
@@ -87,7 +87,7 @@ function Sidebar(props) {
         <NavLink
           activeClassName="active-route"
           data-testid="sidebar-root"
-          to={`/${search}`}
+          to={{ pathname: '/', search }}
           exact
         >
           <FontAwesomeIcon icon={faWindowMaximize} />

--- a/webapp/javascript/components/Sidebar.jsx
+++ b/webapp/javascript/components/Sidebar.jsx
@@ -15,6 +15,7 @@ import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons/faSignOutAlt';
 import { faChartBar } from '@fortawesome/free-solid-svg-icons/faChartBar';
 import { faWindowMaximize } from '@fortawesome/free-regular-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons/faGithub';
+import { Link, NavLink } from 'react-router-dom';
 import ShortcutsModal from './ShortcutsModal';
 import SlackIcon from './SlackIcon';
 
@@ -54,31 +55,18 @@ function signOut() {
   form.submit();
 }
 
-const initialState = {
-  shortcutsModalOpen: false,
-  currentRoute: '/',
-};
-
 function Sidebar(props) {
   const { shortcut } = props;
 
-  const [state, setState] = useState(initialState);
+  const [shortcutsModalOpen, setShortcutsModalOpen] =
+    useState(shortcutsModalOpen);
 
   const showShortcutsModal = () => {
-    setState({ shortcutsModalOpen: true });
+    setShortcutsModalOpen(true);
   };
 
   const closeShortcutsModal = () => {
-    setState({ shortcutsModalOpen: false });
-  };
-
-  const updateRoute = (newRoute) => {
-    history.push({
-      pathname: newRoute,
-      search: history.location.search,
-    });
-
-    setState({ currentRoute: newRoute });
+    setShortcutsModalOpen(false);
   };
 
   useEffect(() => {
@@ -88,57 +76,40 @@ function Sidebar(props) {
       'Shortcuts',
       'Show Keyboard Shortcuts Modal'
     );
-
-    // console.log('history: ', history.location.pathname);
-    setState({ currentRoute: history.location.pathname });
-
-    function updatePath(location, action) {
-      setState({ currentRoute: location.pathname });
-    }
-
-    const removeupdatePath = history.listen(updatePath);
-
-    return () => {
-      removeupdatePath();
-    };
   }, []);
 
   return (
     <div className="sidebar">
-      <span className="logo" onClick={() => updateRoute('/')} />
+      <span className="logo" onClick={() => history.push('/')} />
       <SidebarItem tooltipText="Single View">
-        <button
-          className={clsx({ 'active-route': state.currentRoute === '/' })}
-          type="button"
+        <NavLink
+          activeClassName="active-route"
           data-testid="sidebar-root"
-          onClick={() => updateRoute('/')}
+          to="/"
+          exact
         >
           <FontAwesomeIcon icon={faWindowMaximize} />
-        </button>
+        </NavLink>
       </SidebarItem>
       <SidebarItem tooltipText="Comparison View">
-        <button
-          className={clsx({
-            'active-route': state.currentRoute === '/comparison',
-          })}
+        <NavLink
+          activeClassName="active-route"
           data-testid="sidebar-comparison"
-          type="button"
-          onClick={() => updateRoute('/comparison')}
+          to="/comparison"
+          exact
         >
           <FontAwesomeIcon icon={faColumns} />
-        </button>
+        </NavLink>
       </SidebarItem>
       <SidebarItem tooltipText="Diff View">
-        <button
-          className={clsx({
-            'active-route': state.currentRoute === '/comparison-diff',
-          })}
-          type="button"
+        <NavLink
+          activeClassName="active-route"
           data-testid="sidebar-comparison-diff"
-          onClick={() => updateRoute('/comparison-diff')}
+          to="/comparison-diff"
+          exact
         >
           <FontAwesomeIcon icon={faChartBar} />
-        </button>
+        </NavLink>
       </SidebarItem>
       <SidebarItem tooltipText="Alerts - Coming Soon">
         <button type="button">
@@ -184,7 +155,7 @@ function Sidebar(props) {
         []
       )}
       <Modal
-        isOpen={state.shortcutsModalOpen}
+        isOpen={shortcutsModalOpen}
         style={modalStyle}
         appElement={document.getElementById('root')}
         ariaHideApp={false}

--- a/webapp/javascript/components/Sidebar.jsx
+++ b/webapp/javascript/components/Sidebar.jsx
@@ -97,7 +97,7 @@ function Sidebar(props) {
         <NavLink
           activeClassName="active-route"
           data-testid="sidebar-comparison"
-          to={`/comparison${search}`}
+          to={{ pathname: '/comparison', search }}
           exact
         >
           <FontAwesomeIcon icon={faColumns} />
@@ -107,7 +107,7 @@ function Sidebar(props) {
         <NavLink
           activeClassName="active-route"
           data-testid="sidebar-comparison-diff"
-          to={`/comparison-diff${search}`}
+          to={{ pathname: '/comparison-diff', search }}
           exact
         >
           <FontAwesomeIcon icon={faChartBar} />

--- a/webapp/javascript/components/Sidebar.jsx
+++ b/webapp/javascript/components/Sidebar.jsx
@@ -15,7 +15,7 @@ import { faSignOutAlt } from '@fortawesome/free-solid-svg-icons/faSignOutAlt';
 import { faChartBar } from '@fortawesome/free-solid-svg-icons/faChartBar';
 import { faWindowMaximize } from '@fortawesome/free-regular-svg-icons';
 import { faGithub } from '@fortawesome/free-brands-svg-icons/faGithub';
-import { Link, NavLink } from 'react-router-dom';
+import { useLocation, NavLink } from 'react-router-dom';
 import ShortcutsModal from './ShortcutsModal';
 import SlackIcon from './SlackIcon';
 
@@ -61,6 +61,8 @@ function Sidebar(props) {
   const [shortcutsModalOpen, setShortcutsModalOpen] =
     useState(shortcutsModalOpen);
 
+  const { search } = useLocation();
+
   const showShortcutsModal = () => {
     setShortcutsModalOpen(true);
   };
@@ -85,7 +87,7 @@ function Sidebar(props) {
         <NavLink
           activeClassName="active-route"
           data-testid="sidebar-root"
-          to="/"
+          to={`/${search}`}
           exact
         >
           <FontAwesomeIcon icon={faWindowMaximize} />
@@ -95,7 +97,7 @@ function Sidebar(props) {
         <NavLink
           activeClassName="active-route"
           data-testid="sidebar-comparison"
-          to="/comparison"
+          to={`/comparison${search}`}
           exact
         >
           <FontAwesomeIcon icon={faColumns} />
@@ -105,7 +107,7 @@ function Sidebar(props) {
         <NavLink
           activeClassName="active-route"
           data-testid="sidebar-comparison-diff"
-          to="/comparison-diff"
+          to={`/comparison-diff${search}`}
           exact
         >
           <FontAwesomeIcon icon={faChartBar} />

--- a/webapp/javascript/components/Sidebar.spec.tsx
+++ b/webapp/javascript/components/Sidebar.spec.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { ShortcutProvider } from 'react-keybind';
 import Sidebar from './Sidebar';
-import history from '../util/history';
 
 jest.mock('react-redux', () => ({
   connect: () => (Component: any) => Component,
@@ -12,7 +12,9 @@ describe('Sidebar', () => {
   it('Successfully changes location when clicked', () => {
     render(
       <ShortcutProvider>
-        <Sidebar />
+        <MemoryRouter>
+          <Sidebar />
+        </MemoryRouter>
       </ShortcutProvider>
     );
     const singleView = screen.getByTestId('sidebar-root');
@@ -25,33 +27,5 @@ describe('Sidebar', () => {
     fireEvent.click(singleView);
     expect(singleView).toHaveClass('active-route');
     expect(comparisonView).not.toHaveClass('active-route');
-  });
-  it('Successfully changes location when it changes externally', () => {
-    // Replace the listener implementation with a mock.
-    let registeredListener;
-    history.listen = (fn) => {
-      registeredListener = fn;
-      return () => {};
-    };
-
-    render(
-      <ShortcutProvider>
-        <Sidebar />
-      </ShortcutProvider>
-    );
-    expect(registeredListener).not.toBeUndefined();
-    const singleView = screen.getByTestId('sidebar-root');
-    const comparisonView = screen.getByTestId('sidebar-comparison');
-    fireEvent.click(comparisonView);
-    fireEvent.click(singleView);
-    expect(singleView).toHaveClass('active-route');
-    expect(comparisonView).not.toHaveClass('active-route');
-
-    // Changes the location on the history object
-    act(() => {
-      registeredListener({ pathname: '/comparison' });
-    });
-    expect(singleView).not.toHaveClass('active-route');
-    expect(comparisonView).toHaveClass('active-route');
   });
 });


### PR DESCRIPTION
This PR uses the NavLink component on the sidebar to make these act as links. Because the history state is now managed by a 3rd party, we can safely remove the previous test as well (otherwise we would be basically testing the 3rd party library...).

closes https://github.com/pyroscope-io/pyroscope/issues/305