### PR TITLE
fix: ignore ErrServerClosed when admin server is closed

### DIFF
--- a/pkg/admin/http_over_uds_server.go
+++ b/pkg/admin/http_over_uds_server.go
@@ -141,12 +141,10 @@ func (u *UdsHTTPServer) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
-	err := u.server.Shutdown(ctx)
-	if err != nil {
-		return err
-	}
-
-	return os.Remove(u.socketAddr)
+	// there's no need to remove the socket
+	// since go does it for us
+	// https://github.com/golang/go/blob/47db3bb443774c0b0df2cab188aa3d76b361dca2/src/net/unixsock_posix.go#L187
+	return u.server.Shutdown(ctx)
 }
 
 // https://stackoverflow.com/a/65865898

--- a/pkg/admin/http_over_uds_server.go
+++ b/pkg/admin/http_over_uds_server.go
@@ -71,7 +71,15 @@ func (m myHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (u *UdsHTTPServer) Start(handler http.Handler) error {
 	h := myHandler{handler}
 	u.server = &http.Server{Handler: h}
-	return u.server.Serve(u.listener)
+	err := u.server.Serve(u.listener)
+
+	// ListenAndServe always returns a non-nil error. After Shutdown or Close,
+	// the returned error is ErrServerClosed.
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+
+	return err
 }
 
 // createListener creates a listener on socketAddr UDS

--- a/pkg/admin/http_over_uds_server_test.go
+++ b/pkg/admin/http_over_uds_server_test.go
@@ -105,7 +105,10 @@ var _ = Describe("HTTP Over UDS", func() {
 			server, err := admin.NewUdsHTTPServer(socketAddr, createHttpClientWithFastTimeout(socketAddr))
 			Expect(err).ToNot(HaveOccurred())
 			go func() {
-				server.Start(http.NewServeMux())
+				defer GinkgoRecover()
+
+				err := server.Start(http.NewServeMux())
+				Expect(err).ToNot(HaveOccurred())
 			}()
 
 			waitUntilServerIsReady(socketAddr)

--- a/pkg/admin/http_over_uds_server_test.go
+++ b/pkg/admin/http_over_uds_server_test.go
@@ -113,9 +113,10 @@ var _ = Describe("HTTP Over UDS", func() {
 
 			waitUntilServerIsReady(socketAddr)
 
-			server.Stop()
+			err = server.Stop()
 
 			Expect(socketAddr).ToNot(BeAnExistingFile())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -257,7 +257,6 @@ func (svc *serverService) stop() {
 	if err := svc.controller.Stop(); err != nil {
 		svc.logger.WithError(err).Error("controller stop")
 	}
-
 }
 
 func (svc *serverService) ApplyConfig(c *config.Server) error {


### PR DESCRIPTION
While debugging code with @kolesnikovae we noticed the admin socket server wasn't handling shutdown properly, which was affecting other things such as the cache writeback.

