### PR TITLE
chore: adhoc polishing

### DIFF
--- a/pkg/adhoc/util/util.go
+++ b/pkg/adhoc/util/util.go
@@ -1,12 +1,10 @@
 package util
 
 import (
-	"os"
 	"path/filepath"
 )
 
-// Retrieve pyroscope data directory, creating it if needed.
-func EnsureDataDirectory() (string, error) {
-	dir := filepath.Join(dataBaseDirectory(), "pyroscope")
-	return dir, os.MkdirAll(dir, os.ModeDir|os.ModePerm)
+// Retrieve pyroscope data directory
+func DataDirectory() string {
+	return filepath.Join(dataBaseDirectory(), "pyroscope")
 }

--- a/pkg/adhoc/util/util_darwin.go
+++ b/pkg/adhoc/util/util_darwin.go
@@ -10,5 +10,5 @@ func dataBaseDirectory() string {
 	if !ok {
 		homeDir = "/"
 	}
-	return filepath.Join(homeDir, "Library", "Application Support")
+	return filepath.Join(homeDir, ".pyroscope")
 }

--- a/pkg/adhoc/writer.go
+++ b/pkg/adhoc/writer.go
@@ -40,6 +40,7 @@ func (w writer) write(t0, t1 time.Time) error {
 		return fmt.Errorf("could not create data directory: %w", err)
 	}
 
+	profiles := 0
 	for _, name := range w.storage.GetAppNames() {
 		skey, err := segment.ParseKey(name)
 		if err != nil {
@@ -99,9 +100,15 @@ func (w writer) write(t0, t1 time.Time) error {
 			}
 		}
 		w.logger.Infof("profiling data has been saved to %s", path)
+		profiles++
 		if err := f.Close(); err != nil {
 			w.logger.WithError(err).Error("closing output file")
 		}
+	}
+	if profiles == 0 {
+		w.logger.Warning("no profiling data was saved, maybe the profiled process didn't run long enough?")
+	} else {
+		w.logger.Info("you can now run `pyroscope server` and see the profiling data at http://localhost:4040/adhoc-single")
 	}
 	return nil
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
+	"github.com/pyroscope-io/pyroscope/pkg/adhoc/util"
 	"github.com/pyroscope-io/pyroscope/pkg/agent/spy"
 	"github.com/pyroscope-io/pyroscope/pkg/config"
 	"github.com/pyroscope-io/pyroscope/pkg/util/bytesize"
@@ -212,6 +213,7 @@ func PopulateFlagSet(obj interface{}, flagSet *pflag.FlagSet, vpr *viper.Viper, 
 	o := &options{
 		replacements: map[string]string{
 			"<installPrefix>":           getInstallPrefix(),
+			"<defaultAdhocDataPath>":    util.DataDirectory(),
 			"<defaultAgentConfigPath>":  defaultAgentConfigPath(),
 			"<defaultAgentLogFilePath>": defaultAgentLogFilePath(),
 			"<supportedProfilers>":      strings.Join(spy.SupportedExecSpies(), ", "),

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -189,6 +189,7 @@ var _ = Describe("flags", func() {
 				exampleCommand.SetArgs([]string{
 					"--config=testdata/server.yml",
 					"--log-level=debug",
+					"--adhoc-data-path=", // Override as it's platform dependent.
 				})
 
 				err := exampleCommand.Execute()

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -149,6 +149,7 @@ func newServerService(c *config.Server) (*serverService, error) {
 		Notifier:        svc.healthController,
 		Adhoc: adhocserver.New(
 			svc.logger,
+			svc.config.AdhocDataPath,
 			svc.config.MaxNodesRender,
 			svc.config.EnableExperimentalAdhocUI,
 		),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,9 +33,10 @@ type Adhoc struct {
 	MaxNodesSerialization int           `def:"2048" desc:"max number of nodes used when saving profiles to disk" mapstructure:"max-nodes-serialization"`
 	Duration              time.Duration `def:"0" desc:"duration of the profiling session, which is the whole execution of the profield process by default" mapstructure:"duration"`
 
-	// JSON output configuration
+	// Output configuration
 	MaxNodesRender int    `def:"8192" desc:"max number of nodes used to display data on the frontend" mapstructure:"max-nodes-render"`
 	OutputFormat   string `def:"json" desc:"format to export profiling data, supported formats are: json, pprof, collapsed" mapstructure:"output-format"`
+	DataPath       string `def:"<defaultAdhocDataPath>" desc:"directory where pyroscope stores adhoc profiles" mapstructure:"data-path"`
 
 	// Spy configuration
 	ApplicationName    string `def:"" desc:"application name used when uploading profiling data" mapstructure:"application-name"`
@@ -137,6 +138,7 @@ type Server struct {
 	AdminSocketPath           string `def:"/tmp/pyroscope.sock" desc:"path where the admin server socket will be created." mapstructure:"admin-socket-path"`
 	EnableExperimentalAdmin   bool   `def:"true" deprecated:"true" desc:"whether to enable the experimental admin interface" mapstructure:"enable-experimental-admin"`
 	EnableExperimentalAdhocUI bool   `def:"false" desc:"whether to enable the experimental adhoc ui interface" mapstructure:"enable-experimental-adhoc-ui"`
+	AdhocDataPath             string `def:"<defaultAdhocDataPath>" desc:"directory where pyroscope stores adhoc profiles" mapstructure:"adhoc-data-path"`
 
 	ScrapeConfigs []*scrape.Config `yaml:"scrape-configs" mapstructure:"-"`
 


### PR DESCRIPTION
- Add instructions on how to launch the server / view profiling data after using `pyroscope adhoc`.
- Make adhoc data directory configurable.
- Use `$HOME/.pyroscope` by default adhoc data directory in macOS.
- Replace Walk by WalkDir and avoid recursive walking.