### PR TITLE
chore: install yarn dependencies when running 'make dev'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ install-dev-tools: ## Install dev tools
 	cat tools/tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI {} go install {}
 
 .PHONY: dev
-dev: install-web-dependencies
+dev: install-web-dependencies ## Start webpack and pyroscope server. Use this one for working on pyroscope
 	goreman -exit-on-error -f scripts/dev-procfile start
 
 .PHONY: godoc

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,18 @@ install-web-dependencies: ## Install the web dependencies
 install-build-web-dependencies: ## Install web dependencies only necessary for a build
 	NODE_ENV=production yarn install --frozen-lockfile
 
+.PHONY: assets
+assets: install-web-dependencies ## deprecated
+	@echo "This command is deprecated, please use `make dev` to develop locally"
+	exit 1
+	# yarn dev
+
+.PHONY: assets-watch
+assets-watch: install-web-dependencies ## deprecated
+	@echo "This command is deprecated, please use `make dev` to develop locally"
+	exit 1
+	# yarn dev -- --watch
+
 .PHONY: assets-release
 assets-release: ## Configure the assets for release
 	rm -rf webapp/public/assets

--- a/Makefile
+++ b/Makefile
@@ -158,14 +158,6 @@ install-web-dependencies: ## Install the web dependencies
 install-build-web-dependencies: ## Install web dependencies only necessary for a build
 	NODE_ENV=production yarn install --frozen-lockfile
 
-.PHONY: assets
-assets: install-web-dependencies ## Configure the assets
-	yarn dev
-
-.PHONY: assets-watch
-assets-watch: install-web-dependencies ## Configure the assets with live reloading
-	yarn dev -- --watch
-
 .PHONY: assets-release
 assets-release: ## Configure the assets for release
 	rm -rf webapp/public/assets
@@ -208,7 +200,7 @@ install-dev-tools: ## Install dev tools
 	cat tools/tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI {} go install {}
 
 .PHONY: dev
-dev: ## dev
+dev: install-web-dependencies
 	goreman -exit-on-error -f scripts/dev-procfile start
 
 .PHONY: godoc


### PR DESCRIPTION
This was brought up by @petethepig, it's annoying how you run `make dev` then to only realize the app is not working because there are new dependencies. 

This PR makes  the `install-web-dependencies` run before `make dev`.

Also cleans up other tasks that don't seem to be used anymore.