### PR TITLE
chore: make tests faster by reducing the timeout

### DIFF
--- a/pkg/admin/admin_integration_test.go
+++ b/pkg/admin/admin_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -32,7 +33,10 @@ var _ = Describe("integration", func() {
 		socketAddr = dir + "/pyroscope.tmp.sock"
 
 		// create the server
-		httpServer, err := admin.NewUdsHTTPServer(socketAddr)
+		http, err := admin.NewHTTPOverUDSClient(socketAddr, admin.WithTimeout(time.Millisecond*10))
+		Expect(err).ToNot(HaveOccurred())
+
+		httpServer, err := admin.NewUdsHTTPServer(socketAddr, http)
 		Expect(err).ToNot(HaveOccurred())
 		svc := admin.NewService(mockStorage{})
 		ctrl := admin.NewController(logger, svc)

--- a/pkg/admin/client_test.go
+++ b/pkg/admin/client_test.go
@@ -28,7 +28,7 @@ var _ = Describe("client", func() {
 	})
 
 	JustBeforeEach(func() {
-		s, err := admin.NewUdsHTTPServer(socketAddr)
+		s, err := admin.NewUdsHTTPServer(socketAddr, createHttpClientWithFastTimeout(socketAddr))
 		Expect(err).ToNot(HaveOccurred())
 		server = s
 		go server.Start(handler)

--- a/pkg/admin/http_over_uds_server.go
+++ b/pkg/admin/http_over_uds_server.go
@@ -32,13 +32,17 @@ type UdsHTTPServer struct {
 	socketAddr string
 }
 
+type HTTPClient interface {
+	Get(url string) (resp *http.Response, err error)
+}
+
 // NewUdsHttpServer creates a http server that responds over UDS (unix domain socket)
-func NewUdsHTTPServer(socketAddr string) (*UdsHTTPServer, error) {
+func NewUdsHTTPServer(socketAddr string, httpClient HTTPClient) (*UdsHTTPServer, error) {
 	if err := validateSocketAddress(socketAddr); err != nil {
 		return nil, err
 	}
 
-	listener, err := createListener(socketAddr)
+	listener, err := createListener(socketAddr, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +74,7 @@ func (u *UdsHTTPServer) Start(handler *http.ServeMux) error {
 // keep in mind there's a slight chance for a race condition there
 // where a socket is verified to be not responding
 // but the moment it's taken over, it starts to respond (probably because it was taken over by a different instance)
-func createListener(socketAddr string) (net.Listener, error) {
+func createListener(socketAddr string, httpClient HTTPClient) (net.Listener, error) {
 	takeOver := func(socketAddr string) (net.Listener, error) {
 		err := os.Remove(socketAddr)
 		if err != nil {
@@ -89,11 +93,6 @@ func createListener(socketAddr string) (net.Listener, error) {
 		if isErrorAddressAlreadyInUse(err) {
 			// that socket is already being used
 			// let's check if the server is also responding
-			httpClient, err := NewHTTPOverUDSClient(socketAddr)
-			if err != nil {
-				return nil, err
-			}
-
 			resp, err := httpClient.Get(HealthAddress)
 
 			// the httpclient failed

--- a/pkg/admin/http_over_uds_server_test.go
+++ b/pkg/admin/http_over_uds_server_test.go
@@ -15,6 +15,8 @@ type mockHandler struct{}
 
 func (m mockHandler) ServeHTTP(http.ResponseWriter, *http.Request) {}
 
+var fastTimeout = admin.WithTimeout(time.Millisecond * 1)
+
 var _ = Describe("HTTP Over UDS", func() {
 	var (
 		socketAddr string
@@ -24,7 +26,8 @@ var _ = Describe("HTTP Over UDS", func() {
 
 	When("passed an empty socket address", func() {
 		It("should give an error", func() {
-			_, err := admin.NewUdsHTTPServer("")
+			httpClient, _ := admin.NewHTTPOverUDSClient("")
+			_, err := admin.NewUdsHTTPServer("", httpClient)
 
 			Expect(err).To(MatchError(admin.ErrInvalidSocketPathname))
 		})
@@ -37,7 +40,8 @@ var _ = Describe("HTTP Over UDS", func() {
 				Skip("test is invalid when running as root")
 			}
 
-			_, err := admin.NewUdsHTTPServer("/non_existing_path")
+			socketAddr := "/non_existing_path"
+			_, err := admin.NewUdsHTTPServer(socketAddr, createHttpClientWithFastTimeout(socketAddr))
 
 			// TODO how to test for wrapped errors?
 			// Expect(err).To(MatchError(fmt.Errorf("could not bind to socket")))
@@ -58,12 +62,12 @@ var _ = Describe("HTTP Over UDS", func() {
 			It("should take over that socket", func() {
 				// create server 1
 				By("creating server 1 that's not running")
-				_, err := admin.NewUdsHTTPServer(socketAddr)
+				_, err := admin.NewUdsHTTPServer(socketAddr, createHttpClientWithFastTimeout(socketAddr))
 				Expect(err).ToNot(HaveOccurred())
 
 				By("creating server 2")
 				// create server 2
-				_, err = admin.NewUdsHTTPServer(socketAddr)
+				_, err = admin.NewUdsHTTPServer(socketAddr, createHttpClientWithFastTimeout(socketAddr))
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
@@ -71,7 +75,7 @@ var _ = Describe("HTTP Over UDS", func() {
 		When("that socket is still responding", func() {
 			It("should error", func() {
 				By("creating server 1 and running it")
-				server, err := admin.NewUdsHTTPServer(socketAddr)
+				server, err := admin.NewUdsHTTPServer(socketAddr, createHttpClientWithFastTimeout(socketAddr))
 				Expect(err).ToNot(HaveOccurred())
 
 				go func() {
@@ -82,7 +86,7 @@ var _ = Describe("HTTP Over UDS", func() {
 
 				// create server 2
 				By("creating server 2")
-				_, err = admin.NewUdsHTTPServer(socketAddr)
+				_, err = admin.NewUdsHTTPServer(socketAddr, createHttpClientWithFastTimeout(socketAddr))
 				Expect(err).To(MatchError(admin.ErrSocketStillResponding))
 			})
 		})
@@ -95,7 +99,7 @@ var _ = Describe("HTTP Over UDS", func() {
 			defer cleanup()
 
 			// start the server
-			server, err := admin.NewUdsHTTPServer(socketAddr)
+			server, err := admin.NewUdsHTTPServer(socketAddr, createHttpClientWithFastTimeout(socketAddr))
 			Expect(err).ToNot(HaveOccurred())
 			go func() {
 				server.Start(http.NewServeMux())
@@ -112,10 +116,8 @@ var _ = Describe("HTTP Over UDS", func() {
 
 func waitUntilServerIsReady(socketAddr string) error {
 	const MaxReadinessRetries = 5
-	client, err := admin.NewHTTPOverUDSClient(socketAddr)
-	if err != nil {
-		return err
-	}
+
+	client := createHttpClientWithFastTimeout(socketAddr)
 	retries := 0
 
 	for {

--- a/pkg/admin/utils_test.go
+++ b/pkg/admin/utils_test.go
@@ -1,0 +1,15 @@
+package admin_test
+
+import (
+	"github.com/pyroscope-io/pyroscope/pkg/admin"
+	"time"
+)
+
+func createHttpClientWithFastTimeout(socketAddr string) admin.HTTPClient {
+	fastTimeout := admin.WithTimeout(time.Millisecond * 1)
+	http, err := admin.NewHTTPOverUDSClient(socketAddr, fastTimeout)
+	if err != nil {
+		panic(err)
+	}
+	return http
+}

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -59,7 +59,12 @@ func newServerService(logger *logrus.Logger, c *config.Server) (*serverService, 
 		socketPath := svc.config.AdminSocketPath
 		adminSvc := admin.NewService(svc.storage)
 		adminCtrl := admin.NewController(svc.logger, adminSvc)
-		adminHTTPOverUDS, err := admin.NewUdsHTTPServer(socketPath)
+		httpClient, err := admin.NewHTTPOverUDSClient(socketPath)
+		if err != nil {
+			return nil, fmt.Errorf("admin: %w", err)
+		}
+
+		adminHTTPOverUDS, err := admin.NewUdsHTTPServer(socketPath, httpClient)
 		if err != nil {
 			return nil, fmt.Errorf("admin: %w", err)
 		}


### PR DESCRIPTION
In https://github.com/pyroscope-io/pyroscope/pull/551 I increased the timeout, since the server may be busy (for ex when you are just starting the server, it happens often in local dev). But I didn't realize it also affected the tests.

This PR makes the HTTPOverUDSServer to receive a `HTTPClient` dependency which will be used to probe if there's an already runnign server. That `HTTPClient` can then be customized (here in tests we set a ver low timeout).

Just for reference, the timeout is set to 30 seconds by default, so tests (for `pkg/admin` bit) where taking at least that long. Now it's under half a second.