### PR TITLE
chore: retry cypress tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,7 @@
 {
   "video": false,
-  "baseUrl": "http://localhost:4040"
+  "baseUrl": "http://localhost:4040",
+  "retries": {
+    "runMode": 2
+  }
 }


### PR DESCRIPTION
we noticed tests sometimes fail with false negatives (specially the screenshot ones)

this commit uses Test Retries
https://docs.cypress.io/guides/guides/test-retries#Only-upload-videos-for-specs-with-failing-or-retried-tests
to retry each failed test up to 3 times
that should be enough to get rid of most flakyness and also not be slow
enough to delay real failures too much