### PR TITLE
chore(frontend): set a default query when there's nothing in the url

### DIFF
--- a/cypress/integration/webapp/e2e.ts
+++ b/cypress/integration/webapp/e2e.ts
@@ -13,6 +13,9 @@ function randomName() {
     .join('');
 }
 
+// assume this is probably the first app when ordered alphabetically
+const firstApp = 'aaaaa';
+
 describe('E2E Tests', () => {
   // TODO:
   // instead of generating a new application
@@ -33,6 +36,12 @@ describe('E2E Tests', () => {
     // it's important that they are recent
     // otherwise the database may just drop them
     // if they are older than the retention date
+
+    cy.request({
+      method: 'POST',
+      url: `/ingest?name=${firstApp}&sampleRate=100&from=${t1}&until=${t1}`,
+      body: 'foo;bar 100',
+    });
 
     cy.request({
       method: 'POST',
@@ -104,5 +113,16 @@ describe('E2E Tests', () => {
     cy.findByTestId('flamegraph-canvas').matchImageSnapshot(
       `e2e-comparison-diff-flamegraph`
     );
+  });
+
+  // This is tested as an e2e test
+  // Since the list of app names comes populated from the database
+  it('sets the first app as the query if nothing is set', () => {
+    cy.visit('/');
+
+    cy.location().should((loc) => {
+      const params = new URLSearchParams(loc.search);
+      expect(params.get('query')).to.eq(`${firstApp}{}`);
+    });
   });
 });

--- a/webapp/javascript/components/Header.jsx
+++ b/webapp/javascript/components/Header.jsx
@@ -13,7 +13,14 @@ import TagsBar from './TagsBar';
 import { fetchNames } from '../redux/actions';
 
 function Header(props) {
-  const { areNamesLoading, isJSONLoading } = props;
+  const { areNamesLoading, isJSONLoading, query } = props;
+
+  // This component initializes using a value frmo the redux store (query)
+  // Which doesn't work well when the 'query' changes in the store (see https://reactjs.org/docs/forms.html#controlled-components)
+  // This is a workaround to force the component to always remount
+  // TODO: move the state from this component into the redux store
+  const tagsBar = <TagsBar key={query} />;
+
   return (
     <>
       <div className="navbar">
@@ -37,7 +44,7 @@ function Header(props) {
         &nbsp;
         <DateRangePicker />
       </div>
-      <TagsBar />
+      {tagsBar}
     </>
   );
 }

--- a/webapp/javascript/components/NameSelector.spec.tsx
+++ b/webapp/javascript/components/NameSelector.spec.tsx
@@ -50,4 +50,9 @@ describe('NameSelector', () => {
       .click();
     screen.getByRole('menuitem', { name: 'myapp' });
   });
+
+  //  it('sets the first available app as the default', () => {
+  //    (appNames as any).fetchAppNames.mockResolvedValueOnce(Result.ok(['myapp']));
+  //    render(<NameSelector />);
+  //  })
 });

--- a/webapp/javascript/components/NameSelector.tsx
+++ b/webapp/javascript/components/NameSelector.tsx
@@ -1,6 +1,6 @@
 // TODO reenable spreading lint
 /* eslint-disable react/jsx-props-no-spreading */
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { useAppSelector, useAppDispatch } from '@pyroscope/redux/hooks';
@@ -14,7 +14,6 @@ import LoadingSpinner from '@ui/LoadingSpinner';
 import Button from '@ui/Button';
 import { faSyncAlt } from '@fortawesome/free-solid-svg-icons/faSyncAlt';
 import Dropdown, { MenuItem, FocusableItem } from '@ui/Dropdown';
-import { Maybe } from '@utils/fp';
 import { setQuery } from '../redux/actions';
 import styles from './NameSelector.module.scss';
 
@@ -25,7 +24,7 @@ function NameSelector(props) {
   const appNamesState = useAppSelector(selectAppNamesState);
   const appNames = useAppSelector(selectAppNames);
 
-  const [filter, setFilter] = useState<Maybe<string>>(Maybe.nothing());
+  const [filter, setFilter] = useState('');
 
   const selectAppName = (name: string) => {
     const query = appNameToQuery(name);
@@ -33,6 +32,18 @@ function NameSelector(props) {
   };
 
   const dispatch = useAppDispatch();
+
+  // if there's no query set
+  // set the first app as the default (if exists)
+  useEffect(() => {
+    if (!query) {
+      const first = appNames[0];
+      if (first) {
+        const query = appNameToQuery(first);
+        actions.setQuery(query);
+      }
+    }
+  }, [query]);
 
   const selectedValue = queryToAppName(query).mapOr('', (q) => {
     if (appNames.indexOf(q) !== -1) {
@@ -42,7 +53,7 @@ function NameSelector(props) {
   });
 
   const filterOptions = (n: string) => {
-    const f = filter.mapOr('', (v) => v.trim().toLowerCase());
+    const f = filter.trim().toLowerCase();
     return n.toLowerCase().includes(f);
   };
 
@@ -79,8 +90,8 @@ function NameSelector(props) {
               ref={ref}
               type="text"
               placeholder="Type an app"
-              value={filter.mapOr('', (v) => v)}
-              onChange={(e) => setFilter(Maybe.just(e.target.value))}
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
             />
           )}
         </FocusableItem>

--- a/webapp/javascript/components/TagsBar.jsx
+++ b/webapp/javascript/components/TagsBar.jsx
@@ -20,10 +20,6 @@ function TagsBar({ query, actions, tags, tagValuesLoading }) {
   const [filter, setFilter] = useState({});
 
   useEffect(() => {
-    setQuery(query);
-  }, [query]);
-
-  useEffect(() => {
     actions.fetchTags(query);
 
     return actions.abortFetchTags;

--- a/webapp/javascript/redux/store.ts
+++ b/webapp/javascript/redux/store.ts
@@ -39,10 +39,6 @@ const store = configureStore({
   // middleware: [thunkMiddleware],
 });
 
-const defaultName = (window as any).initialState.appNames.find(
-  (x) => x !== 'pyroscope.server.cpu'
-);
-
 ReduxQuerySync({
   store, // your Redux store
   params: {
@@ -77,7 +73,7 @@ ReduxQuerySync({
       action: setRightUntil,
     },
     query: {
-      defaultValue: `${defaultName || 'pyroscope.server.cpu'}{}`,
+      defaultvalue: '',
       selector: (state) => state.root.query,
       action: setQuery,
     },


### PR DESCRIPTION
When one opens up the app, there's no `query` set, so it uses a default based on certain heuristics.
That makes it a bit annoying when you refresh the page, since the app you were just lookign at may have changed (depending on these heuristics).

This PR does the following:
* if there's no query set in the url
* use the FIRST one, ordered alphabetically via what the store is returning
* pushes that to the store and CONSEQUENTELY updates the query param
https://user-images.githubusercontent.com/6951209/148997182-7f97b40e-c081-498a-be2f-3380323774cc.mp4



Also handles https://github.com/pyroscope-io/pyroscope/issues/656
https://user-images.githubusercontent.com/6951209/148997289-d9896e93-c3ce-453d-821f-184b1a8a0be0.mp4




