### PR TITLE
fix(frontend): keep query param when changing routes

### DIFF
--- a/cypress/integration/webapp/routes.ts
+++ b/cypress/integration/webapp/routes.ts
@@ -1,0 +1,33 @@
+describe('QueryParams', () => {
+  // on smaller screens component will be collapsed by default
+  beforeEach(() => {
+    cy.viewport(1440, 900);
+  });
+
+  // type a tag so that it's synced to the URL
+  // IMPORTANT! don't access the url directly since it will render this test useless
+  // since we are testing populating the queryParams and maintaining between routes
+  it('maintains queryParams when changing route', () => {
+    const myTag = 'myrandomtag{}';
+    const validate = () => {
+      cy.location().then((loc) => {
+        const urlParams = new URLSearchParams(loc.search);
+        expect(urlParams.get('query')).to.eq(myTag);
+      });
+    };
+
+    cy.visit('/');
+    cy.get('.tags-input').clear().type(myTag);
+    cy.get('.tags-query button').click();
+    validate();
+
+    cy.findByTestId('sidebar-continuous-comparison').click();
+    validate();
+
+    cy.findByTestId('sidebar-continuous-diff').click();
+    validate();
+
+    cy.findByTestId('sidebar-continuous-single').click();
+    validate();
+  });
+});

--- a/webapp/javascript/index.jsx
+++ b/webapp/javascript/index.jsx
@@ -2,7 +2,7 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 
 import { Provider } from 'react-redux';
-import { BrowserRouter, Switch, Route } from 'react-router-dom';
+import { Router, BrowserRouter, Switch, Route } from 'react-router-dom';
 import FPSStats from 'react-fps-stats';
 import { isExperimentalAdhocUIEnabled } from '@utils/features';
 import Notifications from '@ui/Notifications';
@@ -17,7 +17,6 @@ import AdhocComparison from './components/AdhocComparison';
 import ServerNotifications from './components/ServerNotifications';
 
 import history from './util/history';
-import basename from './util/baseurl';
 
 let showFps = false;
 try {
@@ -30,7 +29,7 @@ try {
 
 ReactDOM.render(
   <Provider store={store}>
-    <BrowserRouter history={history} basename={basename()}>
+    <Router history={history}>
       <ServerNotifications />
       <Notifications />
       <div className="app">
@@ -57,7 +56,7 @@ ReactDOM.render(
           )}
         </Switch>
       </div>
-    </BrowserRouter>
+    </Router>
     {showFps ? <FPSStats left="auto" top="auto" bottom={2} right={2} /> : ''}
   </Provider>,
   document.getElementById('root')

--- a/webapp/javascript/util/history.js
+++ b/webapp/javascript/util/history.js
@@ -1,4 +1,8 @@
 // src/myHistory.js
 import { createBrowserHistory } from 'history';
-const history = createBrowserHistory();
+import basename from './baseurl';
+
+const history = createBrowserHistory({
+  basename: basename(),
+});
 export default history;


### PR DESCRIPTION
Closes #671 

This was introduced when we added baseUrl support, where we replaced the barebones `Router` for `BrowserRouter`, which broke the `react-query-sync` library, since it doesn't expose the `history` object which is handled under the hood.
(see more details at https://github.com/Treora/redux-query-sync/issues/13#issuecomment-327361957)

 I spoke with @petethepig and the only reason we did that  was to allow passing a `basename`, which `BrowserRouter` support.

So I just replaced `BrowserRouter` for `Router` to get `redux-query-sync` working (which is the may issue this PR resolves), and then adds the basename to the history object.

The only thing here is that `basename` was removed from `history` from version 5 and onwards (https://github.com/remix-run/history/issues/810), so that may become a problem. But it should be fine for now since we have a simple test that covers the functionality.

Some other thoughts:
* This is where having the file with typescript would be useful, since we would spot that `BrowserRouter` does not take a `history` parameter (https://v5.reactrouter.com/web/api/BrowserRouter) which would probably raise an eyebrown.
* We need to test the `baseURL` stuff. Already spoken with @petethepig previously about doing it when we have more time, but honestly, this is the kind of thing we will forget if we don't do it soon.