### PR TITLE
chore: improve error message for when admin server is not up

### DIFF
--- a/pkg/admin/cli.go
+++ b/pkg/admin/cli.go
@@ -14,8 +14,9 @@ func (e CLIError) Error() string {
 	if errors.Is(e.err, ErrMakingRequest) {
 		return fmt.Sprintf(`failed to contact the admin socket server. 
 this may happen if
-a) the admin socket server is not running
+a) pyroscope server is not running
 b) the socket path is incorrect
+c) admin features are not enabled, in that case check the server flags
 
 %v`, e.err)
 	}

--- a/pkg/admin/cli.go
+++ b/pkg/admin/cli.go
@@ -81,9 +81,14 @@ func (c *CLI) CompleteApp(_ string) (appNames []string, err error) {
 	return appNames, err
 }
 
-func (c *CLI) enhanceError(err error) error {
+func (*CLI) enhanceError(err error) error {
 	if errors.Is(err, ErrMakingRequest) {
-		return fmt.Errorf("failed to contact the admin socket server. \nthis may happen if \na) the admin socket server is not running \nb) the socket path is incorrect \n\nadditional info: %w", err)
+		return fmt.Errorf(`failed to contact the admin socket server. 
+this may happen if 
+a) the admin socket server is not running
+b) the socket path is incorrect
+
+additional info: %w`, err)
 	}
 
 	return err

--- a/pkg/admin/client.go
+++ b/pkg/admin/client.go
@@ -20,7 +20,7 @@ const AppsEndpoint = "http://pyroscope/v1/apps"
 
 var (
 	ErrHTTPClientCreation = errors.New("failed to create http over uds client")
-	ErrMakingRequest      = errors.New("failed while making a request")
+	ErrMakingRequest      = errors.New("failed to make a request")
 	ErrStatusCodeNotOK    = errors.New("failed to get a response with a valid status code")
 	ErrDecodingResponse   = errors.New("error while decoding a (assumed) json response")
 	ErrMarshalingPayload  = errors.New("error while marshalling the payload")

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -58,9 +57,6 @@ func newServerService(logger *logrus.Logger, c *config.Server) (*serverService, 
 	// this needs to happen after storage is initiated!
 	if svc.config.EnableExperimentalAdmin {
 		socketPath := svc.config.AdminSocketPath
-		if socketPath == "" {
-			socketPath = filepath.Join(svc.config.StoragePath, "/pyroscope.sock")
-		}
 		adminSvc := admin.NewService(svc.storage)
 		adminCtrl := admin.NewController(svc.logger, adminSvc)
 		adminHTTPOverUDS, err := admin.NewUdsHTTPServer(socketPath)


### PR DESCRIPTION
For illustration: 
```
$ pyroscope admin app get

Error: failed to contact the admin socket server. 
this may happen if 
a) the admin socket server is not running 
b) the socket path is incorrect 

additional info: 2 errors occurred:
        * failed to make a request
        * Get "http://pyroscope/v1/apps": dial unix /tmp/pyroscope.sock: connect: no such file or directory
```