### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/benchmark/internal/cireport/tablereport.go
+++ b/benchmark/internal/cireport/tablereport.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"golang.org/x/sync/errgroup"
-	"gopkg.in/yaml.v2"
-	"io/ioutil"
 	"math"
+	"os"
 	"sync"
 	"text/template"
 	"time"
+
+	"golang.org/x/sync/errgroup"
+	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -60,7 +61,7 @@ func TableReportCli(q Querier, queriesFile string) (string, error) {
 	var qCfg QueriesConfig
 
 	// read the file
-	yamlFile, err := ioutil.ReadFile(queriesFile)
+	yamlFile, err := os.ReadFile(queriesFile)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/admin/admin_integration_test.go
+++ b/pkg/admin/admin_integration_test.go
@@ -4,7 +4,6 @@
 package admin_test
 
 import (
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -84,7 +83,7 @@ func genRandomDir() (func(), string) {
 	// so we first create a temporary directory
 	// and pass a well-known file name
 	// that way tests can be run concurrently
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	Expect(err).ToNot(HaveOccurred())
 
 	return func() {

--- a/pkg/admin/controller_test.go
+++ b/pkg/admin/controller_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -65,7 +65,7 @@ var _ = Describe("controller", func() {
 
 					svr.Handler.ServeHTTP(response, request)
 
-					body, err := ioutil.ReadAll(response.Body)
+					body, err := io.ReadAll(response.Body)
 					Expect(err).To(BeNil())
 
 					Expect(response.Code).To(Equal(http.StatusOK))

--- a/pkg/agent/pprof/proto.go
+++ b/pkg/agent/pprof/proto.go
@@ -9,7 +9,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"runtime"
 	"sort"
 	"strconv"
@@ -602,7 +602,7 @@ func (b *profileBuilder) emitLocation() uint64 {
 // It saves the address ranges of the mappings in b.mem for use
 // when emitting locations.
 func (b *profileBuilder) readMapping() {
-	data, _ := ioutil.ReadFile("/proc/self/maps")
+	data, _ := os.ReadFile("/proc/self/maps")
 	parseProcSelfMaps(data, b.addMapping)
 	if len(b.mem) == 0 { // pprof expects a map entry, so fake one.
 		b.addMappingEntry(0, 0, 0, "", "", true)

--- a/pkg/agent/upstream/remote/remote.go
+++ b/pkg/agent/upstream/remote/remote.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -136,7 +136,7 @@ func (r *Remote) uploadProfile(j *upstream.UploadJob) error {
 	defer response.Body.Close()
 
 	// read all the response body
-	_, err = ioutil.ReadAll(response.Body)
+	_, err = io.ReadAll(response.Body)
 	if err != nil {
 		return fmt.Errorf("read response body: %v", err)
 	}

--- a/pkg/agent/upstream/remote/remote_test.go
+++ b/pkg/agent/upstream/remote/remote_test.go
@@ -3,7 +3,7 @@ package remote
 import (
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -34,7 +34,7 @@ var _ = Describe("remote.Remote", func() {
 					timestampsMutex.Lock()
 					timestamps = append(timestamps, time.Now())
 					timestampsMutex.Unlock()
-					_, err := ioutil.ReadAll(r.Body)
+					_, err := io.ReadAll(r.Body)
 					Expect(err).ToNot(HaveOccurred())
 
 					fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))

--- a/pkg/analytics/analytics.go
+++ b/pkg/analytics/analytics.go
@@ -18,7 +18,7 @@ package analytics
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"runtime"
 	"time"
@@ -179,7 +179,7 @@ func (s *Service) sendReport() {
 		logrus.WithField("err", err).Error("Error happened when uploading anonymized usage data")
 	}
 	if resp != nil {
-		_, err := ioutil.ReadAll(resp.Body)
+		_, err := io.ReadAll(resp.Body)
 		if err != nil {
 			logrus.WithField("err", err).Error("Error happened when uploading reading server response")
 			return

--- a/pkg/analytics/analytics_test.go
+++ b/pkg/analytics/analytics_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -47,7 +47,7 @@ var _ = Describe("analytics", func() {
 					timestamps := []time.Time{}
 					myHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 						timestamps = append(timestamps, time.Now())
-						bytes, err := ioutil.ReadAll(r.Body)
+						bytes, err := io.ReadAll(r.Body)
 						Expect(err).ToNot(HaveOccurred())
 
 						v := make(map[string]interface{})

--- a/pkg/cli/agent.go
+++ b/pkg/cli/agent.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -54,7 +54,7 @@ func (svc *agentService) Stop(_ service.Service) error {
 // https://github.com/spf13/viper#accessing-nested-keys.
 // TODO(kolesnikovae): find a way to get rid of the function.
 func loadAgentConfig(c *config.Agent) error {
-	b, err := ioutil.ReadFile(c.Config)
+	b, err := os.ReadFile(c.Config)
 	switch {
 	case err == nil:
 	case os.IsNotExist(err):
@@ -90,7 +90,7 @@ func mergeTags(a, b map[string]string) map[string]string {
 
 func createLogger(cfg *config.Agent) (*logrus.Logger, error) {
 	if cfg.NoLogging {
-		logrus.SetOutput(ioutil.Discard)
+		logrus.SetOutput(io.Discard)
 		return logrus.StandardLogger(), nil
 	}
 	l, err := logrus.ParseLevel(cfg.LogLevel)

--- a/pkg/convert/parser.go
+++ b/pkg/convert/parser.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"strconv"
 
 	"google.golang.org/protobuf/proto"
@@ -46,7 +45,7 @@ func ParsePprof(r io.Reader) (*tree.Profile, error) {
 		r = bufioReader
 	}
 
-	b, err := ioutil.ReadAll(r)
+	b, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/convert/parser_test.go
+++ b/pkg/convert/parser_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -16,7 +16,7 @@ var _ = Describe("convert", func() {
 		It("parses data correctly", func() {
 			result := []string{}
 
-			b, err := ioutil.ReadFile("testdata/cpu.pprof")
+			b, err := os.ReadFile("testdata/cpu.pprof")
 			Expect(err).ToNot(HaveOccurred())
 			r := bytes.NewReader(b)
 			g, err := gzip.NewReader(r)

--- a/pkg/convert/profile_extra_bench_test.go
+++ b/pkg/convert/profile_extra_bench_test.go
@@ -3,14 +3,14 @@ package convert
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/pyroscope-io/pyroscope/pkg/agent/spy"
 )
 
 func BenchmarkProfile_Get(b *testing.B) {
-	buf, _ := ioutil.ReadFile("testdata/cpu.pprof")
+	buf, _ := os.ReadFile("testdata/cpu.pprof")
 	g, _ := gzip.NewReader(bytes.NewReader(buf))
 	p, _ := ParsePprof(g)
 	noop := func(labels *spy.Labels, name []byte, val int) {}

--- a/pkg/scrape/config/config_http.go
+++ b/pkg/scrape/config/config_http.go
@@ -25,7 +25,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -503,7 +502,7 @@ func NewAuthorizationCredentialsFileRoundTripper(authType, authCredentialsFile s
 
 func (rt *authorizationCredentialsFileRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if len(req.Header.Get("Authorization")) == 0 {
-		b, err := ioutil.ReadFile(rt.authCredentialsFile)
+		b, err := os.ReadFile(rt.authCredentialsFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read authorization credentials file %s: %s", rt.authCredentialsFile, err)
 		}
@@ -541,7 +540,7 @@ func (rt *basicAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, e
 	}
 	req = cloneRequest(req)
 	if rt.passwordFile != "" {
-		bs, err := ioutil.ReadFile(rt.passwordFile)
+		bs, err := os.ReadFile(rt.passwordFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read basic auth password file %s: %s", rt.passwordFile, err)
 		}
@@ -580,7 +579,7 @@ func (rt *oauth2RoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	)
 
 	if rt.config.ClientSecretFile != "" {
-		data, err := ioutil.ReadFile(rt.config.ClientSecretFile)
+		data, err := os.ReadFile(rt.config.ClientSecretFile)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read oauth2 client secret file %s: %s", rt.config.ClientSecretFile, err)
 		}
@@ -744,7 +743,7 @@ func (c *TLSConfig) getClientCertificate(*tls.CertificateRequestInfo) (*tls.Cert
 
 // readCAFile reads the CA cert file from disk.
 func readCAFile(f string) ([]byte, error) {
-	data, err := ioutil.ReadFile(f)
+	data, err := os.ReadFile(f)
 	if err != nil {
 		return nil, fmt.Errorf("unable to load specified CA cert %s: %s", f, err)
 	}

--- a/pkg/server/build_test.go
+++ b/pkg/server/build_test.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -47,7 +47,7 @@ var _ = Describe("server", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(res.StatusCode).To(Equal(200))
 
-					b, err := ioutil.ReadAll(res.Body)
+					b, err := io.ReadAll(res.Body)
 					Expect(err).ToNot(HaveOccurred())
 
 					actual := make(map[string]interface{})

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -46,7 +46,7 @@ var _ = Describe("server", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(res.StatusCode).To(Equal(200))
 
-					b, err := ioutil.ReadAll(res.Body)
+					b, err := io.ReadAll(res.Body)
 					Expect(err).ToNot(HaveOccurred())
 
 					actual := make(map[string]interface{})

--- a/pkg/server/controller_gzip_test.go
+++ b/pkg/server/controller_gzip_test.go
@@ -2,9 +2,9 @@ package server
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
@@ -26,8 +26,8 @@ var _ = Describe("server", func() {
 		var tempAssetDir *testing.TmpDirectory
 		BeforeSuite(func() {
 			tempAssetDir = testing.TmpDirSync()
-			ioutil.WriteFile(filepath.Join(tempAssetDir.Path, assetLtCompressionThreshold), make([]byte, gzHTTPCompressionThreshold-1), 0644)
-			ioutil.WriteFile(filepath.Join(tempAssetDir.Path, assetAtCompressionThreshold), make([]byte, gzHTTPCompressionThreshold), 0644)
+			os.WriteFile(filepath.Join(tempAssetDir.Path, assetLtCompressionThreshold), make([]byte, gzHTTPCompressionThreshold-1), 0644)
+			os.WriteFile(filepath.Join(tempAssetDir.Path, assetAtCompressionThreshold), make([]byte, gzHTTPCompressionThreshold), 0644)
 		})
 		AfterSuite(func() {
 			tempAssetDir.Close()

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -220,7 +219,7 @@ func (ctrl *Controller) getTemplate(path string) (*template.Template, error) {
 		return nil, fmt.Errorf("could not find file %s: %q", path, err)
 	}
 
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return nil, fmt.Errorf("could not read file %s: %q", path, err)
 	}
@@ -253,7 +252,7 @@ func (ctrl *Controller) renderIndexPage(w http.ResponseWriter, _ *http.Request) 
 	var extraMetadataStr string
 	extraMetadataPath := os.Getenv("PYROSCOPE_EXTRA_METADATA")
 	if extraMetadataPath != "" {
-		b, err = ioutil.ReadFile(extraMetadataPath)
+		b, err = os.ReadFile(extraMetadataPath)
 		if err != nil {
 			logrus.Errorf("failed to read file at %s", extraMetadataPath)
 		}

--- a/pkg/server/render_test.go
+++ b/pkg/server/render_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -121,7 +121,7 @@ var _ = Describe("server", func() {
 				Expect(resp.Header.Get("Content-Disposition")).To(MatchRegexp(
 					"^attachment; filename=.+\\.pprof$",
 				))
-				body, _ := ioutil.ReadAll(resp.Body)
+				body, _ := io.ReadAll(resp.Body)
 				profile := &tree.Profile{}
 				err = proto.Unmarshal(body, profile)
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/storage/mem_linux.go
+++ b/pkg/storage/mem_linux.go
@@ -3,7 +3,7 @@
 package storage
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -20,7 +20,7 @@ func getCgroupMemLimit() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/testing/load/cmd/dataloader/main.go
+++ b/pkg/testing/load/cmd/dataloader/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -26,7 +25,7 @@ type Config struct {
 
 func loadConfig(path string) (Config, error) {
 	var c Config
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return c, err
 	}

--- a/pkg/testing/tmpdir.go
+++ b/pkg/testing/tmpdir.go
@@ -1,7 +1,6 @@
 package testing
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -31,7 +30,7 @@ func DirStats(path string) (directories, files int, size bytesize.ByteSize) {
 
 func TmpDir(cb func(name string)) {
 	defer ginkgo.GinkgoRecover()
-	path, err := ioutil.TempDir("", "pyroscope-test-dir")
+	path, err := os.MkdirTemp("", "pyroscope-test-dir")
 	if err != nil {
 		panic(err)
 	}
@@ -50,7 +49,7 @@ func (t *TmpDirectory) Close() {
 
 func TmpDirSync() *TmpDirectory {
 	defer ginkgo.GinkgoRecover()
-	path, err := ioutil.TempDir("", "pyroscope-test-dir")
+	path, err := os.MkdirTemp("", "pyroscope-test-dir")
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/util/updates/updates.go
+++ b/pkg/util/updates/updates.go
@@ -2,7 +2,7 @@ package updates
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -30,7 +30,7 @@ func updateLatestVersion() error {
 		return err
 	}
 
-	b, err := ioutil.ReadAll(resp.Body)
+	b, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/scripts/decode-resp/main.go
+++ b/scripts/decode-resp/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -43,7 +42,7 @@ func main() {
 	}
 
 	// read file
-	inData, err := ioutil.ReadFile(inFile)
+	inData, err := os.ReadFile(inFile)
 	must(err)
 	var input Input
 	must(json.Unmarshal(inData, &input))
@@ -54,7 +53,7 @@ func main() {
 	// write file
 	outData, err := json.MarshalIndent(output, "", "  ")
 	must(err)
-	must(ioutil.WriteFile(outFile, outData, 0644))
+	must(os.WriteFile(outFile, outData, 0644))
 
 	fmt.Fprintf(os.Stderr, "decoded to %v\n", outFile)
 }

--- a/scripts/generate-sample-config/main.go
+++ b/scripts/generate-sample-config/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -61,7 +60,7 @@ var (
 )
 
 func processFile(path string) error {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("reading file: %w", err)
 	}
@@ -80,7 +79,7 @@ func processFile(path string) error {
 	}
 
 	fmt.Println(path)
-	return ioutil.WriteFile(path, newContent, 0640)
+	return os.WriteFile(path, newContent, 0640)
 }
 
 func writeConfigDocs(w io.Writer, subcommand, format string) {

--- a/scripts/pprof-view/main.go
+++ b/scripts/pprof-view/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"compress/gzip"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -20,7 +20,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	buf, err := ioutil.ReadAll(g)
+	buf, err := io.ReadAll(g)
 	if err != nil {
 		panic(err)
 	}

--- a/scripts/traffic-duplicator/main.go
+++ b/scripts/traffic-duplicator/main.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"flag"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os/exec"
@@ -64,7 +63,7 @@ func startProxy() {
 }
 
 func handleConn(_ http.ResponseWriter, r *http.Request) {
-	b, err := ioutil.ReadAll(r.Body)
+	b, err := io.ReadAll(r.Body)
 	if err != nil {
 		logrus.WithError(err).Error("failed to read body")
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.