### PR TITLE
Downgrade minimal node engine version required from 11 to 10.

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "size-limit": "^6.0.3"
   },
   "engines": {
-    "node": ">=11"
+    "node": ">=10"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
Downgrading supports older v10 versions, which seem to work fine.