### PR TITLE
feat(frontend): allow to export flamegraph json

### DIFF
--- a/webapp/javascript/components/ComparisonApp.jsx
+++ b/webapp/javascript/components/ComparisonApp.jsx
@@ -22,6 +22,7 @@ import styles from './ComparisonApp.module.css';
 function ComparisonApp(props) {
   const { actions, renderURL, leftRenderURL, rightRenderURL, comparison } =
     props;
+  const { rawLeft, rawRight } = comparison;
 
   useEffect(() => {
     actions.fetchComparisonAppData(leftRenderURL, 'left');
@@ -59,6 +60,7 @@ function ComparisonApp(props) {
               flamebearer={comparison.left.flamebearer}
               data-testid="flamegraph-renderer-left"
               display="both"
+              rawFlamegraph={rawLeft}
             >
               <InstructionText viewType="double" viewSide="left" />
               <TimelineChartWrapper
@@ -77,6 +79,7 @@ function ComparisonApp(props) {
               flamebearer={comparison.right.flamebearer}
               data-testid="flamegraph-renderer-right"
               display="both"
+              rawFlamegraph={rawRight}
             >
               <InstructionText viewType="double" viewSide="right" />
               <TimelineChartWrapper

--- a/webapp/javascript/components/ExportData.tsx
+++ b/webapp/javascript/components/ExportData.tsx
@@ -5,8 +5,13 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars } from '@fortawesome/free-solid-svg-icons/faBars';
 
 import clsx from 'clsx';
+import { Flamebearer } from '@models/flamebearer';
 
-function ExportData() {
+interface ExportDataProps {
+  exportFlamebearer?: Flamebearer;
+}
+function ExportData(props: ExportDataProps) {
+  const { exportFlamebearer } = props;
   const [toggleMenu, setToggleMenu] = useState(false);
 
   const formattedDate = () => {
@@ -44,6 +49,21 @@ function ExportData() {
     setToggleMenu(!toggleMenu);
   };
 
+  const downloadFlamebearer = function (
+    exportObj: Flamebearer,
+    exportName: string
+  ) {
+    const dataStr = `data:text/json;charset=utf-8,${encodeURIComponent(
+      JSON.stringify(exportObj)
+    )}`;
+    const downloadAnchorNode = document.createElement('a');
+    downloadAnchorNode.setAttribute('href', dataStr);
+    downloadAnchorNode.setAttribute('download', `${exportName}.json`);
+    document.body.appendChild(downloadAnchorNode); // required for firefox
+    downloadAnchorNode.click();
+    downloadAnchorNode.remove();
+  };
+
   return (
     <div className="dropdown-container">
       <Button icon={faBars} onClick={handleToggleMenu} />
@@ -61,6 +81,17 @@ function ExportData() {
           >
             PNG
           </button>
+          {exportFlamebearer && (
+            <button
+              className="dropdown-menu-item"
+              type="button"
+              onClick={() =>
+                downloadFlamebearer(exportFlamebearer, 'pyroscope_export')
+              }
+            >
+              JSON
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/Header.tsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/Header.tsx
@@ -3,15 +3,14 @@ import { Flamebearer } from '@models/flamebearer';
 import DiffLegend from './DiffLegend';
 import styles from './Header.module.css';
 
-export default function Header({
-  format,
-  units,
-  ExportData,
-}: {
+interface HeaderProps {
   format: Flamebearer['format'];
   units: Flamebearer['units'];
   ExportData: () => React.ReactElement;
-}) {
+}
+export default function Header(props: HeaderProps) {
+  const { format, units, ExportData } = props;
+
   const unitsToFlamegraphTitle = {
     objects: 'amount of objects in RAM per function',
     bytes: 'amount of RAM per function',

--- a/webapp/javascript/components/FlameGraph/FlameGraphRenderer.jsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphRenderer.jsx
@@ -229,6 +229,23 @@ class FlameGraphRenderer extends React.Component {
       this.props.viewSide
     );
 
+    const exportData = () => {
+      if (!this.state.flamebearer) {
+        return <ExportData />;
+      }
+
+      if (!this.props.rawFlamegraph) {
+        return <ExportData />;
+      }
+
+      // we only want to download single ones
+      if (this.state.flamebearer.format === 'double') {
+        return <ExportData />;
+      }
+
+      return <ExportData exportFlamebearer={this.props.rawFlamegraph} />;
+    };
+
     const flameGraphPane =
       this.state.flamebearer && dataExists ? (
         <Graph
@@ -237,7 +254,7 @@ class FlameGraphRenderer extends React.Component {
           flamebearer={this.state.flamebearer}
           format={this.parseFormat(this.state.flamebearer.format)}
           view={this.state.view}
-          ExportData={ExportData}
+          ExportData={exportData}
           highlightQuery={this.state.highlightQuery}
           fitMode={this.state.fitMode}
           viewType={this.props.viewType}

--- a/webapp/javascript/components/PyroscopeApp.jsx
+++ b/webapp/javascript/components/PyroscopeApp.jsx
@@ -16,7 +16,7 @@ import {
 } from '../redux/actions';
 
 function PyroscopeApp(props) {
-  const { actions, renderURL, single } = props;
+  const { actions, renderURL, single, raw } = props;
   const prevPropsRef = useRef();
 
   useEffect(() => {
@@ -41,6 +41,7 @@ function PyroscopeApp(props) {
             flamebearer={single?.flamebearer}
             viewType="single"
             display="both"
+            rawFlamegraph={raw}
           />
         </Box>
       </div>

--- a/webapp/javascript/redux/reducers/filters.js
+++ b/webapp/javascript/redux/reducers/filters.js
@@ -186,10 +186,13 @@ export default function (state = initialState, action) {
       };
     case RECEIVE_PYRESCOPE_APP_DATA:
       data = action.payload.data;
+      // since we gonna mutate that data, keep a reference to the old one
+      const raw = JSON.parse(JSON.stringify(data));
       timeline = data.timeline;
-      flamebearer = decodeFlamebearer(data);
+      flamebearer = decodeFlamebearer({ ...data });
       return {
         ...state,
+        raw,
         timeline: decodeTimelineData(timeline),
         single: { flamebearer },
         isJSONLoading: false,
@@ -202,19 +205,29 @@ export default function (state = initialState, action) {
       };
     case RECEIVE_COMPARISON_APP_DATA:
       viewSide = action.payload.viewSide;
-      flamebearer = decodeFlamebearer(action.payload.data);
+      flamebearer = action.payload.data;
 
       let left;
       let right;
+      let rawLeft;
+      let rawRight;
       switch (viewSide) {
         case 'left':
-          left = { flamebearer };
+          // since we gonna mutate that data, keep a reference to the old one
+          rawLeft = JSON.parse(JSON.stringify(flamebearer));
+
+          left = { flamebearer: decodeFlamebearer(flamebearer) };
           right = state.comparison.right;
+          rawRight = state.comparison.rawRight;
           break;
 
         case 'right': {
+          // since we gonna mutate that data, keep a reference to the old one
+          rawRight = JSON.parse(JSON.stringify(flamebearer));
+
           left = state.comparison.left;
-          right = { flamebearer };
+          right = { flamebearer: decodeFlamebearer(flamebearer) };
+          rawLeft = state.comparison.rawLeft;
           break;
         }
         default:
@@ -226,6 +239,8 @@ export default function (state = initialState, action) {
         comparison: {
           left,
           right,
+          rawLeft,
+          rawRight,
         },
         isJSONLoading: false,
       };


### PR DESCRIPTION
Not optimal but it works.
Currently scoped to `single` flamegraphs (ie. singel view, comparison diff but NOT diff view, since we don't support importing that yet).

Had to store the raw response from /render in the store since that's what adhoc expects. Yadda yadda `deltaDiffWrapper` is troublesome.

![Peek 2021-12-16 11-20](https://user-images.githubusercontent.com/6951209/146389053-21ede2f9-a40f-4062-a5fc-72070bb478b5.gif)
