### PR TITLE
fix: add --pid=host option

### DIFF
--- a/examples/ebpf/docker-compose.yml
+++ b/examples/ebpf/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     image: 'pyroscope/pyroscope:latest'
     user: root
     privileged: true
+    pid: "host"
     volumes:
       - /lib/modules:/lib/modules
     command:


### PR DESCRIPTION
## WHAT

I added the pid=host option to the ebpf docker example

## WHY

The process ID of the host cannot be recognized from within the container, so the frame result will be UNKNOW.

![2022-01-16T23_41_54,329708157+09_00](https://user-images.githubusercontent.com/25459661/149664893-dbfffb94-0275-4fea-9819-80e9569070f0.png)

However, with this PR fix, the result will be as follows.

![2022-01-16T23_56_20,187117378+09_00](https://user-images.githubusercontent.com/25459661/149665300-8690daf2-c99d-4ad4-a0fd-e73f217231dc.png)

## Which version of docker

```
Client:
 Version:           20.10.12
 API version:       1.41
 Go version:        go1.17.5
 Git commit:        e91ed5707e
 Built:             Mon Dec 13 22:31:40 2021
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server:
 Engine:
  Version:          20.10.12
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.17.5
  Git commit:       459d0dfbbb
  Built:            Mon Dec 13 22:30:43 2021
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          v1.5.9
  GitCommit:        1407cab509ff0d96baa4f0eb6ff9980270e6e620.m
 runc:
  Version:          1.0.3
  GitCommit:        v1.0.3-0-gf46b6ba2
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

