### PR TITLE
fix: generate trie from pprof at scraping correctly

### DIFF
--- a/pkg/scrape/pprof.go
+++ b/pkg/scrape/pprof.go
@@ -216,7 +216,7 @@ func (t *cache) writeProfiles(x *tree.Profile, sampleType int64) {
 			}
 		}
 
-		entry.Insert(b.Bytes(), uint64(s.Value[valueIndex]))
+		entry.Insert(b.Bytes(), uint64(s.Value[valueIndex]), true)
 		b.Reset()
 	}
 }


### PR DESCRIPTION
See #575: `trie.Insert` overrides values by default.