### PR TITLE
fix(panel): import @szhsin/react-menu styles in contextmenu

### DIFF
--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/ContextMenu.module.scss
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/ContextMenu.module.scss
@@ -1,0 +1,8 @@
+@import '../../../../../node_modules/@szhsin/react-menu/dist/index.css';
+
+// a dummy class is required
+// so that the component can import this class
+// and therefore the library style (index.css above) is imported
+.dummy {
+  display: block;
+}

--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/ContextMenu.tsx
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/ContextMenu.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ControlledMenu, useMenuState } from '@szhsin/react-menu';
+import styles from './ContextMenu.module.scss';
 
 type xyToMenuItems = (x: number, y: number) => JSX.Element[];
 
@@ -74,6 +75,7 @@ export default function ContextMenu(props: ContextMenuProps) {
 
   return (
     <ControlledMenu
+      className={styles.dummy}
       menuItemFocus={menuProps.menuItemFocus}
       isMounted={menuProps.isMounted}
       isOpen={menuProps.isOpen}


### PR DESCRIPTION
Closes #668

After we stopped importing `node_modules/@szhsin/react-menu/dist/index.css` from `styles.scss`, it stopped being included by default. Instead, it's being imported when one component that uses it is imported (for example, the `DropdownComponent`). Hence, it works on the webapp.

However, `ContextMenu` also requires that style, and in the grafana panel plugin, we don't use a `DropdownComponent`, therefore that style is not present.

This PR makes the `ContextMenu` import the required style, fixing the problem above.

