### PR TITLE
Add html export

### DIFF
--- a/webapp/javascript/components/ExportData.tsx
+++ b/webapp/javascript/components/ExportData.tsx
@@ -146,7 +146,8 @@ function ExportData(props: ExportDataProps) {
               className="dropdown-menu-item"
               type="button"
               onClick={() => exportHtml(exportFlamebearer)}
-            >   Html
+            >
+              Html
             </button>
           )}
         </div>

--- a/webapp/javascript/util/formatDate.js
+++ b/webapp/javascript/util/formatDate.js
@@ -38,6 +38,17 @@ export function readableRange(from, until) {
   return `${format(d1, dateFormat)} - ${format(d2, dateFormat)}`;
 }
 
+export function dateForExportFilename(from, until) {
+  const dateFormat = 'yyyy-MM-dd_HHmm';
+  if (/^now-/.test(from) && until === 'now') {
+    const { number, _multiplier } = convertPresetsToDate(from);
+    return `Last ${number} ${_multiplier}`;
+  }
+
+  const d1 = new Date(Math.round(from * 1000));
+  const d2 = new Date(Math.round(until * 1000));
+  return `${format(d1, dateFormat)}-to-${format(d2, dateFormat)}`;
+}
 /**
  * formateAsOBject() returns a Date object
  * based on the passed-in parameter value


### PR DESCRIPTION
Adds html export button and changes the way we do filenames for it.

Before we were just doing current date, but I think its more helpful for debugging if we do the start and enddate of the query so that different queries taken on the same day will reflect that as opposed to having the same file name.