### PR TITLE
chore: add a flag to enable/disable self profiling

### DIFF
--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -125,7 +125,7 @@ func newServerService(c *config.Server) (*serverService, error) {
 	svc.debugReporter = debug.NewReporter(svc.logger, svc.storage, prometheus.DefaultRegisterer)
 	svc.directUpstream = direct.New(svc.storage, metricsExporter)
 
-	if svc.config.EnableSelfProfiling {
+	if !svc.config.NoSelfProfiling {
 		svc.selfProfiling, _ = agent.NewSession(agent.SessionConfig{
 			Upstream:       svc.directUpstream,
 			AppName:        "pyroscope.server",
@@ -188,7 +188,7 @@ func (svc *serverService) Start() error {
 	svc.healthController.Start()
 	svc.directUpstream.Start()
 
-	if svc.config.EnableSelfProfiling {
+	if !svc.config.NoSelfProfiling {
 		if err := svc.selfProfiling.Start(); err != nil {
 			svc.logger.WithError(err).Error("failed to start self-profiling")
 		}
@@ -242,7 +242,7 @@ func (svc *serverService) stop() {
 		svc.analyticsService.Stop()
 	}
 
-	if svc.config.EnableSelfProfiling {
+	if !svc.config.NoSelfProfiling {
 		svc.logger.Debug("stopping self profiling")
 		svc.selfProfiling.Stop()
 	}

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -124,15 +124,18 @@ func newServerService(c *config.Server) (*serverService, error) {
 	svc.healthController = health.NewController(svc.logger, time.Minute, diskPressure)
 	svc.debugReporter = debug.NewReporter(svc.logger, svc.storage, prometheus.DefaultRegisterer)
 	svc.directUpstream = direct.New(svc.storage, metricsExporter)
-	svc.selfProfiling, _ = agent.NewSession(agent.SessionConfig{
-		Upstream:       svc.directUpstream,
-		AppName:        "pyroscope.server",
-		ProfilingTypes: types.DefaultProfileTypes,
-		SpyName:        types.GoSpy,
-		SampleRate:     100,
-		UploadRate:     10 * time.Second,
-		Logger:         logger,
-	})
+
+	if svc.config.EnableSelfProfiling {
+		svc.selfProfiling, _ = agent.NewSession(agent.SessionConfig{
+			Upstream:       svc.directUpstream,
+			AppName:        "pyroscope.server",
+			ProfilingTypes: types.DefaultProfileTypes,
+			SpyName:        types.GoSpy,
+			SampleRate:     100,
+			UploadRate:     10 * time.Second,
+			Logger:         logger,
+		})
+	}
 
 	svc.controller, err = server.New(server.Config{
 		Configuration:           svc.config,
@@ -184,8 +187,11 @@ func (svc *serverService) Start() error {
 
 	svc.healthController.Start()
 	svc.directUpstream.Start()
-	if err := svc.selfProfiling.Start(); err != nil {
-		svc.logger.WithError(err).Error("failed to start self-profiling")
+
+	if svc.config.EnableSelfProfiling {
+		if err := svc.selfProfiling.Start(); err != nil {
+			svc.logger.WithError(err).Error("failed to start self-profiling")
+		}
 	}
 
 	// Scrape and Discovery managers have to be initialized
@@ -235,8 +241,12 @@ func (svc *serverService) stop() {
 		svc.logger.Debug("stopping analytics service")
 		svc.analyticsService.Stop()
 	}
-	svc.logger.Debug("stopping profiling")
-	svc.selfProfiling.Stop()
+
+	if svc.config.EnableSelfProfiling {
+		svc.logger.Debug("stopping self profiling")
+		svc.selfProfiling.Stop()
+	}
+
 	svc.logger.Debug("stopping upstream")
 	svc.directUpstream.Stop()
 	svc.logger.Debug("stopping storage")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -120,7 +120,7 @@ type Server struct {
 
 	ScrapeConfigs []*scrape.Config `yaml:"scrape-configs" mapstructure:"-"`
 
-	EnableSelfProfiling bool `def:"true" desc:"enable profiling of pyroscope itself" mapstructure:"enable-self-profiling"`
+	NoSelfProfiling bool `def:"false" desc:"disable profiling of pyroscope itself" mapstructure:"no-self-profiling"`
 }
 
 type MetricsExportRules map[string]MetricsExportRule

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -119,6 +119,8 @@ type Server struct {
 	EnableExperimentalAdmin bool   `def:"false" desc:"whether to enable the experimental admin interface" mapstructure:"enable-experimental-admin"`
 
 	ScrapeConfigs []*scrape.Config `yaml:"scrape-configs" mapstructure:"-"`
+
+	EnableSelfProfiling bool `def:"true" desc:"enable profiling of pyroscope itself" mapstructure:"enable-self-profiling"`
 }
 
 type MetricsExportRules map[string]MetricsExportRule

--- a/pkg/storage/storage_get.go
+++ b/pkg/storage/storage_get.go
@@ -200,7 +200,7 @@ func (s *Storage) GetValuesByQuery(label string, query string, cb func(v string)
 
 // GetAppNames returns the list of all app's names
 func (s *Storage) GetAppNames() []string {
-	var appNames []string
+	appNames := make([]string, 0)
 
 	s.GetValues("__name__", func(v string) bool {
 		appNames = append(appNames, v)


### PR DESCRIPTION
As previously discussed in slack.
Motivations are:
a) reduce clutter when running locally (specially the logs)
b) reduce disk/mem usage for certain cases
c) maybe incorporate in adhoc? cc @abeaumont 


I was considering adding a `noopAgent` or something like that, but I guess simply not launching `selfProfiling` is the easiest way to go about this.