### PR TITLE
chore: use gorilla mux for admin server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/google/go-jsonnet v0.17.0
 	github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5
 	github.com/google/uuid v1.1.2
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/iancoleman/strcase v0.2.0
 	github.com/imdario/mergo v0.3.11 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/fatih/color v1.10.0
 	github.com/felixge/fgprof v0.9.1
+	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/go-ole/go-ole v1.2.5 // indirect
 	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/golang/protobuf v1.5.2
@@ -26,6 +27,7 @@ require (
 	github.com/google/go-jsonnet v0.17.0
 	github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5
 	github.com/google/uuid v1.1.2
+	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/iancoleman/strcase v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,9 @@ github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/felixge/fgprof v0.9.1 h1:E6FUJ2Mlv043ipLOCFqo8+cHo9MhQ203E2cdEK/isEs=
 github.com/felixge/fgprof v0.9.1/go.mod h1:7/HK6JFtFaARhIljgP2IV8rJLIoHDoOYoUphsnGvqxE=
+github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW4o=
+github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -248,6 +251,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,7 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=

--- a/pkg/admin/controller.go
+++ b/pkg/admin/controller.go
@@ -22,7 +22,7 @@ func NewController(log *logrus.Logger, svc *AdminService) *Controller {
 }
 
 // HandleGetApps handles GET requests
-func (ctrl *Controller) GetAppsHandler(w http.ResponseWriter, r *http.Request) {
+func (ctrl *Controller) HandleGetApps(w http.ResponseWriter, _ *http.Request) {
 	appNames := ctrl.svc.GetAppNames()
 
 	w.WriteHeader(200)
@@ -34,7 +34,7 @@ type DeleteAppInput struct {
 }
 
 // HandleDeleteApp handles DELETE requests
-func (ctrl *Controller) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
+func (ctrl *Controller) HandleDeleteApp(w http.ResponseWriter, r *http.Request) {
 	var payload DeleteAppInput
 
 	err := json.NewDecoder(r.Body).Decode(&payload)

--- a/pkg/admin/controller.go
+++ b/pkg/admin/controller.go
@@ -21,27 +21,8 @@ func NewController(log *logrus.Logger, svc *AdminService) *Controller {
 	return ctrl
 }
 
-func (ctrl *Controller) HandleApps(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		{
-			ctrl.HandleGetApps(w, r)
-			return
-		}
-
-	case http.MethodDelete:
-		{
-			ctrl.HandleDeleteApp(w, r)
-			return
-		}
-
-	default:
-		http.Error(w, "Method not allowed: "+r.Method, http.StatusMethodNotAllowed)
-	}
-}
-
 // HandleGetApps handles GET requests
-func (ctrl *Controller) HandleGetApps(w http.ResponseWriter, _ *http.Request) {
+func (ctrl *Controller) GetAppsHandler(w http.ResponseWriter, r *http.Request) {
 	appNames := ctrl.svc.GetAppNames()
 
 	w.WriteHeader(200)
@@ -53,7 +34,7 @@ type DeleteAppInput struct {
 }
 
 // HandleDeleteApp handles DELETE requests
-func (ctrl *Controller) HandleDeleteApp(w http.ResponseWriter, r *http.Request) {
+func (ctrl *Controller) DeleteAppHandler(w http.ResponseWriter, r *http.Request) {
 	var payload DeleteAppInput
 
 	err := json.NewDecoder(r.Body).Decode(&payload)

--- a/pkg/admin/controller_test.go
+++ b/pkg/admin/controller_test.go
@@ -64,7 +64,7 @@ var _ = Describe("controller", func() {
 					request, err := http.NewRequest(http.MethodGet, "/v1/apps", nil)
 					Expect(err).ToNot(HaveOccurred())
 
-					svr.Mux.ServeHTTP(response, request)
+					svr.Handler.ServeHTTP(response, request)
 
 					body, err := ioutil.ReadAll(response.Body)
 					Expect(err).To(BeNil())
@@ -87,7 +87,7 @@ var _ = Describe("controller", func() {
 					request, err := http.NewRequest(http.MethodDelete, "/v1/apps", bytes.NewBuffer(marshalledPayload))
 					Expect(err).ToNot(HaveOccurred())
 
-					svr.Mux.ServeHTTP(response, request)
+					svr.Handler.ServeHTTP(response, request)
 					Expect(response.Code).To(Equal(http.StatusOK))
 				})
 			})
@@ -98,7 +98,7 @@ var _ = Describe("controller", func() {
 						request, err := http.NewRequest(http.MethodDelete, "/v1/apps", bytes.NewBuffer([]byte(``)))
 						Expect(err).ToNot(HaveOccurred())
 
-						svr.Mux.ServeHTTP(response, request)
+						svr.Handler.ServeHTTP(response, request)
 						Expect(response.Code).To(Equal(http.StatusBadRequest))
 					})
 				})
@@ -118,7 +118,7 @@ var _ = Describe("controller", func() {
 						request, err := http.NewRequest(http.MethodDelete, "/v1/apps", bytes.NewBuffer(marshalledPayload))
 						Expect(err).ToNot(HaveOccurred())
 
-						svr.Mux.ServeHTTP(response, request)
+						svr.Handler.ServeHTTP(response, request)
 						Expect(response.Code).To(Equal(http.StatusInternalServerError))
 					})
 				})
@@ -128,7 +128,7 @@ var _ = Describe("controller", func() {
 		DescribeTable("Non supported requests return 405 (method not allowed)",
 			func(method string) {
 				request, _ := http.NewRequest(method, "/v1/apps", nil)
-				svr.Mux.ServeHTTP(response, request)
+				svr.Handler.ServeHTTP(response, request)
 				Expect(response.Code).To(Equal(405))
 			},
 			Entry("POST", http.MethodPost),

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -2,7 +2,9 @@ package admin
 
 import (
 	"net/http"
+	"os"
 
+	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 )
@@ -36,9 +38,11 @@ func NewServer(logger *logrus.Logger, ctrl *Controller, httpServer HTTPServer) (
 	as.Handler = r
 
 	// Routes
-	// TODO maybe use gorilla?
 	r.HandleFunc("/v1/apps", as.ctrl.GetAppsHandler).Methods("GET")
 	r.HandleFunc("/v1/apps", as.ctrl.DeleteAppHandler).Methods("DELETE")
+
+	// Global middlewares
+	r.Use(logginMiddleware)
 
 	return as, nil
 }
@@ -49,4 +53,10 @@ func (as *Server) Start() error {
 
 func (as *Server) Stop() error {
 	return as.HTTPServer.Stop()
+}
+
+func logginMiddleware(next http.Handler) http.Handler {
+	// log to Stdout using Apache Common Log Format
+	// TODO maybe use JSON?
+	return handlers.LoggingHandler(os.Stdout, next)
 }

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -38,8 +38,8 @@ func NewServer(logger *logrus.Logger, ctrl *Controller, httpServer HTTPServer) (
 	as.Handler = r
 
 	// Routes
-	r.HandleFunc("/v1/apps", as.ctrl.GetAppsHandler).Methods("GET")
-	r.HandleFunc("/v1/apps", as.ctrl.DeleteAppHandler).Methods("DELETE")
+	r.HandleFunc("/v1/apps", as.ctrl.HandleGetApps).Methods("GET")
+	r.HandleFunc("/v1/apps", as.ctrl.HandleDeleteApp).Methods("DELETE")
 
 	// Global middlewares
 	r.Use(logginMiddleware)


### PR DESCRIPTION
This was previously discussed in a meeting. In the long run we want to use a framework (we chose gorilla)  for our http servers.

This PR adds gorilla for the admin server, which is a bit more scoped and therefore easier to understand its impacts.

Unfortunately the API isn't exactly 1:1 with `net.ServeMux` so it required a little refactor (to receive `http.Handler` instead).

Also add a logging middleware as 
a) an example of how to add a middleware 
and b) I often find useful to check in the logs whether the request got received or not.