### PR TITLE
feat: storage.Get tracing

### DIFF
--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -284,7 +284,7 @@ func (ctrl *Controller) Start() error {
 		Addr:           ctrl.config.APIBindAddr,
 		Handler:        handler,
 		ReadTimeout:    10 * time.Second,
-		WriteTimeout:   10 * time.Second,
+		WriteTimeout:   15 * time.Second,
 		IdleTimeout:    30 * time.Second,
 		MaxHeaderBytes: 1 << 20,
 		ErrorLog:       golog.New(w, "", 0),

--- a/pkg/storage/storage_get.go
+++ b/pkg/storage/storage_get.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"runtime/trace"
 	"sort"
-	"time"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -32,9 +33,22 @@ type GetOutput struct {
 	Units      string
 }
 
-const averageAggregationType = "average"
+const (
+	averageAggregationType = "average"
+
+	traceTaskGet        = "storage.Get"
+	traceCatGetKey      = traceTaskGet
+	traceCatGetCallback = traceTaskGet + ".Callback"
+)
 
 func (s *Storage) Get(gi *GetInput) (*GetOutput, error) {
+	return s.GetContext(context.Background(), gi)
+}
+
+func (s *Storage) GetContext(ctx context.Context, gi *GetInput) (*GetOutput, error) {
+	var t *trace.Task
+	ctx, t = trace.NewTask(ctx, traceTaskGet)
+	defer t.End()
 	logger := logrus.WithFields(logrus.Fields{
 		"startTime": gi.StartTime.String(),
 		"endTime":   gi.EndTime.String(),
@@ -55,6 +69,7 @@ func (s *Storage) Get(gi *GetInput) (*GetOutput, error) {
 
 	s.getTotal.Inc()
 	logger.Debug("storage.Get")
+	trace.Logf(ctx, traceCatGetKey, "%+v", gi)
 
 	var (
 		resultTrie  *tree.Tree
@@ -86,8 +101,12 @@ func (s *Storage) Get(gi *GetInput) (*GetOutput, error) {
 		timeline.PopulateTimeline(st)
 		lastSegment = st
 
-		st.Get(gi.StartTime, gi.EndTime, func(depth int, samples, writes uint64, t time.Time, r *big.Rat) {
-			if res, ok = s.trees.Lookup(parsedKey.TreeKey(depth, t)); ok {
+		trace.Logf(ctx, traceCatGetCallback, "segment_key=%s", key)
+		st.GetContext(ctx, gi.StartTime, gi.EndTime, func(depth int, samples, writes uint64, t time.Time, r *big.Rat) {
+			tk := parsedKey.TreeKey(depth, t)
+			res, ok = s.trees.Lookup(tk)
+			trace.Logf(ctx, traceCatGetCallback, "tree_found=%v time=%d r=%v", ok, t.Unix(), r)
+			if ok {
 				x := res.(*tree.Tree).Clone(r)
 				writesTotal += writes
 				if resultTrie == nil {


### PR DESCRIPTION
The PR adds pprof trace for storage Get. This is aimed at improving our ability to debug issues similar to https://github.com/pyroscope-io/pyroscope/issues/715.

The trace can be collected via the default `/debug/pprof/trace` endpoint:
1. Ensure pyroscope server is running and pprof endpoint is enabled (by default).
2. Start tracing (substitute URL as appropriate) - note that the duration is limited to 15s (we use 10 as it should be enough in most cases):
```
curl "http://localhost:4040/debug/pprof/trace?seconds=10" -o /tmp/trace
```
3. Execute the query of interest via UI/API.
4. Open collected trace with `go tool trace`:
```
go tool trace -http=localhost:7532 /tmp/trace
```
5. Navigate to the opened page, **User-defined tasks**, **storage.Get**.
6. You should see logs similar to:

<details>
  <summary>Task log</summary>

  ```javascript

3.345484334 | .          | 150 | task storage.Get (id 2, parent 0) created
3.345539611 | .    55277 | 150 | storage.Get=&{StartTime:2022-01-14 18:08:34.755357 +0100 CET m=-3565.791375588 EndTime:2022-01-14 19:08:34.755359 +0100 CET m=+34.208626135 Key:<nil> Query:pyroscope.server.cpu{}}
3.345624754 | .    85143 | 150 | storage.Get.Callback=segment_key=pyroscope.server.cpu{}
3.345633193 | .     8439 | 150 | region segment.Get started (duration: 11.803354ms)
3.345647439 | .    14246 | 150 | node.get=D=4 T=1642103200 P=true M=false R=inside
3.345655285 | .     7846 | 150 | node.get=drill down
3.345677495 | .    22210 | 150 | node.get=D=3 T=1642173200 P=true M=false R=overlap
3.345685175 | .     7680 | 150 | node.get=drill down
3.345693234 | .     8059 | 150 | node.get=D=2 T=1642173200 P=true M=false R=outside
3.345701886 | .     8652 | 150 | node.get=D=2 T=1642174200 P=true M=false R=outside
3.345710348 | .     8462 | 150 | node.get=D=2 T=1642175200 P=true M=false R=outside
3.345718265 | .     7917 | 150 | node.get=D=2 T=1642176200 P=true M=false R=outside
3.345726396 | .     8131 | 150 | node.get=D=2 T=1642177200 P=true M=false R=outside
3.345734740 | .     8344 | 150 | node.get=D=2 T=1642178200 P=true M=false R=outside
3.345742894 | .     8154 | 150 | node.get=D=2 T=1642179200 P=true M=false R=overlap
3.345750218 | .     7324 | 150 | node.get=drill down
3.345758348 | .     8130 | 150 | node.get=D=1 T=1642179200 P=true M=false R=outside
3.345766977 | .     8629 | 150 | node.get=D=1 T=1642179300 P=true M=false R=outside
3.345774396 | .     7419 | 150 | node.get=D=1 T=1642179400 P=true M=false R=outside
3.345781744 | .     7348 | 150 | node.get=D=1 T=1642179500 P=true M=false R=outside
3.345789614 | .     7870 | 150 | node.get=D=1 T=1642179600 P=true M=false R=outside
3.345797483 | .     7869 | 150 | node.get=D=1 T=1642179700 P=true M=false R=outside
3.345806325 | .     8842 | 150 | node.get=D=1 T=1642179800 P=true M=false R=outside
3.345814242 | .     7917 | 150 | node.get=D=1 T=1642179900 P=true M=false R=outside
3.345822396 | .     8154 | 150 | node.get=D=1 T=1642180000 P=true M=false R=outside
3.345831285 | .     8889 | 150 | node.get=D=1 T=1642180100 P=true M=false R=overlap
3.345838017 | .     6732 | 150 | node.get=drill down
3.345846740 | .     8723 | 150 | node.get=D=0 T=1642180100 P=true M=false R=outside
3.345854870 | .     8130 | 150 | node.get=D=0 T=1642180110 P=true M=true R=contain
3.346147966 | .   293096 | 150 | storage.Get.Callback=tree_found=true time=1642180110 r=1/1
3.346169276 | .    21310 | 150 | node.get=D=0 T=1642180120 P=true M=true R=contain
3.348387753 | .  2218477 | 150 | storage.Get.Callback=tree_found=true time=1642180120 r=1/1
3.348446467 | .    58714 | 150 | node.get=D=0 T=1642180130 P=true M=true R=contain
3.348717116 | .   270649 | 150 | storage.Get.Callback=tree_found=true time=1642180130 r=1/1
3.348759166 | .    42050 | 150 | node.get=D=0 T=1642180140 P=true M=true R=contain
3.348982669 | .   223503 | 150 | storage.Get.Callback=tree_found=true time=1642180140 r=1/1
3.349017442 | .    34773 | 150 | node.get=D=0 T=1642180150 P=true M=true R=contain
3.349236346 | .   218904 | 150 | storage.Get.Callback=tree_found=true time=1642180150 r=1/1
3.349269531 | .    33185 | 150 | node.get=D=0 T=1642180160 P=true M=true R=contain
3.349497703 | .   228172 | 150 | storage.Get.Callback=tree_found=true time=1642180160 r=1/1
3.349526977 | .    29274 | 150 | node.get=D=0 T=1642180170 P=true M=true R=contain
3.349922046 | .   395069 | 150 | storage.Get.Callback=tree_found=true time=1642180170 r=1/1
3.349957223 | .    35177 | 150 | node.get=D=0 T=1642180180 P=true M=true R=contain
3.352051421 | .  2094198 | 150 | storage.Get.Callback=tree_found=true time=1642180180 r=1/1
3.352264778 | .   213357 | 150 | node.get=D=0 T=1642180190 P=true M=true R=contain
3.353511688 | .  1246910 | 150 | storage.Get.Callback=tree_found=true time=1642180190 r=1/1
3.353620440 | .   108752 | 150 | node.get=D=2 T=1642180200 P=true M=true R=contain
3.353685270 | .    64830 | 150 | storage.Get.Callback=tree_found=true time=1642180200 r=1/1
3.354193430 | .   508160 | 150 | node.get=D=2 T=1642181200 P=true M=true R=contain
3.354216043 | .    22613 | 150 | storage.Get.Callback=tree_found=true time=1642181200 r=1/1
3.354631214 | .   415171 | 150 | node.get=D=2 T=1642182200 P=true M=true R=contain
3.354719202 | .    87988 | 150 | storage.Get.Callback=tree_found=true time=1642182200 r=1/1
3.355278775 | .   559573 | 150 | node.get=D=3 T=1642183200 P=false M=false R=overlap
3.355294017 | .    15242 | 150 | node.get=drill down
3.356730580 | .  1436563 | 150 | node.get=D=2 T=1642183200 P=true M=false R=overlap
3.356765780 | .    35200 | 150 | node.get=drill down
3.356782989 | .    17209 | 150 | node.get=D=1 T=1642183300 P=false M=false R=contain
3.356792138 | .     9149 | 150 | node.get=drill down
3.356802189 | .    10051 | 150 | node.get=D=0 T=1642183390 P=true M=true R=contain
3.356875718 | .    73529 | 150 | storage.Get.Callback=tree_found=true time=1642183390 r=1/1
3.356995895 | .   120177 | 150 | node.get=D=1 T=1642183400 P=true M=true R=contain
3.357024814 | .    28919 | 150 | storage.Get.Callback=tree_found=true time=1642183400 r=1/1
3.357127546 | .   102732 | 150 | node.get=D=1 T=1642183600 P=true M=true R=contain
3.357153383 | .    25837 | 150 | storage.Get.Callback=tree_found=true time=1642183600 r=1/1
3.357307599 | .   154216 | 150 | node.get=D=1 T=1642183700 P=false M=false R=overlap
3.357320802 | .    13203 | 150 | node.get=drill down
3.357329430 | .     8628 | 150 | node.get=D=0 T=1642183700 P=true M=true R=contain
3.357352162 | .    22732 | 150 | storage.Get.Callback=tree_found=true time=1642183700 r=1/1
3.357450746 | .    98584 | 150 | task end
  ```
  
</details>
