### PR TITLE
Fix race condition in version update.

### DIFF
--- a/pkg/util/updates/updates.go
+++ b/pkg/util/updates/updates.go
@@ -15,8 +15,11 @@ var latestVersionStruct struct {
 }
 
 var runOnce sync.Once
+var m sync.RWMutex
 
 func LatestVersionJSON() string {
+	m.RLock()
+	defer m.RUnlock()
 	b, _ := json.Marshal(latestVersionStruct)
 	return string(b)
 }
@@ -32,6 +35,8 @@ func updateLatestVersion() error {
 		return err
 	}
 
+	m.Lock()
+	defer m.Unlock()
 	err = json.Unmarshal(b, &latestVersionStruct)
 	if err != nil {
 		return err


### PR DESCRIPTION
The testsuite (sometimes) fails due to this race condition.
Even if runOnce guarantees that there's a single writer, there can
still be concurrent read and writes. A read/write lock prevents this
from happening.