### PR TITLE
feat: improve pyroscope data format.

### DIFF
--- a/pkg/adhoc/writer.go
+++ b/pkg/adhoc/writer.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pyroscope-io/pyroscope/pkg/storage"
 	"github.com/pyroscope-io/pyroscope/pkg/storage/segment"
 	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
+	"github.com/pyroscope-io/pyroscope/pkg/structs/flamebearer"
 )
 
 type writer struct {
@@ -75,21 +76,7 @@ func (w writer) write(t0, t1 time.Time) error {
 		defer f.Close()
 		switch w.outputFormat {
 		case "json":
-			// TODO(abeaumont): This is duplicated code, fix the original first.
-			fs := out.Tree.FlamebearerStruct(w.maxNodesRender)
-			fs.SpyName = out.SpyName
-			fs.SampleRate = out.SampleRate
-			fs.Units = out.Units
-			res := map[string]interface{}{
-				"timeline":    out.Timeline,
-				"flamebearer": fs,
-				"metadata": map[string]interface{}{
-					"format":     fs.Format, // "single" | "double"
-					"spyName":    out.SpyName,
-					"sampleRate": out.SampleRate,
-					"units":      out.Units,
-				},
-			}
+			res := flamebearer.NewProfile(out, w.maxNodesRender)
 			if err := json.NewEncoder(f).Encode(res); err != nil {
 				w.logger.WithError(err).Error("saving output file")
 			}

--- a/pkg/structs/flamebearer/flamebearer.go
+++ b/pkg/structs/flamebearer/flamebearer.go
@@ -1,0 +1,100 @@
+package flamebearer
+
+import (
+	"github.com/pyroscope-io/pyroscope/pkg/storage"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/segment"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
+)
+
+// FlamebearerProfile is a versioned flambearer based profile.
+// It's the native format both for rendering and file saving (in adhoc mode).
+type FlamebearerProfile struct {
+	Version uint `json:"version"`
+	FlamebearerProfileV1
+}
+
+type FlamebearerProfileV1 struct {
+	Flamebearer FlamebearerV1          `json:"flamebearer"`
+	Metadata    FlamebearerMetadataV1  `json:"metadata"`
+	Timeline    *FlamebearerTimelineV1 `json:"timeline"`
+	LeftTicks   uint64                 `json:"leftTicks,omitempty"`
+	RightTicks  uint64                 `json:"rightTicks,omitempty"`
+}
+
+type FlamebearerV1 struct {
+	Names    []string `json:"names"`
+	Levels   [][]int  `json:"levels"`
+	NumTicks int      `json:"numTicks"`
+	MaxSelf  int      `json:"maxSelf"`
+}
+
+type FlamebearerMetadataV1 struct {
+	Format     string `json:"format"`
+	SpyName    string `json:"spyName"`
+	SampleRate uint32 `json:"sampleRate"`
+	Units      string `json:"units"`
+}
+
+type FlamebearerTimelineV1 struct {
+	StartTime     int64         `json:"startTime"`
+	Samples       []uint64      `json:"samples"`
+	DurationDelta int64         `json:"durationDelta"`
+	Watermarks    map[int]int64 `json:"watermarks"`
+}
+
+func NewProfile(output *storage.GetOutput, maxNodes int) FlamebearerProfile {
+	fb := output.Tree.FlamebearerStruct(maxNodes)
+	return FlamebearerProfile{
+		Version: 1,
+		FlamebearerProfileV1: FlamebearerProfileV1{
+			Flamebearer: newFlambearer(fb),
+			Metadata:    newMetadata(fb.Format, output),
+			Timeline:    newTimeline(output.Timeline),
+		},
+	}
+}
+
+func NewCombinedProfile(output, left, right *storage.GetOutput, maxNodes int) FlamebearerProfile {
+	lt, rt := tree.CombineTree(left.Tree, right.Tree)
+	fb := tree.CombineToFlamebearerStruct(lt, rt, maxNodes)
+	return FlamebearerProfile{
+		Version: 1,
+		FlamebearerProfileV1: FlamebearerProfileV1{
+			Flamebearer: newFlambearer(fb),
+			Metadata:    newMetadata(fb.Format, output),
+			Timeline:    newTimeline(output.Timeline),
+			LeftTicks:   lt.Samples(),
+			RightTicks:  rt.Samples(),
+		},
+	}
+}
+
+func newFlambearer(fb *tree.Flamebearer) FlamebearerV1 {
+	return FlamebearerV1{
+		Names:    fb.Names,
+		Levels:   fb.Levels,
+		NumTicks: fb.NumTicks,
+		MaxSelf:  fb.MaxSelf,
+	}
+}
+
+func newMetadata(format tree.Format, output *storage.GetOutput) FlamebearerMetadataV1 {
+	return FlamebearerMetadataV1{
+		Format:     string(format),
+		SpyName:    output.SpyName,
+		SampleRate: output.SampleRate,
+		Units:      output.Units,
+	}
+}
+
+func newTimeline(timeline *segment.Timeline) *FlamebearerTimelineV1 {
+	if timeline == nil {
+		return nil
+	}
+	return &FlamebearerTimelineV1{
+		StartTime:     timeline.StartTime,
+		Samples:       timeline.Samples,
+		DurationDelta: timeline.DurationDeltaNormalized,
+		Watermarks:    timeline.Watermarks,
+	}
+}

--- a/pkg/structs/flamebearer/flamebearer_suite_test.go
+++ b/pkg/structs/flamebearer/flamebearer_suite_test.go
@@ -1,0 +1,15 @@
+package flamebearer_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	testing2 "github.com/pyroscope-io/pyroscope/pkg/testing"
+)
+
+func TestFlamebearer(t *testing.T) {
+	testing2.SetupLogging()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Flambearer Suite")
+}

--- a/pkg/structs/flamebearer/flamebearer_test.go
+++ b/pkg/structs/flamebearer/flamebearer_test.go
@@ -1,0 +1,129 @@
+package flamebearer
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/pyroscope-io/pyroscope/pkg/storage"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/segment"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
+)
+
+var (
+	startTime     = int64(1635508310)
+	durationDelta = int64(10)
+	samples       = []uint64{1}
+	watermarks    = map[int]int64{1: 1}
+	maxNodes      = 1024
+	spyName       = "spy-name"
+	sampleRate    = uint32(10)
+	units         = "units"
+)
+
+var _ = Describe("FlamebearerProfile", func() {
+	Context("single", func() {
+		It("sets all attributes correctly", func() {
+			// taken from tree package tests
+			tree := tree.New()
+			tree.Insert([]byte("a;b"), uint64(1))
+			tree.Insert([]byte("a;c"), uint64(2))
+
+			timeline := &segment.Timeline{
+				StartTime:               startTime,
+				Samples:                 samples,
+				DurationDeltaNormalized: durationDelta,
+				Watermarks:              watermarks,
+			}
+
+			out := &storage.GetOutput{
+				Tree:       tree,
+				Timeline:   timeline,
+				SpyName:    spyName,
+				SampleRate: sampleRate,
+				Units:      units,
+			}
+			p := NewProfile(out, maxNodes)
+
+			// Flamebearer
+			Expect(p.Flamebearer.Names).To(ConsistOf("total", "a", "b", "c"))
+			Expect(p.Flamebearer.Levels).To(Equal([][]int{
+				{0, 3, 0, 0},
+				{0, 3, 0, 1},
+				{0, 1, 1, 3, 0, 2, 2, 2},
+			}))
+			Expect(p.Flamebearer.NumTicks).To(Equal(3))
+			Expect(p.Flamebearer.MaxSelf).To(Equal(2))
+
+			// Metadata
+			Expect(p.Metadata.Format).To(Equal("single"))
+			Expect(p.Metadata.SpyName).To(Equal(spyName))
+			Expect(p.Metadata.SampleRate).To(Equal(sampleRate))
+			Expect(p.Metadata.Units).To(Equal(units))
+
+			// Timeline
+			Expect(p.Timeline.StartTime).To(Equal(startTime))
+			Expect(p.Timeline.Samples).To(Equal(samples))
+			Expect(p.Timeline.DurationDelta).To(Equal(durationDelta))
+			Expect(p.Timeline.Watermarks).To(Equal(watermarks))
+
+			// Ticks
+			Expect(p.LeftTicks).To(BeZero())
+			Expect(p.RightTicks).To(BeZero())
+		})
+	})
+
+	Context("diff", func() {
+		It("sets all attributes correctly", func() {
+			// taken from tree package tests
+			treeA := tree.New()
+			treeA.Insert([]byte("a;b"), uint64(1))
+			treeA.Insert([]byte("a;c"), uint64(2))
+			treeB := tree.New()
+			treeB.Insert([]byte("a;b"), uint64(4))
+			treeB.Insert([]byte("a;c"), uint64(8))
+
+			timeline := &segment.Timeline{
+				StartTime:               startTime,
+				Samples:                 samples,
+				DurationDeltaNormalized: durationDelta,
+				Watermarks:              watermarks,
+			}
+
+			out := &storage.GetOutput{
+				Timeline:   timeline,
+				SpyName:    spyName,
+				SampleRate: sampleRate,
+				Units:      units,
+			}
+			left := &storage.GetOutput{Tree: treeA}
+			right := &storage.GetOutput{Tree: treeB}
+			p := NewCombinedProfile(out, left, right, maxNodes)
+
+			// Flamebearer
+			Expect(p.Flamebearer.Names).To(ConsistOf("total", "a", "b", "c"))
+			Expect(p.Flamebearer.Levels).To(Equal([][]int{
+				{0, 3, 0, 0, 12, 0, 0},
+				{0, 3, 0, 0, 12, 0, 1},
+				{0, 1, 1, 0, 4, 4, 3, 0, 2, 2, 0, 8, 8, 2},
+			}))
+			Expect(p.Flamebearer.NumTicks).To(Equal(15))
+			Expect(p.Flamebearer.MaxSelf).To(Equal(8))
+
+			// Metadata
+			Expect(p.Metadata.Format).To(Equal("double"))
+			Expect(p.Metadata.SpyName).To(Equal(spyName))
+			Expect(p.Metadata.SampleRate).To(Equal(sampleRate))
+			Expect(p.Metadata.Units).To(Equal(units))
+
+			// Timeline
+			Expect(p.Timeline.StartTime).To(Equal(startTime))
+			Expect(p.Timeline.Samples).To(Equal(samples))
+			Expect(p.Timeline.DurationDelta).To(Equal(durationDelta))
+			Expect(p.Timeline.Watermarks).To(Equal(watermarks))
+
+			// Ticks
+			Expect(p.LeftTicks).To(Equal(uint64(3)))
+			Expect(p.RightTicks).To(Equal(uint64(12)))
+		})
+	})
+})

--- a/webapp/javascript/redux/actions.js
+++ b/webapp/javascript/redux/actions.js
@@ -27,7 +27,6 @@ import {
   RECEIVE_COMPARISON_TIMELINE,
 } from './actionTypes';
 import { isAbortError } from '../util/abort';
-import { deltaDiffWrapper } from '../util/flamebearer';
 
 export const setDateRange = (from, until) => ({
   type: SET_DATE_RANGE,
@@ -221,12 +220,6 @@ export function fetchComparisonAppData(url, viewSide) {
     })
       .then((response) => response.json())
       .then((data) => {
-        const calculatedLevels = deltaDiffWrapper(
-          data.flamebearer.format,
-          data.flamebearer.levels
-        );
-
-        data.flamebearer.levels = calculatedLevels;
         dispatch(receiveComparisonAppData(data, viewSide));
       })
       .catch((e) => {
@@ -251,12 +244,6 @@ export function fetchPyrescopeAppData(url) {
     })
       .then((response) => response.json())
       .then((data) => {
-        const calculatedLevels = deltaDiffWrapper(
-          data.flamebearer.format,
-          data.flamebearer.levels
-        );
-
-        data.flamebearer.levels = calculatedLevels;
         dispatch(receivePyrescopeAppData(data));
       })
       .catch((e) => {
@@ -281,12 +268,6 @@ export function fetchComparisonDiffAppData(url) {
     })
       .then((response) => response.json())
       .then((data) => {
-        const calculatedLevels = deltaDiffWrapper(
-          data.flamebearer.format,
-          data.flamebearer.levels
-        );
-
-        data.flamebearer.levels = calculatedLevels;
         dispatch(receiveComparisonDiffAppData(data));
       })
       .catch((e) => {

--- a/webapp/javascript/redux/reducers/filters.js
+++ b/webapp/javascript/redux/reducers/filters.js
@@ -74,7 +74,23 @@ function decodeTimelineData(timelineData) {
   });
 }
 
-export default function (state = initialState, action) {
+function decodeFlamebearer({ flamebearer, metadata, leftTicks, rightTicks }) {
+  let fb = {
+    ...flamebearer,
+    format: metadata.format,
+    spyName: metadata.spyName,
+    sampleRate: metadata.sampleRate,
+    units: metadata.units,
+  };
+  if (fb.format == 'double') {
+    fb.leftTicks = leftTicks;
+    fb.rightTicks = rightTicks;
+  }
+  fb.levels = deltaDiffWrapper(fb.format, fb.levels);
+  return fb;
+}
+
+export default function(state = initialState, action) {
   let flamebearer;
   let timeline;
   let data;
@@ -147,8 +163,7 @@ export default function (state = initialState, action) {
     case RECEIVE_PYRESCOPE_APP_DATA:
       data = action.payload.data;
       timeline = data.timeline;
-      flamebearer = data.flamebearer;
-
+      flamebearer = decodeFlamebearer(data);
       return {
         ...state,
         timeline: decodeTimelineData(timeline),
@@ -163,7 +178,7 @@ export default function (state = initialState, action) {
       };
     case RECEIVE_COMPARISON_APP_DATA:
       viewSide = action.payload.viewSide;
-      flamebearer = action.payload.data.flamebearer;
+      flamebearer = decodeFlamebearer(action.payload.data);
 
       let left;
       let right;
@@ -210,18 +225,12 @@ export default function (state = initialState, action) {
     case RECEIVE_COMPARISON_DIFF_APP_DATA:
       data = action.payload.data;
       timeline = data.timeline;
-      const { leftTicks, rightTicks } = data;
+      flamebearer = decodeFlamebearer(data);
 
       return {
         ...state,
         timeline: decodeTimelineData(timeline),
-        diff: {
-          flamebearer: {
-            leftTicks,
-            rightTicks,
-            ...data.flamebearer,
-          },
-        },
+        diff: { flamebearer },
         isJSONLoading: false,
       };
 


### PR DESCRIPTION
Current data format used for rendering is not defined formally and has
a couple of issues:
- There's no format versioning, which makes it hard to evolve the
format or migrate between versions.
- Current format has redudancy, with duplicated metadata.

This may become a problem especially once adhoc mode is released, as
this format is directly exported to JSON.

I have created a new package with the flamebearer profile versioned
model, which should make the format more explicit and easier to
evolve. I have also removed the duplicated metadata.