### PR TITLE
Fix the stack overflow on Alpine generated binaries.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,7 +101,12 @@ COPY webapp/assets_embedded.go ./webapp/assets_embedded.go
 COPY webapp/assets.go ./webapp/assets.go
 COPY scripts ./scripts
 
-RUN EMBEDDED_ASSETS_DEPS="" EXTRA_LDFLAGS="-linkmode external -extldflags '-static'" make build-release
+# Alpine's default stack size too small for pyspy, causing exec mode with pyspy to segfault.
+# See https://github.com/pyroscope-io/pyroscope/issues/503
+RUN EMBEDDED_ASSETS_DEPS="" \
+    CGO_LDFLAGS_ALLOW="-Wl,-z,stack-size=0x200000" \
+    EXTRA_LDFLAGS="-linkmode external -extldflags '-static -Wl,-z,stack-size=0x200000'" \
+    make build-release
 
 #      _        _   _        _ _ _
 #     | |      | | (_)      | (_) |


### PR DESCRIPTION
Currently, running the published pyroscope binary or running a docker
container on exec mode to run Python programs causes a segmentation
fault, due to a stack overflow.
This doesn't seem to affect to binaries generated by other Linux
distributions, so Alpine setting a smaller default stack size maybe
the cause.
The default is overridden with a 2MB stack, which seems to be enough to
solve the problem.

Fixes #503 