### PR TITLE
Decouple internal config from public CLI config in exec and server/storage

### DIFF
--- a/cmd/pyroscope/command/connect.go
+++ b/cmd/pyroscope/command/connect.go
@@ -16,7 +16,7 @@ func newConnectCmd(cfg *config.Exec) *cobra.Command {
 
 		DisableFlagParsing: true,
 		RunE: cli.CreateCmdRunFn(cfg, vpr, func(_ *cobra.Command, args []string) error {
-			return exec.Cli(cfg, args)
+			return exec.Cli(exec.NewConfig(cfg).WithConnect(), args)
 		}),
 	}
 

--- a/cmd/pyroscope/command/exec.go
+++ b/cmd/pyroscope/command/exec.go
@@ -20,7 +20,7 @@ func newExecCmd(cfg *config.Exec) *cobra.Command {
 
 		DisableFlagParsing: true,
 		RunE: cli.CreateCmdRunFn(cfg, vpr, func(_ *cobra.Command, args []string) error {
-			err := exec.Cli(cfg, args)
+			err := exec.Cli(exec.NewConfig(cfg), args)
 			// Normally, if the program ran, the call should return ExitError and
 			// the exit code must be preserved. Otherwise, the error originates from
 			// pyroscope and will be printed.

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -58,7 +58,7 @@ var _ = Describe("analytics", func() {
 					defer httpServer.Close()
 					url = httpServer.URL + "/api/events"
 
-					s, err := storage.New(&(*cfg).Server, prometheus.NewRegistry())
+					s, err := storage.New(storage.NewConfig(&(*cfg).Server), prometheus.NewRegistry())
 					Expect(err).ToNot(HaveOccurred())
 
 					analytics := NewService(&(*cfg).Server, s, mockStatsProvider{})

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -47,7 +47,7 @@ func newServerService(logger *logrus.Logger, c *config.Server) (*serverService, 
 	}
 
 	var err error
-	svc.storage, err = storage.New(svc.config, prometheus.DefaultRegisterer)
+	svc.storage, err = storage.New(storage.NewConfig(svc.config), prometheus.DefaultRegisterer)
 	if err != nil {
 		return nil, fmt.Errorf("new storage: %w", err)
 	}

--- a/pkg/dbmanager/cli.go
+++ b/pkg/dbmanager/cli.go
@@ -23,10 +23,8 @@ import (
 func Cli(dbCfg *config.DbManager, srvCfg *config.Server, args []string) error {
 	switch args[0] {
 	case "copy":
-		// TODO: this is meh, I think config.Config should be separate from storage config
-		srvCfg.StoragePath = dbCfg.StoragePath
-		srvCfg.LogLevel = "error"
-		err := copyData(dbCfg, srvCfg)
+		stCfg := storage.NewConfig(srvCfg).WithPath(dbCfg.StoragePath)
+		err := copyData(dbCfg, stCfg)
 		if err != nil {
 			return err
 		}
@@ -41,7 +39,7 @@ func Cli(dbCfg *config.DbManager, srvCfg *config.Server, args []string) error {
 const resolution = 10 * time.Second
 
 // src start time, src end time, dst start time
-func copyData(dbCfg *config.DbManager, srvCfg *config.Server) error {
+func copyData(dbCfg *config.DbManager, stCfg *storage.Config) error {
 	appName := dbCfg.ApplicationName
 	srcSt := dbCfg.SrcStartTime.Truncate(resolution)
 	dstSt := dbCfg.DstStartTime.Truncate(resolution)
@@ -62,7 +60,7 @@ func copyData(dbCfg *config.DbManager, srvCfg *config.Server) error {
 			"src start: %q end: %q, dst start: %q end: %q", srcSt, srcEt, dstSt, dstEt)
 	}
 
-	s, err := storage.New(srvCfg, prometheus.DefaultRegisterer)
+	s, err := storage.New(stCfg, prometheus.DefaultRegisterer)
 	if err != nil {
 		return err
 	}

--- a/pkg/exec/cli.go
+++ b/pkg/exec/cli.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pyroscope-io/pyroscope/pkg/agent/spy"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/types"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/upstream/remote"
-	"github.com/pyroscope-io/pyroscope/pkg/config"
 	"github.com/pyroscope-io/pyroscope/pkg/util/names"
 )
 
@@ -29,26 +28,22 @@ var disableMacOSChecks bool
 var disableLinuxChecks bool
 
 // Cli is command line interface for both exec and connect commands
-func Cli(cfg *config.Exec, args []string) error {
-	// isExec = true means we need to start the process first (pyroscope exec)
-	// isExec = false means the process is already there (pyroscope connect)
-	isExec := cfg.Pid == 0
-
-	if isExec {
+func Cli(cfg *Config, args []string) error {
+	if cfg.kind == exec {
 		if len(args) == 0 {
 			return errors.New("no arguments passed")
 		}
-	} else if (cfg.Pid != -1 && cfg.SpyName == "ebpfspy") && !processExists(cfg.Pid) {
+	} else if (cfg.pid != -1 && cfg.spyName == "ebpfspy") && !processExists(cfg.pid) {
 		return errors.New("process not found")
 	}
 
 	// TODO: this is somewhat hacky, we need to find a better way to configure agents
-	pyspy.Blocking = cfg.PyspyBlocking
-	rbspy.Blocking = cfg.RbspyBlocking
+	pyspy.Blocking = cfg.pyspyBlocking
+	rbspy.Blocking = cfg.rbspyBlocking
 
-	spyName := cfg.SpyName
+	spyName := cfg.spyName
 	if spyName == "auto" {
-		if isExec {
+		if cfg.kind == exec {
 			baseName := path.Base(args[0])
 			spyName = spy.ResolveAutoName(baseName)
 			if spyName == "" {
@@ -80,31 +75,23 @@ func Cli(cfg *config.Exec, args []string) error {
 	if err := performChecks(spyName); err != nil {
 		return err
 	}
-	if cfg.NoLogging {
-		logrus.SetLevel(logrus.PanicLevel)
-	} else if l, err := logrus.ParseLevel(cfg.LogLevel); err == nil {
-		logrus.SetLevel(l)
+	logrus.SetLevel(cfg.logLevel)
+	if cfg.logLevel != logrus.PanicLevel {
 		logrus.Info("to disable logging from pyroscope, specify " + color.YellowString("-no-logging") + " flag")
 	}
 
-	if cfg.ApplicationName == "" {
+	if cfg.applicationName == "" {
 		logrus.Infof("we recommend specifying application name via %s flag or env variable %s",
 			color.YellowString("-application-name"), color.YellowString("PYROSCOPE_APPLICATION_NAME"))
-		cfg.ApplicationName = spyName + "." + names.GetRandomName(generateSeed(args))
-		logrus.Infof("for now we chose the name for you and it's \"%s\"", color.GreenString(cfg.ApplicationName))
+		cfg.applicationName = spyName + "." + names.GetRandomName(generateSeed(args))
+		logrus.Infof("for now we chose the name for you and it's \"%s\"", color.GreenString(cfg.applicationName))
 	}
 
 	logrus.WithFields(logrus.Fields{
 		"args": fmt.Sprintf("%q", args),
 	}).Debug("starting command")
 
-	rc := remote.RemoteConfig{
-		AuthToken:              cfg.AuthToken,
-		UpstreamAddress:        cfg.ServerAddress,
-		UpstreamThreads:        cfg.UpstreamThreads,
-		UpstreamRequestTimeout: cfg.UpstreamRequestTimeout,
-	}
-	u, err := remote.New(rc, logrus.StandardLogger())
+	u, err := remote.New(cfg.RemoteConfig, logrus.StandardLogger())
 	if err != nil {
 		return fmt.Errorf("new remote upstream: %v", err)
 	}
@@ -114,9 +101,9 @@ func Cli(cfg *config.Exec, args []string) error {
 	// the expected signal rate (in case of Exec all the signals to be relayed
 	// to the child process)
 	c := make(chan os.Signal, 10)
-	pid := cfg.Pid
+	pid := cfg.pid
 	var cmd *goexec.Cmd
-	if isExec {
+	if cfg.kind == exec {
 		// Note that we don't specify which signals to be sent: any signal to be
 		// relayed to the child process (including SIGINT and SIGTERM).
 		signal.Notify(c)
@@ -140,27 +127,22 @@ func Cli(cfg *config.Exec, args []string) error {
 	}()
 
 	logrus.WithFields(logrus.Fields{
-		"app-name":            cfg.ApplicationName,
+		"app-name":            cfg.applicationName,
 		"spy-name":            spyName,
 		"pid":                 pid,
-		"detect-subprocesses": cfg.DetectSubprocesses,
+		"detect-subprocesses": cfg.detectSubprocesses,
 	}).Debug("starting agent session")
-
-	// if the sample rate is zero, use the default value
-	if cfg.SampleRate == 0 {
-		cfg.SampleRate = types.DefaultSampleRate
-	}
 
 	sc := agent.SessionConfig{
 		Upstream:         u,
-		AppName:          cfg.ApplicationName,
-		Tags:             cfg.Tags,
+		AppName:          cfg.applicationName,
+		Tags:             cfg.tags,
 		ProfilingTypes:   []spy.ProfileType{spy.ProfileCPU},
 		SpyName:          spyName,
-		SampleRate:       uint32(cfg.SampleRate),
+		SampleRate:       cfg.sampleRate,
 		UploadRate:       10 * time.Second,
 		Pid:              pid,
-		WithSubprocesses: cfg.DetectSubprocesses,
+		WithSubprocesses: cfg.detectSubprocesses,
 		Logger:           logrus.StandardLogger(),
 	}
 	session, err := agent.NewSession(sc)
@@ -172,7 +154,7 @@ func Cli(cfg *config.Exec, args []string) error {
 	}
 	defer session.Stop()
 
-	if isExec {
+	if cfg.kind == exec {
 		return waitForSpawnedProcessToExit(c, cmd)
 	}
 

--- a/pkg/exec/cli_unix.go
+++ b/pkg/exec/cli_unix.go
@@ -12,14 +12,12 @@ import (
 
 	"github.com/shirou/gopsutil/process"
 	"github.com/sirupsen/logrus"
-
-	"github.com/pyroscope-io/pyroscope/pkg/config"
 )
 
-func adjustCmd(cmd *goexec.Cmd, cfg config.Exec) error {
+func adjustCmd(cmd *goexec.Cmd, cfg Config) error {
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
 	// permissions drop
-	if isRoot() && !cfg.NoRootDrop && os.Getenv("SUDO_UID") != "" && os.Getenv("SUDO_GID") != "" {
+	if isRoot() && !cfg.noRootDrop && os.Getenv("SUDO_UID") != "" && os.Getenv("SUDO_GID") != "" {
 		creds, err := generateCredentialsDrop()
 		if err != nil {
 			logrus.Errorf("failed to drop permissions, %q", err)
@@ -28,8 +26,8 @@ func adjustCmd(cmd *goexec.Cmd, cfg config.Exec) error {
 		}
 	}
 
-	if cfg.UserName != "" || cfg.GroupName != "" {
-		creds, err := generateCredentials(cfg.UserName, cfg.GroupName)
+	if cfg.userName != "" || cfg.groupName != "" {
+		creds, err := generateCredentials(cfg.userName, cfg.groupName)
 		if err != nil {
 			logrus.Errorf("failed to generate credentials: %q", err)
 		} else {

--- a/pkg/exec/config.go
+++ b/pkg/exec/config.go
@@ -1,0 +1,82 @@
+package exec
+
+import (
+	"github.com/pyroscope-io/pyroscope/pkg/agent/types"
+	"github.com/pyroscope-io/pyroscope/pkg/agent/upstream/remote"
+	"github.com/pyroscope-io/pyroscope/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+type kind int
+
+const (
+	exec kind = iota
+	connect
+)
+
+type Config struct {
+	kind     kind
+	logLevel logrus.Level
+
+	// Spies
+	pyspyBlocking bool
+	rbspyBlocking bool
+
+	// Connect
+	pid int
+
+	// Exec
+	noRootDrop bool
+	userName   string
+	groupName  string
+
+	// Remote upload
+	remote.RemoteConfig
+
+	// Session
+	spyName            string
+	applicationName    string
+	sampleRate         uint32
+	detectSubprocesses bool
+	tags               map[string]string
+}
+
+func NewConfig(c *config.Exec) *Config {
+	logLevel := logrus.PanicLevel
+	if l, err := logrus.ParseLevel(c.LogLevel); !c.NoLogging && err == nil {
+		logLevel = l
+	}
+
+	// if the sample rate is zero, use the default value
+	sampleRate := uint32(types.DefaultSampleRate)
+	if c.SampleRate != 0 {
+		sampleRate = uint32(c.SampleRate)
+	}
+
+	return &Config{
+		kind:          exec,
+		logLevel:      logLevel,
+		pyspyBlocking: c.PyspyBlocking,
+		rbspyBlocking: c.RbspyBlocking,
+		pid:           c.Pid,
+		noRootDrop:    c.NoRootDrop,
+		userName:      c.UserName,
+		groupName:     c.GroupName,
+		RemoteConfig: remote.RemoteConfig{
+			AuthToken:              c.AuthToken,
+			UpstreamAddress:        c.ServerAddress,
+			UpstreamThreads:        c.UpstreamThreads,
+			UpstreamRequestTimeout: c.UpstreamRequestTimeout,
+		},
+		spyName:            c.SpyName,
+		applicationName:    c.ApplicationName,
+		sampleRate:         sampleRate,
+		detectSubprocesses: c.DetectSubprocesses,
+		tags:               c.Tags,
+	}
+}
+
+func (c *Config) WithConnect() *Config {
+	c.kind = connect
+	return c
+}

--- a/pkg/exec/config.go
+++ b/pkg/exec/config.go
@@ -1,10 +1,11 @@
 package exec
 
 import (
+	"github.com/sirupsen/logrus"
+
 	"github.com/pyroscope-io/pyroscope/pkg/agent/types"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/upstream/remote"
 	"github.com/pyroscope-io/pyroscope/pkg/config"
-	"github.com/sirupsen/logrus"
 )
 
 type kind int

--- a/pkg/exec/config_test.go
+++ b/pkg/exec/config_test.go
@@ -5,8 +5,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pyroscope-io/pyroscope/pkg/config"
 	"github.com/sirupsen/logrus"
+
+	"github.com/pyroscope-io/pyroscope/pkg/config"
 )
 
 var _ = Describe("Exec config", func() {

--- a/pkg/exec/config_test.go
+++ b/pkg/exec/config_test.go
@@ -1,0 +1,75 @@
+package exec
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pyroscope-io/pyroscope/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+var _ = Describe("Exec config", func() {
+	Context("Default config", func() {
+		cfg := config.Exec{
+			SpyName:                "spy-name",
+			ApplicationName:        "application-name",
+			SampleRate:             100,
+			DetectSubprocesses:     true,
+			LogLevel:               "info",
+			ServerAddress:          "http://localhost:4040",
+			AuthToken:              "auth-token",
+			UpstreamThreads:        4,
+			UpstreamRequestTimeout: 10 * time.Second,
+			NoLogging:              false,
+			NoRootDrop:             true,
+			Pid:                    1000,
+			UserName:               "user-name",
+			GroupName:              "group-name",
+			PyspyBlocking:          true,
+			RbspyBlocking:          true,
+			Tags:                   map[string]string{"key": "value"},
+		}
+
+		It("NewConfig returns exec config", func() {
+			c := NewConfig(&cfg)
+			Expect(c.kind).To(Equal(exec))
+			Expect(c.spyName).To(Equal("spy-name"))
+			Expect(c.applicationName).To(Equal("application-name"))
+			Expect(c.sampleRate).To(Equal(uint32(100)))
+			Expect(c.detectSubprocesses).To(BeTrue())
+			Expect(c.logLevel).To(Equal(logrus.InfoLevel))
+			Expect(c.RemoteConfig.UpstreamAddress).To(Equal(cfg.ServerAddress))
+			Expect(c.RemoteConfig.AuthToken).To(Equal(cfg.AuthToken))
+			Expect(c.RemoteConfig.UpstreamThreads).To(Equal(cfg.UpstreamThreads))
+			Expect(c.RemoteConfig.UpstreamRequestTimeout).To(Equal(cfg.UpstreamRequestTimeout))
+			Expect(c.noRootDrop).To(BeTrue())
+			Expect(c.pid).To(Equal(1000))
+			Expect(c.userName).To(Equal("user-name"))
+			Expect(c.groupName).To(Equal("group-name"))
+			Expect(c.pyspyBlocking).To(BeTrue())
+			Expect(c.rbspyBlocking).To(BeTrue())
+			Expect(c.tags).To(HaveLen(1))
+			Expect(c.tags).To(HaveKeyWithValue("key", "value"))
+		})
+
+		It("WithConnect returns connect config", func() {
+			c := NewConfig(&cfg).WithConnect()
+			Expect(c.kind).To(Equal(connect))
+		})
+	})
+
+	Context("Config with no logging", func() {
+		It("NewConfig returns config with Panic log level", func() {
+			c := NewConfig(&config.Exec{NoLogging: true})
+			Expect(c.logLevel).To(Equal(logrus.PanicLevel))
+		})
+	})
+
+	Context("Config without sample rate", func() {
+		It("NewConfig returns config with default sampling rate", func() {
+			c := NewConfig(&config.Exec{})
+			Expect(c.sampleRate).To(Equal(uint32(100)))
+		})
+	})
+})

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -18,14 +18,14 @@ var _ = Describe("Cli", func() {
 		Describe("Cli", func() {
 			Context("no arguments", func() {
 				It("returns error", func() {
-					err := Cli(&(*cfg).Exec, []string{})
+					err := Cli(NewConfig(&(*cfg).Exec), []string{})
 					Expect(err).To(MatchError("no arguments passed"))
 				})
 			})
 			Context("simple case", func() {
 				It("returns nil", func() {
 					(*cfg).Exec.SpyName = "debugspy"
-					err := Cli(&(*cfg).Exec, []string{"ls"})
+					err := Cli(NewConfig(&(*cfg).Exec), []string{"ls"})
 					Expect(err).ToNot(HaveOccurred())
 				})
 			})

--- a/pkg/server/build_test.go
+++ b/pkg/server/build_test.go
@@ -27,7 +27,7 @@ var _ = Describe("server", func() {
 					defer GinkgoRecover()
 
 					(*cfg).Server.APIBindAddr = ":10044"
-					s, err := storage.New(&(*cfg).Server, prometheus.NewRegistry())
+					s, err := storage.New(storage.NewConfig(&(*cfg).Server), prometheus.NewRegistry())
 					Expect(err).ToNot(HaveOccurred())
 					e, _ := exporter.NewExporter(nil, nil)
 					c, _ := New(Config{

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -26,7 +26,7 @@ var _ = Describe("server", func() {
 					defer GinkgoRecover()
 
 					(*cfg).Server.APIBindAddr = ":10045"
-					s, err := storage.New(&(*cfg).Server, prometheus.NewRegistry())
+					s, err := storage.New(storage.NewConfig(&(*cfg).Server), prometheus.NewRegistry())
 					Expect(err).ToNot(HaveOccurred())
 					e, _ := exporter.NewExporter(nil, nil)
 					c, _ := New(Config{

--- a/pkg/server/controller_gzip_test.go
+++ b/pkg/server/controller_gzip_test.go
@@ -39,7 +39,7 @@ var _ = Describe("server", func() {
 					defer GinkgoRecover()
 
 					(*cfg).Server.APIBindAddr = ":10045"
-					s, err := storage.New(&(*cfg).Server, prometheus.NewRegistry())
+					s, err := storage.New(storage.NewConfig(&(*cfg).Server), prometheus.NewRegistry())
 					Expect(err).ToNot(HaveOccurred())
 					e, _ := exporter.NewExporter(nil, nil)
 					c, _ := New(Config{

--- a/pkg/server/controller_https_test.go
+++ b/pkg/server/controller_https_test.go
@@ -32,7 +32,7 @@ var _ = Describe("server", func() {
 					(*cfg).Server.TLSCertificateFile = filepath.Join(testDataDir, tlsCertificateFile)
 					(*cfg).Server.TLSKeyFile = filepath.Join(testDataDir, tlsKeyFile)
 
-					s, err := storage.New(&(*cfg).Server, prometheus.NewRegistry())
+					s, err := storage.New(storage.NewConfig(&(*cfg).Server), prometheus.NewRegistry())
 					Expect(err).ToNot(HaveOccurred())
 					e, _ := exporter.NewExporter(nil, nil)
 					c, _ := New(Config{
@@ -71,7 +71,7 @@ var _ = Describe("server", func() {
 					const addr = ":10046"
 					(*cfg).Server.APIBindAddr = addr
 
-					s, err := storage.New(&(*cfg).Server, prometheus.NewRegistry())
+					s, err := storage.New(storage.NewConfig(&(*cfg).Server), prometheus.NewRegistry())
 					Expect(err).ToNot(HaveOccurred())
 					e, _ := exporter.NewExporter(nil, nil)
 					c, _ := New(Config{

--- a/pkg/server/ingest_test.go
+++ b/pkg/server/ingest_test.go
@@ -39,7 +39,7 @@ var _ = Describe("server", func() {
 					done := make(chan interface{})
 					go func() {
 						defer GinkgoRecover()
-						s, err := storage.New(&(*cfg).Server, prometheus.NewRegistry())
+						s, err := storage.New(storage.NewConfig(&(*cfg).Server), prometheus.NewRegistry())
 						Expect(err).ToNot(HaveOccurred())
 						e, _ := exporter.NewExporter(nil, nil)
 						c, _ := New(Config{

--- a/pkg/server/render_test.go
+++ b/pkg/server/render_test.go
@@ -66,7 +66,7 @@ var _ = Describe("server", func() {
 			It("supports name and query parameters", func() {
 				var httpServer *httptest.Server
 				(*cfg).Server.APIBindAddr = ":10044"
-				s, err := storage.New(&(*cfg).Server, prometheus.NewRegistry())
+				s, err := storage.New(storage.NewConfig(&(*cfg).Server), prometheus.NewRegistry())
 				Expect(err).ToNot(HaveOccurred())
 				e, _ := exporter.NewExporter(nil, nil)
 				c, _ := New(Config{

--- a/pkg/storage/codec.go
+++ b/pkg/storage/codec.go
@@ -20,7 +20,7 @@ func (c treeCodec) Serialize(w io.Writer, k string, v interface{}) error {
 	if err != nil {
 		return fmt.Errorf("dicts cache for %v: %w", key, err)
 	}
-	err = v.(*tree.Tree).SerializeTruncate(d.(*dict.Dict), c.config.MaxNodesSerialization, w)
+	err = v.(*tree.Tree).SerializeTruncate(d.(*dict.Dict), c.config.maxNodesSerialization, w)
 	if err != nil {
 		return fmt.Errorf("serialize %v: %w", key, err)
 	}

--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -1,0 +1,38 @@
+package storage
+
+import (
+	"time"
+
+	"github.com/pyroscope-io/pyroscope/pkg/config"
+)
+
+type Config struct {
+	badgerLogLevel        string
+	badgerNoTruncate      bool
+	badgerBasePath        string
+	cacheEvictThreshold   float64
+	cacheEvictVolume      float64
+	maxNodesSerialization int
+	retention             time.Duration
+	hideApplications      []string
+}
+
+// NewConfig returns a new storage config from a server config
+func NewConfig(server *config.Server) *Config {
+	return &Config{
+		badgerLogLevel:        server.BadgerLogLevel,
+		badgerBasePath:        server.StoragePath,
+		badgerNoTruncate:      server.BadgerNoTruncate,
+		cacheEvictThreshold:   server.CacheEvictThreshold,
+		cacheEvictVolume:      server.CacheEvictVolume,
+		maxNodesSerialization: server.MaxNodesSerialization,
+		retention:             server.Retention,
+		hideApplications:      server.HideApplications,
+	}
+}
+
+// WithPath sets the storage base path
+func (c *Config) WithPath(path string) *Config {
+	c.badgerBasePath = path
+	return c
+}

--- a/pkg/storage/config_test.go
+++ b/pkg/storage/config_test.go
@@ -1,0 +1,46 @@
+package storage
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pyroscope-io/pyroscope/pkg/config"
+)
+
+var _ = Describe("Storage config", func() {
+	cfg := config.Server{
+		BadgerLogLevel:        "debug",
+		StoragePath:           "/var/lib/pyroscope",
+		CacheEvictThreshold:   0.25,
+		CacheEvictVolume:      0.33,
+		BadgerNoTruncate:      true,
+		MaxNodesSerialization: 2048,
+		HideApplications:      []string{"app"},
+		Retention:             24 * time.Hour,
+		SampleRate:            100,
+		CacheDimensionSize:    1,
+		CacheDictionarySize:   1,
+		CacheSegmentSize:      1,
+		CacheTreeSize:         1,
+	}
+	Context("Basic config", func() {
+		It("NewConfig returns storage config", func() {
+			c := NewConfig(&cfg)
+			Expect(c.badgerLogLevel).To(Equal("debug"))
+			Expect(c.badgerNoTruncate).To(BeTrue())
+			Expect(c.badgerBasePath).To(Equal("/var/lib/pyroscope"))
+			Expect(c.cacheEvictThreshold).To(Equal(0.25))
+			Expect(c.cacheEvictVolume).To(Equal(0.33))
+			Expect(c.maxNodesSerialization).To(Equal(2048))
+			Expect(c.retention).To(Equal(24 * time.Hour))
+			Expect(c.hideApplications).To(HaveLen(1))
+			Expect(c.hideApplications).To(ContainElement("app"))
+		})
+
+		It("WithPath returns storage config with overriden storage base path", func() {
+			c := NewConfig(&cfg).WithPath("/tmp/pyroscope")
+			Expect(c.badgerBasePath).To(Equal("/tmp/pyroscope"))
+		})
+	})
+})

--- a/pkg/storage/config_test.go
+++ b/pkg/storage/config_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	"github.com/pyroscope-io/pyroscope/pkg/config"
 )
 

--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -105,7 +105,7 @@ func (s *Storage) PutLocal(po *PutInput) error {
 	varint.Write(&buf, uint64(len(mb)))
 	buf.Write(mb)
 
-	if err := t.SerializeNoDict(s.config.MaxNodesSerialization, &buf); err != nil {
+	if err := t.SerializeNoDict(s.config.maxNodesSerialization, &buf); err != nil {
 		return err
 	}
 

--- a/pkg/storage/periodic.go
+++ b/pkg/storage/periodic.go
@@ -52,8 +52,8 @@ func (s *Storage) evictionTask(memTotal uint64) func() {
 		s.evictionsAllocBytes.Set(float64(m.Alloc))
 		s.evictionsTotalBytes.Set(float64(memTotal))
 
-		percent := s.config.CacheEvictVolume
-		if used > s.config.CacheEvictThreshold {
+		percent := s.config.cacheEvictVolume
+		if used > s.config.cacheEvictThreshold {
 			func() {
 				timer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
 					logrus.Debugf("eviction task took %f seconds\n", v)

--- a/pkg/storage/query_test.go
+++ b/pkg/storage/query_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Querying", func() {
 	testing.WithConfig(func(cfg **config.Config) {
 		JustBeforeEach(func() {
 			var err error
-			s, err = New(&(*cfg).Server, prometheus.NewRegistry())
+			s, err = New(NewConfig(&(*cfg).Server), prometheus.NewRegistry())
 			Expect(err).ToNot(HaveOccurred())
 			keys := []string{
 				"app.name{foo=bar,baz=qux}",

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -34,7 +34,7 @@ var _ = Describe("storage package", func() {
 			evictInterval = 2 * time.Second
 
 			var err error
-			s, err = New(&(*cfg).Server, prometheus.NewRegistry())
+			s, err = New(NewConfig(&(*cfg).Server), prometheus.NewRegistry())
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -333,7 +333,7 @@ var _ = Describe("storage package", func() {
 					Expect(o.Tree.String()).To(Equal(tree.String()))
 					Expect(s.Close()).ToNot(HaveOccurred())
 
-					s2, err := New(&(*cfg).Server, prometheus.NewRegistry())
+					s2, err := New(NewConfig(&(*cfg).Server), prometheus.NewRegistry())
 					Expect(err).ToNot(HaveOccurred())
 
 					o2, err := s2.Get(&GetInput{
@@ -355,7 +355,7 @@ var _ = Describe("DeleteDataBefore", func() {
 	testing.WithConfig(func(cfg **config.Config) {
 		JustBeforeEach(func() {
 			var err error
-			s, err = New(&(*cfg).Server, prometheus.NewRegistry())
+			s, err = New(NewConfig(&(*cfg).Server), prometheus.NewRegistry())
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/pkg/testing/load/cmd/dataloader/main.go
+++ b/pkg/testing/load/cmd/dataloader/main.go
@@ -42,13 +42,12 @@ func openStorage(path string) (*storage.Storage, error) {
 	if err := os.MkdirAll(path, 0755); err != nil {
 		return nil, err
 	}
-	return storage.New(&config.Server{
+	return storage.New(storage.NewConfig(&config.Server{
 		StoragePath:           path,
 		CacheEvictThreshold:   0.02,
 		CacheEvictVolume:      0.10,
 		MaxNodesSerialization: 2048,
-		MaxNodesRender:        2048,
-	}, prometheus.NewRegistry())
+	}), prometheus.NewRegistry())
 }
 
 func main() {


### PR DESCRIPTION
Internal components' configuration is coupled to public CLI configuration, which makes evolving public and internal configurations independently is harder than it should. This goes both
ways, e.g.:
- Deprecated configuration variables are still accessible internally.
- Adding internal configuration variables without exposing them publicly is hard.

The case of the storage component is worse, as it has access to a lot of unneeded server configuration variables.

While this problem already shows in the code (in how `dbmanager` was implemented, or exec/connect distinction, for example), it may become worse with `adhoc` mode (where we may want to use in-memory storage, direct upload, remove server app, etc.).

This refactor tries to solve this problem by isolating public and private configurations through a public API to build the internal config (through NewConfig and With* methods, as needed) for the `Exec` and `Storage` components, but it could also be extended to other components as needed.