### PR TITLE
feat: Add adhoc push mode support in clib.

### DIFF
--- a/pkg/adhoc/push.go
+++ b/pkg/adhoc/push.go
@@ -55,8 +55,9 @@ func (p push) Run() error {
 	// Note that we don't specify which signals to be sent: any signal to be
 	// relayed to the child process (including SIGINT and SIGTERM).
 	signal.Notify(c)
+	env := fmt.Sprintf("PYROSCOPE_ADHOC_SERVER_ADDRESS=http://localhost:%d", listener.Addr().(*net.TCPAddr).Port)
 	cmd := exec.Command(p.args[0], p.args[1:]...)
-	cmd.Env = append(os.Environ(), fmt.Sprintf("PYROSCOPE_SERVER_ADDRESS=http://localhost:%d", listener.Addr().(*net.TCPAddr).Port))
+	cmd.Env = append(os.Environ(), env)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin

--- a/pkg/agent/clib/clib.go
+++ b/pkg/agent/clib/clib.go
@@ -33,9 +33,16 @@ func Start(applicationName *C.char, spyName *C.char, serverAddress *C.char, auth
 		return -1
 	}
 
+	address := C.GoString(serverAddress)
+	// Override the address to use when the environment variable is defined.
+	// This is useful to support adhoc push ingestion.
+	if addr, ok := os.LookupEnv("PYROSCOPE_ADHOC_SERVER_ADDRESS"); ok {
+		address = addr
+	}
+
 	rc := remote.RemoteConfig{
 		AuthToken:              C.GoString(authToken),
-		UpstreamAddress:        C.GoString(serverAddress),
+		UpstreamAddress:        address,
 		UpstreamThreads:        4,
 		UpstreamRequestTimeout: 10 * time.Second,
 	}

--- a/pkg/agent/profiler/profiler.go
+++ b/pkg/agent/profiler/profiler.go
@@ -54,8 +54,7 @@ func Start(cfg Config) (*Profiler, error) {
 
 	// Override the address to use when the environment variable is defined.
 	// This is useful to support adhoc push ingestion.
-	// TODO(abeaumont): Check if this is the best possible name.
-	if address, ok := os.LookupEnv("PYROSCOPE_SERVER_ADDRESS"); ok {
+	if address, ok := os.LookupEnv("PYROSCOPE_ADHOC_SERVER_ADDRESS"); ok {
 		cfg.ServerAddress = address
 	}
 


### PR DESCRIPTION
For native applications to work, they need to support the overriding
of the upstream address that ahdoc uses for this mode.

Instead of reusing PYROSCOPE_SERVER_ADDRESS enviroment variable,
a new variable PYROSCOPE_ADHOC_SERVER_ADDRESS has been used.
The users shouldn't be bothered with this override, using a separate
name should make it harder to see some undesired interactions.

Note that once this is merged the native integrations should be
upgraded to make use of this new clib for adhoc push to work.