### PR TITLE
chore: don't calculate webpack hash when in local dev

### DIFF
--- a/scripts/webpack/webpack.common.ts
+++ b/scripts/webpack/webpack.common.ts
@@ -28,7 +28,7 @@ const pagePlugins = pages.map(
         // https://webpack.js.org/configuration/mode/
         const hash =
           process.env.NODE_ENV === 'production'
-            ? compilation.getstats().toJson().hash
+            ? compilation.getStats().toJson().hash
             : LOCAL_HASH;
 
         return {

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -47,3 +47,11 @@ For example, acessing http://locahlost:4040/forbidden won't work
 To be able to access it, update the variable `pages` in `scripts/webpack.common.ts` to allow building all pages when in dev mode.
 
 Beware, this will make the (local) build slower.
+
+# Investigating webpack speed
+Run with `--progress=profile` to get more info.
+
+for example `yarn dev --progress=profile`
+
+
+Another interesting flag is `--json`, which you can then analyze on https://chrisbateman.github.io/webpack-visualizer/


### PR DESCRIPTION
That makes local builds faster https://webpack.js.org/guides/build-performance/#avoid-production-specific-tooling

We went from (dev, incremental build)

```
webpack 5.65.0 compiled with 1 warning in 1257 ms
```
to
```
webpack 5.65.0 compiled with 1 warning in 223 ms
```


@petethepig I even removed that ["optimization" we didn't like](https://github.com/pyroscope-io/pyroscope/pull/686#discussion_r780840358) since it doesn't seem to be relevant here anymore :)
