### PR TITLE
fix: use default config file

### DIFF
--- a/benchmark/internal/config/config.go
+++ b/benchmark/internal/config/config.go
@@ -67,6 +67,3 @@ type DashboardScreenshot struct {
 	DashboardUID   string `def:"QF9YgRbUbt3BA5Qd" desc:"UUID of the dashboard"`
 	Destination    string `def:"fs" desc:"where to upload to: s3|fs"`
 }
-
-// File can be read from file system.
-type File interface{ Path() string }

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	github.com/onsi/gomega v1.12.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.32.1
+	github.com/pyroscope-io/client v0.0.0-20211206204731-3fd0a4b8239c
 	github.com/pyroscope-io/dotnetdiag v1.2.1
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rlmcpherson/s3gof3r v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -503,6 +503,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/statsd_exporter v0.15.0/go.mod h1:Dv8HnkoLQkeEjkIE4/2ndAA7WL1zHKK7WMqFQqu72rw=
+github.com/pyroscope-io/client v0.0.0-20211206204731-3fd0a4b8239c h1:QVplAdQO7l4v4b/C2ANubLOMHTSr+5VD5cFpjPgRCJ8=
+github.com/pyroscope-io/client v0.0.0-20211206204731-3fd0a4b8239c/go.mod h1:zRdQXIGxy0H2QbKEkCmZBR6KOLLIFYLWsdzVI0MRm2E=
 github.com/pyroscope-io/dotnetdiag v1.2.1 h1:3XEMrfFJnZ87BiEhozyQKmCUAuMd/Spq7KChPuD2Cf0=
 github.com/pyroscope-io/dotnetdiag v1.2.1/go.mod h1:eFUEHCp4eD1TgcXMlJihC+R4MrqGf7nTRdWxNADbDHA=
 github.com/pyroscope-io/revive v1.0.6-0.20210330033039-4a71146f9dc1 h1:0v9lBNgdmVtpyyk9PP/DfpJlOHkXriu5YgNlrhQw5YE=

--- a/pkg/cli/testdata/test-config.yml
+++ b/pkg/cli/testdata/test-config.yml
@@ -1,0 +1,1 @@
+foo: value-from-default-config-file

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,21 +26,6 @@ type Config struct {
 	Adhoc     Adhoc     `skip:"true" mapstructure:",squash"`
 }
 
-// File can be read from file system.
-type File interface{ Path() string }
-
-func (cfg Agent) Path() string {
-	return cfg.Config
-}
-
-func (cfg Server) Path() string {
-	return cfg.Config
-}
-
-func (cfg CombinedDbManager) Path() string {
-	return cfg.Server.Config
-}
-
 type Adhoc struct {
 	LogLevel  string `def:"info" desc:"log level: debug|info|warn|error" mapstructure:"log-level"`
 	NoLogging bool   `def:"false" desc:"disables logging from pyroscope" mapstructure:"no-logging"`


### PR DESCRIPTION
Before, pyroscope server read the configuration from the default path only if the appropriate flag or env var was provided. In fact, the server ignored the default config file in most cases.