### PR TITLE
fix(frontend): don't allow selecting empty apps

### DIFF
--- a/webapp/javascript/services/appNames.spec.ts
+++ b/webapp/javascript/services/appNames.spec.ts
@@ -44,4 +44,21 @@ describe('AppNames', () => {
       ])
     );
   });
+
+  it('ignores apps with invalid names', async () => {
+    server = setupServer(
+      rest.get(`http://localhost/label-values`, (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+
+          ctx.json(['app1', 'app2', ' ', ''])
+        );
+      })
+    );
+
+    server.listen();
+    const res = await fetchAppNames();
+
+    expect(res).toMatchObject(Result.ok(['app1', 'app2']));
+  });
 });

--- a/webapp/javascript/services/appNames.ts
+++ b/webapp/javascript/services/appNames.ts
@@ -13,13 +13,19 @@ export interface FetchAppNamesError {
   message?: string;
 }
 
+// Due to circunstances, older versions of pyroscope accepted apps with empty names
+// TODO: maybe also check for illegal characters and whatnot?
+function isValidAppName(appName: string) {
+  return appName.trim().length > 0;
+}
+
 export async function fetchAppNames(
   props?: FetchAppNamesProps
 ): Promise<Result<AppNames, RequestError | ZodError>> {
   const response = await request('label-values?label=__name__');
 
   if (response.isOk) {
-    return parse(response.value);
+    return parse(response.value).map((values) => values.filter(isValidAppName));
   }
 
   return Result.err<AppNames, RequestError>(response.error);


### PR DESCRIPTION
Due to circumstances, some of our old apps have empty strings as name. This PR ashamedly skips those when fetching from the backend.

Highlighted an app with empty name (which this PR skips)
![image](https://user-images.githubusercontent.com/6951209/149403523-f5cbeed9-186a-4f38-a923-91d4d711b25d.png)

