### PR TITLE
build: speed up docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,11 +55,14 @@ WORKDIR /opt/pyroscope
 
 COPY scripts ./scripts
 COPY webapp ./webapp
-COPY package.json yarn.lock babel.config.js .eslintrc .eslintignore .prettierrc tsconfig.json Makefile ./
+COPY package.json yarn.lock Makefile ./
+# we only need the dependencies required to BUILD the application
+RUN make install-build-web-dependencies
+COPY babel.config.js .eslintrc .eslintignore .prettierrc tsconfig.json Makefile ./
 
 ARG EXTRA_METADATA=""
-# we only need the dependencies required to BUILD the application
-RUN EXTRA_METADATA=$EXTRA_METADATA make install-build-web-dependencies assets-release
+
+RUN EXTRA_METADATA=$EXTRA_METADATA make assets-release
 
 
 #              _

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,8 +57,7 @@ COPY scripts ./scripts
 COPY package.json yarn.lock Makefile ./
 
 # we only need the dependencies required to BUILD the application
-# cache the dir /usr/local/lib/node_modules between builds
-RUN --mount=type=cache,target=/usr/local/lib/node_modules make install-build-web-dependencies
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn/v6 make install-build-web-dependencies
 
 COPY babel.config.js .eslintrc .eslintignore .prettierrc tsconfig.json ./
 COPY webapp ./webapp

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,16 +54,18 @@ RUN apk add --no-cache make
 WORKDIR /opt/pyroscope
 
 COPY scripts ./scripts
-COPY webapp ./webapp
 COPY package.json yarn.lock Makefile ./
+
 # we only need the dependencies required to BUILD the application
-RUN make install-build-web-dependencies
-COPY babel.config.js .eslintrc .eslintignore .prettierrc tsconfig.json Makefile ./
+# cache the dir /usr/local/lib/node_modules between builds
+RUN --mount=type=cache,target=/usr/local/lib/node_modules make install-build-web-dependencies
+
+COPY babel.config.js .eslintrc .eslintignore .prettierrc tsconfig.json ./
+COPY webapp ./webapp
 
 ARG EXTRA_METADATA=""
 
 RUN EXTRA_METADATA=$EXTRA_METADATA make assets-release
-
 
 #              _
 #             | |

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,6 +1,7 @@
 # Webapp
 
 # Tests
+
 ## Snapshot tests
 Similar to what we do in cypress, we take snapshots of the canvas.
 

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,7 +1,6 @@
 # Webapp
 
 # Tests
-
 ## Snapshot tests
 Similar to what we do in cypress, we take snapshots of the canvas.
 


### PR DESCRIPTION
This PR does 2 things:

* Move installing yarn dependencies at the top of the Dockerfile. That way we don't have to pull dependencies if `package.lock/yarn.lock` haven't changed.
* Use [`RUN --mount=type=cache`](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md#run---mounttypecache) to cache dependencies between builds. This required updating our CI scripts to use the env var `DOCKER_BUILDKIT=1`

There's more room for improvements, but this should be a good start.