### PR TITLE
docs: remove Go example obsolete comment

### DIFF
--- a/examples/golang/main.go
+++ b/examples/golang/main.go
@@ -33,7 +33,7 @@ func slowFunction(c context.Context) {
 func main() {
 	profiler.Start(profiler.Config{
 		ApplicationName: "simple.golang.app",
-		ServerAddress:   "http://localhost:4040", // this will run inside docker-compose, hence `pyroscope` for hostname
+		ServerAddress:   "http://localhost:4040",
 	})
 	profiler.TagWrapper(context.Background(), profiler.Labels("foo", "bar"), func(c context.Context) {
 		for {


### PR DESCRIPTION
The comment refers to a hostname that was removed in 3286f05dae2235cc84248b81caa89a6af5e60e9d