### PR TITLE
chore: skip admin test that creates files in non accessible path when root

### DIFF
--- a/pkg/admin/http_over_uds_server_test.go
+++ b/pkg/admin/http_over_uds_server_test.go
@@ -3,6 +3,7 @@ package admin_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -31,6 +32,11 @@ var _ = Describe("HTTP Over UDS", func() {
 
 	When("passed a non existing socket address", func() {
 		It("should give an error", func() {
+			// if user is root, s/he can create the socket anywhere
+			if os.Getuid() == 0 {
+				Skip("test is invalid when running as root")
+			}
+
 			_, err := admin.NewUdsHTTPServer("/non_existing_path")
 
 			// TODO how to test for wrapped errors?


### PR DESCRIPTION

@abeaumont mentioned while [running linux tests](https://github.com/pyroscope-io/pyroscope/pull/532), that one of the admin tests was failing:
```
------------------------------ 
• Failure [0.000 seconds] 
HTTP Over UDS 
/home/abeaumont/p/pyroscope/pkg/admin/http_over_uds_server_test.go:17 
when passed a non existing socket address 
/home/abeaumont/p/pyroscope/pkg/admin/http_over_uds_server_test.go:32 
should give an error [It] 
/home/abeaumont/p/pyroscope/pkg/admin/http_over_uds_server_test.go:33 
 
Expected an error to have occurred. Got: 
<nil>: nil 
 
/home/abeaumont/p/pyroscope/pkg/admin/http_over_uds_server_test.go:38 
------------------------------ 
••• 
 
Summarizing 1 Failure: 
 
[Fail] HTTP Over UDS when passed a non existing socket address [It] should give an error 
/home/abeaumont/p/pyroscope/pkg/admin/http_over_uds_server_test.go:38
```

Although it's a use case not really supported by us (running as root), It doesn't take much to skip it, so here I am.

If you have any other ideas on how to bypass/fix this test, feel free to suggest them.