### PR TITLE
fix(frontend): set a specific jquery version

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,6 +196,7 @@
   },
   "resolutions": {
     "react": "16.14.0",
-    "react-dom": "16.14.0"
+    "react-dom": "16.14.0",
+    "jquery": "3.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12689,15 +12689,10 @@ jest@^27.2.4:
     import-local "^3.0.2"
     jest-cli "^27.4.4"
 
-jquery@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
-
-jquery@^3.1.1:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+jquery@3.1.1, jquery@3.5.1, jquery@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.1.1.tgz#347c1c21c7e004115e0a4da32cece041fad3c8a3"
+  integrity sha1-NHwcIcfgBBFeCk2jLOzgQfrTyKM=
 
 js-cookie@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
@grafana/ui was pulling a new jquery version
which was breaking the flot library