### PR TITLE
fix: start upstream in clib.

### DIFF
--- a/pkg/agent/clib/clib.go
+++ b/pkg/agent/clib/clib.go
@@ -69,6 +69,7 @@ func Start(applicationName *C.char, spyName *C.char, serverAddress *C.char, auth
 		logger.Errorf("error happened when starting profiling session: %v", err)
 		return -1
 	}
+	u.Start()
 	if err = session.Start(); err != nil {
 		logger.Errorf("error happened when starting profiling session: %v", err)
 		return -1


### PR DESCRIPTION
This fixes a regression introduced in when automatic start in upstream
was removed.