### PR TITLE
fix: trigger retention task when no levels are configured

### DIFF
--- a/pkg/storage/segment/retention.go
+++ b/pkg/storage/segment/retention.go
@@ -16,7 +16,7 @@ func NewRetentionPolicy() *RetentionPolicy {
 }
 
 func (r RetentionPolicy) LowerTimeBoundary() time.Time {
-	if r.Levels == nil {
+	if len(r.Levels) == 0 {
 		return r.AbsoluteTime
 	}
 	return r.Levels[0]

--- a/pkg/storage/segment/timeline.go
+++ b/pkg/storage/segment/timeline.go
@@ -88,7 +88,7 @@ func (sn streeNode) populateTimeline(tl *Timeline, s *Segment) {
 			if hasDataBefore || levelWatermark.IsZero() || sn.isBefore(s.watermarks.absoluteTime) {
 				continue
 			}
-			if c := sn.createSampledChild(i); c.isBefore(levelWatermark) {
+			if c := sn.createSampledChild(i); c.isBefore(levelWatermark) && c.isAfter(s.watermarks.absoluteTime) {
 				c.populateTimeline(tl, s)
 				if m := c.time.Add(durations[c.depth]); m.After(tl.st) {
 					tl.Watermarks[c.depth+1] = c.time.Add(durations[c.depth]).Unix()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -279,11 +279,18 @@ func (s *Storage) retentionTask() {
 }
 
 func (s *Storage) retentionPolicy() *segment.RetentionPolicy {
-	return segment.NewRetentionPolicy().
-		SetAbsolutePeriod(s.config.retention).
-		SetLevelPeriod(0, s.config.retentionLevels.Zero).
-		SetLevelPeriod(1, s.config.retentionLevels.One).
-		SetLevelPeriod(2, s.config.retentionLevels.Two)
+	rp := segment.NewRetentionPolicy().SetAbsolutePeriod(s.config.retention)
+	levels := []time.Duration{
+		s.config.retentionLevels.Zero,
+		s.config.retentionLevels.One,
+		s.config.retentionLevels.Two,
+	}
+	for i, p := range levels {
+		if p != 0 {
+			rp.SetLevelPeriod(i, p)
+		}
+	}
+	return rp
 }
 
 func (s *Storage) databases() []*db {


### PR DESCRIPTION
Pyroscope server ignores the `retention` period configuration option if retention levels are not specified.