### PR TITLE
chore: set image and container name explicitly in benchmarks.

### DIFF
--- a/benchmark/docker-compose.yml
+++ b/benchmark/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     build:
       context: ../
       dockerfile: benchmark/Dockerfile
+    image: benchmark_pyrobench_1
+    container_name: benchmark_pyrobench_1
     # we will be running docker exec against it
     command:
       - sh


### PR DESCRIPTION
These names match the name expected int the start script.