### PR TITLE
refactor(frontend): use redux toolkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
     "@react-hook/resize-observer": "^1.2.4",
+    "@reduxjs/toolkit": "^1.6.2",
     "@szhsin/react-menu": "^1.10.1",
     "@types/react": "^17.0.0",
     "@types/react-notifications-component": "^3.1.1",

--- a/webapp/javascript/components/AdhocSingle.jsx
+++ b/webapp/javascript/components/AdhocSingle.jsx
@@ -59,8 +59,8 @@ function AdhocSingle(props) {
 }
 
 const mapStateToProps = (state) => ({
-  ...state,
-  renderURL: buildRenderURL(state),
+  ...state.root,
+  renderURL: buildRenderURL(state.root),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/webapp/javascript/components/ComparisonApp.jsx
+++ b/webapp/javascript/components/ComparisonApp.jsx
@@ -65,10 +65,18 @@ function ComparisonApp(props) {
 }
 
 const mapStateToProps = (state) => ({
-  ...state,
-  renderURL: buildRenderURL(state),
-  leftRenderURL: buildRenderURL(state, state.leftFrom, state.leftUntil),
-  rightRenderURL: buildRenderURL(state, state.rightFrom, state.rightUntil),
+  ...state.root,
+  renderURL: buildRenderURL(state.root),
+  leftRenderURL: buildRenderURL(
+    state.root,
+    state.root.leftFrom,
+    state.root.leftUntil
+  ),
+  rightRenderURL: buildRenderURL(
+    state.root,
+    state.root.rightFrom,
+    state.root.rightUntil
+  ),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/webapp/javascript/components/ComparisonDiffApp.jsx
+++ b/webapp/javascript/components/ComparisonDiffApp.jsx
@@ -32,8 +32,8 @@ function ComparisonDiffApp(props) {
 }
 
 const mapStateToProps = (state) => ({
-  ...state,
-  diffRenderURL: buildDiffRenderURL(state),
+  ...state.root,
+  diffRenderURL: buildDiffRenderURL(state.root),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/webapp/javascript/components/CustomDatePicker.jsx
+++ b/webapp/javascript/components/CustomDatePicker.jsx
@@ -7,8 +7,8 @@ import Button from '@ui/Button';
 import { readableRange, formatAsOBject } from '../util/formatDate';
 
 function CustomDatePicker({ setRange, dispatch, setDateRange }) {
-  const from = useSelector((state) => state.from);
-  const until = useSelector((state) => state.until);
+  const from = useSelector((state) => state.root.from);
+  const until = useSelector((state) => state.root.until);
   const [warning, setWarning] = useState(false);
   const [selectedDate, setSelectedDate] = useState({
     from: formatAsOBject(from),

--- a/webapp/javascript/components/FlameGraph/index.jsx
+++ b/webapp/javascript/components/FlameGraph/index.jsx
@@ -13,7 +13,7 @@ import { buildDiffRenderURL, buildRenderURL } from '../../util/updateRequests';
 import FlameGraphRenderer from './FlameGraphRenderer';
 
 const mapStateToProps = (state) => ({
-  ...state,
+  ...state.root,
   renderURL: buildRenderURL(state),
   leftRenderURL: buildRenderURL(state, state.leftFrom, state.leftUntil),
   rightRenderURL: buildRenderURL(state, state.rightFrom, state.rightUntil),

--- a/webapp/javascript/components/Footer.jsx
+++ b/webapp/javascript/components/Footer.jsx
@@ -58,4 +58,8 @@ function Footer() {
   );
 }
 
-export default connect((x) => x, {})(Footer);
+const mapStateToProps = (state) => ({
+  ...state.root,
+});
+
+export default connect(mapStateToProps, {})(Footer);

--- a/webapp/javascript/components/Header.jsx
+++ b/webapp/javascript/components/Header.jsx
@@ -42,4 +42,8 @@ function Header(props) {
   );
 }
 
-export default connect((x) => x, { fetchNames })(Header);
+const mapStateToProps = (state) => ({
+  ...state.root,
+});
+
+export default connect(mapStateToProps, { fetchNames })(Header);

--- a/webapp/javascript/components/NameSelector.jsx
+++ b/webapp/javascript/components/NameSelector.jsx
@@ -39,7 +39,7 @@ function NameSelector(props) {
 }
 
 const mapStateToProps = (state) => ({
-  ...state,
+  ...state.root,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/webapp/javascript/components/PyroscopeApp.jsx
+++ b/webapp/javascript/components/PyroscopeApp.jsx
@@ -32,7 +32,7 @@ function PyroscopeApp(props) {
         <Header />
         <TimelineChartWrapper id="timeline-chart-single" viewSide="none" />
         <FlameGraphRenderer
-          flamebearer={single.flamebearer}
+          flamebearer={single?.flamebearer}
           viewType="single"
         />
       </div>
@@ -42,8 +42,8 @@ function PyroscopeApp(props) {
 }
 
 const mapStateToProps = (state) => ({
-  ...state,
-  renderURL: buildRenderURL(state),
+  ...state.root,
+  renderURL: buildRenderURL(state.root),
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/webapp/javascript/components/ShortcutsModal.jsx
+++ b/webapp/javascript/components/ShortcutsModal.jsx
@@ -48,4 +48,8 @@ function ShortcutsModal(props) {
   );
 }
 
-export default connect((x) => x, {})(withShortcut(ShortcutsModal));
+const mapStateToProps = (state) => ({
+  ...state.root,
+});
+
+export default connect(mapStateToProps, {})(withShortcut(ShortcutsModal));

--- a/webapp/javascript/components/Sidebar.jsx
+++ b/webapp/javascript/components/Sidebar.jsx
@@ -186,4 +186,7 @@ function Sidebar(props) {
   );
 }
 
-export default connect((x) => x, { fetchNames })(withShortcut(Sidebar));
+const mapStateToProps = (state) => ({
+  ...state.root,
+});
+export default connect(mapStateToProps, { fetchNames })(withShortcut(Sidebar));

--- a/webapp/javascript/components/TagsBar.jsx
+++ b/webapp/javascript/components/TagsBar.jsx
@@ -165,4 +165,7 @@ const mapDispatchToProps = (dispatch) => ({
   ),
 });
 
-export default connect((state) => state, mapDispatchToProps)(TagsBar);
+const mapStateToProps = (state) => ({
+  ...state.root,
+});
+export default connect(mapStateToProps, mapDispatchToProps)(TagsBar);

--- a/webapp/javascript/components/TimelineChart.jsx
+++ b/webapp/javascript/components/TimelineChart.jsx
@@ -55,7 +55,7 @@ class TimelineChart extends ReactFlot {
 }
 
 const mapStateToProps = (state) => ({
-  ...state,
+  ...state.root,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/webapp/javascript/components/TimelineChartWrapper.jsx
+++ b/webapp/javascript/components/TimelineChartWrapper.jsx
@@ -178,7 +178,7 @@ class TimelineChartWrapper extends React.Component {
 }
 
 const mapStateToProps = (state) => ({
-  ...state,
+  ...state.root,
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/webapp/javascript/redux/hooks.ts
+++ b/webapp/javascript/redux/hooks.ts
@@ -1,0 +1,6 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { RootState, AppDispatch } from './store';
+
+// Use throughout your app instead of plain `useDispatch` and `useSelector`
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/webapp/javascript/redux/reducers/index.js
+++ b/webapp/javascript/redux/reducers/index.js
@@ -1,4 +1,3 @@
 import filters from './filters';
 
 export default filters;
-// export default combineReducers({  });

--- a/webapp/javascript/redux/reducers/views.ts
+++ b/webapp/javascript/redux/reducers/views.ts
@@ -1,0 +1,21 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from '../store';
+
+interface ViewState {
+  value: number;
+}
+
+// Define the initial state using that type
+const initialState: ViewState = {
+  value: 0,
+};
+
+export const viewsSlice = createSlice({
+  name: 'views',
+  initialState,
+  reducers: {},
+});
+
+export const selectCount = (state: RootState) => state.views.value;
+
+export default viewsSlice.reducer;

--- a/webapp/javascript/redux/store.ts
+++ b/webapp/javascript/redux/store.ts
@@ -1,13 +1,14 @@
 import thunkMiddleware from 'redux-thunk';
-
 import { createStore, applyMiddleware } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 
 import ReduxQuerySync from 'redux-query-sync';
+import { configureStore } from '@reduxjs/toolkit';
 
 import rootReducer from './reducers';
 import history from '../util/history';
 
+import viewsReducer from './reducers/views';
 import {
   setLeftFrom,
   setLeftUntil,
@@ -27,7 +28,13 @@ const enhancer = composeWithDevTools(
   // persistState(["from", "until", "labels"]),
 );
 
-const store = createStore(rootReducer, enhancer);
+const store = configureStore({
+  reducer: {
+    root: rootReducer,
+    views: viewsReducer,
+  },
+  // middleware: [thunkMiddleware],
+});
 
 const defaultName = window.initialState.appNames.find(
   (x) => x !== 'pyroscope.server.cpu'
@@ -38,42 +45,42 @@ ReduxQuerySync({
   params: {
     from: {
       defaultValue: 'now-1h',
-      selector: (state) => state.from,
+      selector: (state) => state.root.from,
       action: setFrom,
     },
     until: {
       defaultValue: 'now',
-      selector: (state) => state.until,
+      selector: (state) => state.root.until,
       action: setUntil,
     },
     leftFrom: {
       defaultValue: 'now-1h',
-      selector: (state) => state.leftFrom,
+      selector: (state) => state.root.leftFrom,
       action: setLeftFrom,
     },
     leftUntil: {
       defaultValue: 'now-30m',
-      selector: (state) => state.leftUntil,
+      selector: (state) => state.root.leftUntil,
       action: setLeftUntil,
     },
     rightFrom: {
       defaultValue: 'now-30m',
-      selector: (state) => state.rightFrom,
+      selector: (state) => state.root.rightFrom,
       action: setRightFrom,
     },
     rightUntil: {
       defaultValue: 'now',
-      selector: (state) => state.rightUntil,
+      selector: (state) => state.root.rightUntil,
       action: setRightUntil,
     },
     query: {
       defaultValue: `${defaultName || 'pyroscope.server.cpu'}{}`,
-      selector: (state) => state.query,
+      selector: (state) => state.root.query,
       action: setQuery,
     },
     maxNodes: {
       defaultValue: '1024',
-      selector: (state) => state.maxNodes,
+      selector: (state) => state.root.maxNodes,
       action: setMaxNodes,
     },
   },
@@ -81,5 +88,9 @@ ReduxQuerySync({
   replaceState: false,
   history,
 });
-
 export default store;
+
+// Infer the `RootState` and `AppDispatch` types from the store itself
+export type RootState = ReturnType<typeof store.getState>;
+// Inferred type: {posts: PostsState, comments: CommentsState, users: UsersState}
+export type AppDispatch = typeof store.dispatch;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2525,6 +2525,16 @@
     "@types/raf-schd" "^4.0.0"
     raf-schd "^4.0.2"
 
+"@reduxjs/toolkit@^1.6.2":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.6.2.tgz#2f2b5365df77dd6697da28fdf44f33501ed9ba37"
+  integrity sha512-HbfI/hOVrAcMGAYsMWxw3UJyIoAS9JTdwddsjlr5w3S50tXhWb+EMyhIw+IAvCVCLETkzdjgH91RjDSYZekVBA==
+  dependencies:
+    immer "^9.0.6"
+    redux "^4.1.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@sindresorhus/is@^2.0.0":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-2.1.1.tgz#ceff6a28a5b4867c2dd4a1ba513de278ccbe8bb1"
@@ -9898,6 +9908,11 @@ immer@8.0.1:
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
+immer@^9.0.6:
+  version "9.0.7"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.7.tgz#b6156bd7db55db7abc73fd2fdadf4e579a701075"
+  integrity sha512-KGllzpbamZDvOIxnmJ0jI840g7Oikx58lBPWV0hUh7dtAyZpFqqrBZdKka5GlTwMTZ1Tjc/bKKW4VSFAt6BqMA==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -14669,6 +14684,13 @@ redux@^4.0.0, redux@^4.0.5:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
+redux@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.2.tgz#140f35426d99bb4729af760afcf79eaaac407104"
+  integrity sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
@@ -14911,6 +14933,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.0.0:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 reserved-words@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
Since more and more things are gonna be lifted to the redux store
we might as well start migrating to the official redux toolkit

This PR then introduces redux toolkit, which should be the way moving forward to create new reducers. We can slowly rewrite the existing code to use it.

One nuisance is that currently there's a single reducer, which makes difficult to run with them (old way/toolkit) side by side, so I had to move all the state into `state.root`.