### PR TITLE
simplify local dev

### DIFF
--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -18,25 +18,9 @@ module.exports = merge(common, {
   },
 
   plugins: [
-    new HtmlWebpackPlugin({
-      // fetch index.html from the go server
-      templateContent: () => {
-        let res;
-        let maxTries = 24;
-        do {
-          if (maxTries <= 0) {
-            throw new Error(
-              'Could not find pyroscope instance running on http://localhost:4040. Make sure you have pyroscope server running on port :4040 (run `make build server`)'
-            );
-          }
-          res = request('GET', 'http://localhost:4040');
-          sleep(1000);
-          maxTries -= 1;
-        } while (res.statusCode !== 200);
-
-        return res.getBody('utf8');
-      },
-    }),
+    // create a server on port 4041 with live reload
+    // it will serve all static assets com webapp/public/assets
+    // and for the endpoints it will redirect to the go server (on port 4040)
     new WebpackPluginServe({
       port: 4041,
       static: path.resolve(__dirname, '../../webapp/public/assets'),
@@ -66,6 +50,28 @@ module.exports = merge(common, {
             );
           })
         );
+      },
+    }),
+
+    // serve index.html from the go server
+    // and additionally inject anything else required (eg livereload ws)
+    new HtmlWebpackPlugin({
+      // fetch index.html from the go server
+      templateContent: () => {
+        let res;
+        let maxTries = 24;
+        do {
+          if (maxTries <= 0) {
+            throw new Error(
+              'Could not find pyroscope instance running on http://localhost:4040. Make sure you have pyroscope server running on port :4040'
+            );
+          }
+          res = request('GET', 'http://localhost:4040');
+          sleep(1000);
+          maxTries -= 1;
+        } while (res.statusCode !== 200);
+
+        return res.getBody('utf8');
       },
     }),
   ],


### PR DESCRIPTION
Starting from a clean env

```
make install-dev-tools
make build-third-party-dependencies
make install-web-dependencies

make dev
``` 
Should work now

@abeaumont pleeease can you check it works for you?

If it works I will update the documentation later.

---
Just some explanation, by moving `WebpackPluginServe` to the front, we wait for the build to be finished (`waitForBuild`), which generates `webapp/public/assets`, which the go server serves. The `HtmlWebpackPlugin` hits the go server and serves that under the port `4041`. Whew.