### PR TITLE
fix: register all pprof handlers

### DIFF
--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -184,6 +184,12 @@ func (ctrl *Controller) mux() (http.Handler, error) {
 			{"/debug/pprof/profile", pprof.Profile},
 			{"/debug/pprof/symbol", pprof.Symbol},
 			{"/debug/pprof/trace", pprof.Trace},
+			{"/debug/pprof/allocs", pprof.Index},
+			{"/debug/pprof/goroutine", pprof.Index},
+			{"/debug/pprof/heap", pprof.Index},
+			{"/debug/pprof/threadcreate", pprof.Index},
+			{"/debug/pprof/block", pprof.Index},
+			{"/debug/pprof/mutex", pprof.Index},
 		}...)
 	}
 


### PR DESCRIPTION
`debug/pprof/goroutine` and many other pprof endpoints return 404.

Gorilla router doesn't automatically serve subpaths. Given that profiles like `goroutine`, `block`, and `mutex` are supposed to be handled by `pprof.Index`, the router configuration needs to be updated.

Although it is possible to use `PathPrefix("/debug/pprof/")`, it does not integrate with our routing setup well, therefore I decided to add handlers explicitly.
