### PR TITLE
feat(frontend): persist sidebar collapsed state

### DIFF
--- a/cypress/integration/webapp/basic.ts
+++ b/cypress/integration/webapp/basic.ts
@@ -174,6 +174,10 @@ describe('basic test', () => {
   });
 
   describe('tooltip', () => {
+    // on smaller screens component will be collapsed by default
+    beforeEach(() => {
+      cy.viewport(1440, 900);
+    });
     it('works in single view', () => {
       cy.intercept('**/render*', {
         fixture: 'simple-golang-app-cpu.json',

--- a/cypress/integration/webapp/sidebar.ts
+++ b/cypress/integration/webapp/sidebar.ts
@@ -20,4 +20,50 @@ describe('sidebar', () => {
       cy.location('pathname').should('eq', `${basePath}/`);
     });
   });
+
+  describe('collapse/uncollapse', () => {
+    it('defaults to collapsed in smaller screens', () => {
+      cy.viewport(1000, 900);
+      cy.visit('/');
+      cy.get('.app').find('.pro-sidebar').should('have.class', 'collapsed');
+    });
+
+    it('defaults to uncollapsed in bigger screens', () => {
+      cy.viewport(1440, 900);
+      cy.visit('/');
+      cy.get('.app').find('.pro-sidebar').should('not.have.class', 'collapsed');
+    });
+
+    it('collapses when screen width changes', () => {
+      cy.viewport(1440, 900);
+      cy.visit('/');
+
+      cy.get('.app').find('.pro-sidebar').should('not.have.class', 'collapsed');
+
+      cy.viewport(1000, 900);
+
+      cy.get('.app').find('.pro-sidebar').should('have.class', 'collapsed');
+    });
+
+    describe('when user interacts', () => {
+      it('persists state across reloads', () => {
+        cy.viewport(1440, 900);
+        cy.visit('/');
+
+        cy.get('.app')
+          .find('.pro-sidebar')
+          .should('not.have.class', 'collapsed');
+        cy.get('.app')
+          .find('.pro-sidebar')
+          .findByText('Collapse Sidebar')
+          .click();
+
+        cy.get('.app').find('.pro-sidebar').should('have.class', 'collapsed');
+
+        cy.reload();
+
+        cy.get('.app').find('.pro-sidebar').should('have.class', 'collapsed');
+      });
+    });
+  });
 });

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",
     "redux-localstorage": "^0.4.1",
+    "redux-persist": "^6.0.0",
     "redux-promise": "^0.6.0",
     "redux-query-sync": "^0.1.10",
     "redux-thunk": "^2.3.0",

--- a/webapp/javascript/components/Sidebar.spec.tsx
+++ b/webapp/javascript/components/Sidebar.spec.tsx
@@ -1,7 +1,23 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
+import { configureStore } from '@reduxjs/toolkit';
+import { Provider } from 'react-redux';
+import uiReducer from '@pyroscope/redux/reducers/ui';
+
 import Sidebar from './Sidebar';
+
+// TODO: figure out the types here
+function createStore(preloadedState: any) {
+  const store = configureStore({
+    reducer: {
+      ui: uiReducer,
+    },
+    preloadedState,
+  });
+
+  return store;
+}
 
 describe('Sidebar', () => {
   describe('active routes highlight', () => {
@@ -14,7 +30,18 @@ describe('Sidebar', () => {
         test(`should have menuitem ${b} active`, () => {
           render(
             <MemoryRouter initialEntries={[a]}>
-              <Sidebar initialCollapsed />
+              <Provider
+                store={createStore({
+                  ui: {
+                    sidebar: {
+                      state: 'pristine',
+                      collapsed: true,
+                    },
+                  },
+                })}
+              >
+                <Sidebar />
+              </Provider>
             </MemoryRouter>
           );
 
@@ -27,7 +54,18 @@ describe('Sidebar', () => {
         test(`should have menuitem ${b} active`, () => {
           render(
             <MemoryRouter initialEntries={[a]}>
-              <Sidebar initialCollapsed={false} />
+              <Provider
+                store={createStore({
+                  ui: {
+                    sidebar: {
+                      state: 'pristine',
+                      collapsed: false,
+                    },
+                  },
+                })}
+              >
+                <Sidebar />
+              </Provider>
             </MemoryRouter>
           );
 

--- a/webapp/javascript/components/Sidebar.tsx
+++ b/webapp/javascript/components/Sidebar.tsx
@@ -17,6 +17,13 @@ import Sidebar, {
   SubMenu,
   Menu,
 } from '@ui/Sidebar';
+import { useAppSelector, useAppDispatch } from '@pyroscope/redux/hooks';
+import {
+  selectSidebarCollapsed,
+  collapseSidebar,
+  uncollapseSidebar,
+  recalculateSidebar,
+} from '@pyroscope/redux/reducers/ui';
 import { useLocation, NavLink } from 'react-router-dom';
 import { isExperimentalAdhocUIEnabled } from '@utils/features';
 import Icon from '@ui/Icon';
@@ -41,10 +48,13 @@ function signOut() {
 }
 
 export default function Sidebar2(props: SidebarProps) {
+  const collapsed = useAppSelector(selectSidebarCollapsed);
+  const dispatch = useAppDispatch();
+
   const { initialCollapsed } = props;
 
   const { search, pathname } = useLocation();
-  const [collapsed, setCollapsed] = useState(initialCollapsed);
+  //  const [collapsed, setCollapsed] = useState(initialCollapsed);
   const windowWidth = useWindowWidth();
 
   // the component doesn't seem to support setting up an active item
@@ -54,11 +64,15 @@ export default function Sidebar2(props: SidebarProps) {
     return pathname === route;
   };
 
-  useEffect(() => {
-    const c = windowWidth < 1200;
-    setCollapsed(c);
+  React.useLayoutEffect(() => {
+    dispatch(recalculateSidebar());
   }, [windowWidth]);
 
+  //  useEffect(() => {
+  //    const c = windowWidth < 1200;
+  //    setCollapsed(c);
+  //  }, [windowWidth]);
+  //
   // TODO
   // simplify this
   const isContinuousActive =
@@ -110,7 +124,10 @@ export default function Sidebar2(props: SidebarProps) {
     </SubMenu>
   );
 
-  const toggleCollapse = () => setCollapsed(!collapsed);
+  const toggleCollapse = () => {
+    const action = collapsed ? uncollapseSidebar : collapseSidebar;
+    dispatch(action());
+  };
 
   return (
     <Sidebar collapsed={collapsed}>

--- a/webapp/javascript/components/Sidebar.tsx
+++ b/webapp/javascript/components/Sidebar.tsx
@@ -31,10 +31,6 @@ import { useWindowWidth } from '@react-hook/window-size';
 import basename from '../util/baseurl';
 import styles from './Sidebar.module.css';
 
-export interface SidebarProps {
-  initialCollapsed?: boolean;
-}
-
 // TODO: find a better way of doing this?
 function signOut() {
   const form = document.createElement('form');
@@ -47,14 +43,11 @@ function signOut() {
   form.submit();
 }
 
-export default function Sidebar2(props: SidebarProps) {
+export default function Sidebar2() {
   const collapsed = useAppSelector(selectSidebarCollapsed);
   const dispatch = useAppDispatch();
 
-  const { initialCollapsed } = props;
-
   const { search, pathname } = useLocation();
-  //  const [collapsed, setCollapsed] = useState(initialCollapsed);
   const windowWidth = useWindowWidth();
 
   // the component doesn't seem to support setting up an active item
@@ -68,11 +61,6 @@ export default function Sidebar2(props: SidebarProps) {
     dispatch(recalculateSidebar());
   }, [windowWidth]);
 
-  //  useEffect(() => {
-  //    const c = windowWidth < 1200;
-  //    setCollapsed(c);
-  //  }, [windowWidth]);
-  //
   // TODO
   // simplify this
   const isContinuousActive =

--- a/webapp/javascript/index.jsx
+++ b/webapp/javascript/index.jsx
@@ -6,7 +6,8 @@ import { Router, BrowserRouter, Switch, Route } from 'react-router-dom';
 import FPSStats from 'react-fps-stats';
 import { isExperimentalAdhocUIEnabled } from '@utils/features';
 import Notifications from '@ui/Notifications';
-import store from './redux/store';
+import { PersistGate } from 'redux-persist/integration/react';
+import store, { persistor } from './redux/store';
 
 import PyroscopeApp from './components/PyroscopeApp';
 import ComparisonApp from './components/ComparisonApp';
@@ -30,40 +31,42 @@ try {
 
 ReactDOM.render(
   <Provider store={store}>
-    <Router history={history}>
-      <ServerNotifications />
-      <Notifications />
-      <div className="app">
-        <Sidebar />
-        <Switch>
-          <Route exact path="/">
-            <PyroscopeApp />
-          </Route>
-          <Route path="/comparison">
-            <ComparisonApp />
-          </Route>
-          <Route path="/comparison-diff">
-            <ComparisonDiffApp />
-          </Route>
-          {isExperimentalAdhocUIEnabled && (
-            <Route path="/adhoc-single">
-              <AdhocSingle />
+    <PersistGate persistor={persistor} loading={null}>
+      <Router history={history}>
+        <ServerNotifications />
+        <Notifications />
+        <div className="app">
+          <Sidebar />
+          <Switch>
+            <Route exact path="/">
+              <PyroscopeApp />
             </Route>
-          )}
-          {isExperimentalAdhocUIEnabled && (
-            <Route path="/adhoc-comparison">
-              <AdhocComparison />
+            <Route path="/comparison">
+              <ComparisonApp />
             </Route>
-          )}
-          {isExperimentalAdhocUIEnabled && (
-            <Route path="/adhoc-comparison-diff">
-              <AdhocComparisonDiff />
+            <Route path="/comparison-diff">
+              <ComparisonDiffApp />
             </Route>
-          )}
-        </Switch>
-      </div>
-    </Router>
-    {showFps ? <FPSStats left="auto" top="auto" bottom={2} right={2} /> : ''}
+            {isExperimentalAdhocUIEnabled && (
+              <Route path="/adhoc-single">
+                <AdhocSingle />
+              </Route>
+            )}
+            {isExperimentalAdhocUIEnabled && (
+              <Route path="/adhoc-comparison">
+                <AdhocComparison />
+              </Route>
+            )}
+            {isExperimentalAdhocUIEnabled && (
+              <Route path="/adhoc-comparison-diff">
+                <AdhocComparisonDiff />
+              </Route>
+            )}
+          </Switch>
+        </div>
+      </Router>
+      {showFps ? <FPSStats left="auto" top="auto" bottom={2} right={2} /> : ''}
+    </PersistGate>
   </Provider>,
   document.getElementById('root')
 );

--- a/webapp/javascript/redux/reducers/ui.ts
+++ b/webapp/javascript/redux/reducers/ui.ts
@@ -1,0 +1,56 @@
+import { createSlice, createSelector } from '@reduxjs/toolkit';
+import type { RootState } from '../store';
+
+type SidebarState =
+  // pristine means user hasn't interacted with it yet
+  // so we default to certain heuristics (eg window size)
+  | { state: 'pristine'; collapsed: true }
+  | { state: 'pristine'; collapsed: false }
+
+  // userInteracted means user has actively clicked on the button
+  // so we should keep whatever state they've chosen
+  | { state: 'userInteracted'; collapsed: true }
+  | { state: 'userInteracted'; collapsed: false };
+
+interface UiState {
+  sidebar: SidebarState;
+}
+
+const initialState: UiState = {
+  sidebar: { state: 'pristine', collapsed: window.innerWidth < 1200 },
+  //  sidebar: { state: 'pristine' },
+};
+
+export const uiSlice = createSlice({
+  name: 'ui',
+  initialState,
+  reducers: {
+    recalculateSidebar: (state) => {
+      if (state.sidebar.state === 'pristine') {
+        state.sidebar.collapsed = window.innerWidth < 1200;
+      }
+    },
+    collapseSidebar: (state) => {
+      state.sidebar = { state: 'userInteracted', collapsed: true };
+    },
+    uncollapseSidebar: (state) => {
+      state.sidebar = { state: 'userInteracted', collapsed: false };
+    },
+  },
+});
+
+const selectUiState = (state: RootState) => state.ui;
+
+export const selectSidebarCollapsed = createSelector(selectUiState, (state) => {
+  return state.sidebar.collapsed;
+  // we are trusting the fact this action will probably only be called once
+  //  if (state.sidebar.state === 'pristine') {
+  //    return window.innerWidth < 1200;
+  //  }
+  //  return state.sidebar.collapsed;
+});
+
+export const { collapseSidebar, uncollapseSidebar, recalculateSidebar } =
+  uiSlice.actions;
+
+export default uiSlice.reducer;

--- a/webapp/javascript/redux/reducers/ui.ts
+++ b/webapp/javascript/redux/reducers/ui.ts
@@ -43,11 +43,6 @@ const selectUiState = (state: RootState) => state.ui;
 
 export const selectSidebarCollapsed = createSelector(selectUiState, (state) => {
   return state.sidebar.collapsed;
-  // we are trusting the fact this action will probably only be called once
-  //  if (state.sidebar.state === 'pristine') {
-  //    return window.innerWidth < 1200;
-  //  }
-  //  return state.sidebar.collapsed;
 });
 
 export const { collapseSidebar, uncollapseSidebar, recalculateSidebar } =

--- a/webapp/javascript/redux/reducers/ui.ts
+++ b/webapp/javascript/redux/reducers/ui.ts
@@ -1,5 +1,23 @@
 import { createSlice, createSelector } from '@reduxjs/toolkit';
+import { createMigrate } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
+import { PersistedState } from 'redux-persist/lib/types';
 import type { RootState } from '../store';
+
+// Persistence Migrations
+// See examples on https://github.com/rt2zz/redux-persist/blob/master/docs/migrations.md
+export const migrations = {
+  0: (state: PersistedState) => {
+    return { ...state };
+  },
+};
+
+export const persistConfig = {
+  key: 'pyroscope:ui',
+  version: 0,
+  storage,
+  migrate: createMigrate(migrations, { debug: true }),
+};
 
 type SidebarState =
   // pristine means user hasn't interacted with it yet

--- a/webapp/javascript/redux/reducers/ui.ts
+++ b/webapp/javascript/redux/reducers/ui.ts
@@ -12,7 +12,7 @@ type SidebarState =
   | { state: 'userInteracted'; collapsed: true }
   | { state: 'userInteracted'; collapsed: false };
 
-interface UiState {
+export interface UiState {
   sidebar: SidebarState;
 }
 

--- a/webapp/javascript/redux/store.ts
+++ b/webapp/javascript/redux/store.ts
@@ -7,6 +7,7 @@ import {
   PERSIST,
   PURGE,
   REGISTER,
+  createMigrate,
 } from 'redux-persist';
 import thunkMiddleware from 'redux-thunk';
 import { createStore, applyMiddleware } from 'redux';
@@ -21,7 +22,7 @@ import history from '../util/history';
 
 import viewsReducer from './reducers/views';
 import newRootStore from './reducers/newRoot';
-import uiStore from './reducers/ui';
+import uiStore, { persistConfig as uiPersistConfig } from './reducers/ui';
 
 import {
   setLeftFrom,
@@ -42,16 +43,11 @@ const enhancer = composeWithDevTools(
   // persistState(["from", "until", "labels"]),
 );
 
-const persistConfig = {
-  key: 'pyroscope',
-  storage,
-};
-
 const reducer = combineReducers({
   newRoot: newRootStore,
   root: rootReducer,
   views: viewsReducer,
-  ui: persistReducer(persistConfig, uiStore),
+  ui: persistReducer(uiPersistConfig, uiStore),
 });
 
 const store = configureStore({

--- a/webapp/javascript/redux/store.ts
+++ b/webapp/javascript/redux/store.ts
@@ -21,6 +21,7 @@ import history from '../util/history';
 
 import viewsReducer from './reducers/views';
 import newRootStore from './reducers/newRoot';
+import uiStore from './reducers/ui';
 
 import {
   setLeftFrom,
@@ -46,14 +47,12 @@ const persistConfig = {
   storage,
 };
 
-const reducer = persistReducer(
-  persistConfig,
-  combineReducers({
-    newRoot: newRootStore,
-    root: rootReducer,
-    views: viewsReducer,
-  })
-);
+const reducer = combineReducers({
+  newRoot: newRootStore,
+  root: rootReducer,
+  views: viewsReducer,
+  ui: persistReducer(persistConfig, uiStore),
+});
 
 const store = configureStore({
   reducer,

--- a/webapp/javascript/redux/store.ts
+++ b/webapp/javascript/redux/store.ts
@@ -1,9 +1,20 @@
+import {
+  persistStore,
+  persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+} from 'redux-persist';
 import thunkMiddleware from 'redux-thunk';
 import { createStore, applyMiddleware } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 
 import ReduxQuerySync from 'redux-query-sync';
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
+import storage from 'redux-persist/lib/storage';
 
 import rootReducer from './reducers';
 import history from '../util/history';
@@ -30,18 +41,37 @@ const enhancer = composeWithDevTools(
   // persistState(["from", "until", "labels"]),
 );
 
-const store = configureStore({
-  reducer: {
+const persistConfig = {
+  key: 'pyroscope',
+  storage,
+};
+
+const reducer = persistReducer(
+  persistConfig,
+  combineReducers({
     newRoot: newRootStore,
     root: rootReducer,
     views: viewsReducer,
-  },
-  // middleware: [thunkMiddleware],
+  })
+);
+
+const store = configureStore({
+  reducer,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        // Based on this issue: https://github.com/rt2zz/redux-persist/issues/988
+        // and this guide https://redux-toolkit.js.org/usage/usage-guide#use-with-redux-persist
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    }),
 });
 
 const defaultName = (window as any).initialState.appNames.find(
   (x) => x !== 'pyroscope.server.cpu'
 );
+
+export const persistor = persistStore(store);
 
 ReduxQuerySync({
   store, // your Redux store

--- a/yarn.lock
+++ b/yarn.lock
@@ -16759,6 +16759,11 @@ redux-mock-store@^1.5.4:
   dependencies:
     lodash.isplainobject "^4.0.6"
 
+redux-persist@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
+  integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+
 redux-promise@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/redux-promise/-/redux-promise-0.6.0.tgz#c64723b5213bb5603c11b74302883b682e06b319"


### PR DESCRIPTION
Implements sidebar performance (related to https://github.com/pyroscope-io/pyroscope/issues/591)

The code is based on https://github.com/pyroscope-io/pyroscope/pull/681, except we only do the sidebar here.

The logic is similar to what twitch does:
* If the user has never interacted with the sidebar (state called 'pristine'):
   * If the window is small, we set to collapsed
   * If the window width is large, we set to uncollapsed
   * If the user resizes the screen, these rules should be still be valid.
 * If the user HAS interacted with the sidebar
   * then we assume they know what they are doing and ALWAYS use what've chosen
   * for example, if they had manually collapsed, we will always have it collapsed, even in bigger screens

---
Also added migrations, which currently don't do much but with new versions this is useful. The idea is that what you got from localStorage may not be what your application code is expecting (let's say if you had stored a boolean but now your app code expects an object).

---
Create a `ui` store that currently only holds the sidebar state. Also that's the only state serialized.
Preferred a more straightforward approach to make the code easier to understand, the component interacts directly with the store via the selector and the dispatcher.
