### PR TITLE
perf: optimize segment tree serialization.

### DIFF
--- a/pkg/storage/segment/serialization_bench_test.go
+++ b/pkg/storage/segment/serialization_bench_test.go
@@ -1,0 +1,33 @@
+package segment
+
+import (
+	"bytes"
+	"fmt"
+	"math/big"
+	"math/rand"
+	"testing"
+	"time"
+
+	ptesting "github.com/pyroscope-io/pyroscope/pkg/testing"
+)
+
+func serialize(s *Segment) []byte {
+	var buf bytes.Buffer
+	s.Serialize(&buf)
+	return buf.Bytes()
+}
+
+func BenchmarkSerialize(b *testing.B) {
+	for k := 10; k <= 1000000; k *= 10 {
+		s := New()
+		for i := 0; i < k; i++ {
+			s.Put(ptesting.SimpleTime(i*10), ptesting.SimpleTime(i*10+9), uint64(rand.Intn(100)), func(de int, t time.Time, r *big.Rat, a []Addon) {})
+		}
+		b.ResetTimer()
+		b.Run(fmt.Sprintf("serialize %d", k), func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = serialize(s)
+			}
+		})
+	}
+}

--- a/revive.toml
+++ b/revive.toml
@@ -33,7 +33,6 @@ warningCode = 0
   arguments = [4]
 [rule.empty-block]
 [rule.superfluous-else]
-[rule.confusing-naming]
 [rule.get-return]
 [rule.modifies-parameter]
 [rule.confusing-results]


### PR DESCRIPTION
Segment tree serialization was done traversing the tree in depth
iteratively, using slices.
This causes a lot of slice insertions which caused an important amount
of allocations to grow these slices.

Serialization is now changed to do a recursive traversal instead,
which doesn't require any explicit data structure and thus all these
allocations are removed. Since the depth of segment trees is, in
practice, both bounded and small, it should be more efficient in all
cases, but especially as the segment trees grow.

A benchmark has also been included to be able to compare results
between the old and new implementations.
`benchstat` shows good results:

```
$ benchstat old.txt new.txt
name                            old time/op  new time/op  delta
Serialize/serialize_10-16       5.13µs ± 2%  3.77µs ± 4%  -26.60%  (p=0.008 n=5+5)
Serialize/serialize_100-16      29.4µs ± 4%  11.7µs ± 5%  -60.18%  (p=0.008 n=5+5)
Serialize/serialize_1000-16      299µs ± 1%    83µs ± 5%  -72.24%  (p=0.008 n=5+5)
Serialize/serialize_10000-16    4.34ms ± 9%  1.03ms ± 3%  -76.19%  (p=0.008 n=5+5)
Serialize/serialize_100000-16   35.6ms ± 4%   7.7ms ± 4%  -78.28%  (p=0.008 n=5+5)
Serialize/serialize_1000000-16   331ms ± 2%    76ms ± 6%  -77.15%  (p=0.008 n=5+5)
```

Using pyroscope to benchmark these optimizations is less useful as the
improvement becomes more relevant as the size of the segment trees
increases, and thus it's harder to appreciate the improvements in
short runs. On longer runs, these improvements should become more
significant (e.g. `pyroscope.server.cpu{}` at
https://demo.pyroscope.io/ shows over 11% time invested in
`runtime.growslice` inside segment serialization:
![segment-serialize](https://user-images.githubusercontent.com/80059/148800661-5bd654c2-b9b2-42b0-b4d1-4fd431934494.png)

