### PR TITLE
feat: add shell completion for 'admin app delete' cmd

### DIFF
--- a/cmd/pyroscope/command/admin.go
+++ b/cmd/pyroscope/command/admin.go
@@ -80,6 +80,23 @@ func newAdminAppDeleteCmd(cfg *config.Admin) *cobra.Command {
 		Short: "delete an app",
 		Long:  "delete an app",
 		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) != 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			cli, err := admin.NewCLI(cfg.SocketPath)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			appNames, err := cli.CompleteApp(toComplete)
+			if err != nil {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			return appNames, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: cli.CreateCmdRunFn(cfg, vpr, func(_ *cobra.Command, arg []string) error {
 			cli, err := admin.NewCLI(cfg.SocketPath)
 			if err != nil {

--- a/pkg/admin/cli.go
+++ b/pkg/admin/cli.go
@@ -66,3 +66,16 @@ func (c *CLI) DeleteApp(appname string) error {
 	fmt.Println(fmt.Sprintf("Deleted app '%s'.", appname))
 	return nil
 }
+
+// CompleteApp returns the list of apps
+// it's meant for cobra's autocompletion
+// TODO use the parameter for fuzzy search?
+func (c *CLI) CompleteApp(_ string) (appNames []string, err error) {
+	appNames, err = c.client.GetAppsNames()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return appNames, err
+}


### PR DESCRIPTION
Since the delete API is idempotent, ie, it won't fail if delete a non existent app, the cli ux could be a bit weird, since typos won't be immediately noticed.
We decided that as an easy improvement is to add autocomplete to the delete command, now at least it's less prone to typo.

For illustration, on my machine, `pyroscope admin app delete [tab][tab]` yields
![image](https://user-images.githubusercontent.com/6951209/142032812-ce4635bf-e441-47f5-9fba-da4d0a424417.png)
