### PR TITLE
feat: add debug storage export endpoint

### DIFF
--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -176,6 +176,7 @@ func (ctrl *Controller) mux() (http.Handler, error) {
 	diagnosticSecureRoutes := []route{
 		{"/config", ctrl.configHandler},
 		{"/build", ctrl.buildHandler},
+		{"/debug/storage/export/{db}", ctrl.storage.DebugExport},
 	}
 	if !ctrl.config.DisablePprofEndpoint {
 		diagnosticSecureRoutes = append(diagnosticSecureRoutes, []route{

--- a/pkg/storage/debug.go
+++ b/pkg/storage/debug.go
@@ -1,0 +1,65 @@
+package storage
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/gorilla/mux"
+)
+
+func (s *Storage) DebugExport(w http.ResponseWriter, r *http.Request) {
+	select {
+	default:
+	case <-s.stop:
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	n := mux.Vars(r)["db"]
+	var d *db
+	switch n {
+	case "segments":
+		d = s.segments
+	case "trees":
+		d = s.trees
+	case "dicts":
+		d = s.dicts
+	case "dimensions":
+		d = s.dimensions
+	default:
+		// Note that export from main DB is not allowed.
+		http.Error(w, fmt.Sprintf("database %q not found", n), http.StatusNotFound)
+		return
+	}
+
+	// TODO(kolesnikovae): Refactor routes registration and use gorilla Queries.
+	k, ok := r.URL.Query()["k"]
+	if !ok || len(k) != 1 {
+		http.Error(w, "query parameter 'k' is required", http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	err := d.DB.View(func(txn *badger.Txn) error {
+		item, err := txn.Get([]byte(k[0]))
+		if err != nil {
+			return err
+		}
+		return item.Value(func(v []byte) error {
+			_, err = io.Copy(w, bytes.NewBuffer(v))
+			return err
+		})
+	})
+
+	switch {
+	case err == nil:
+	case errors.Is(err, badger.ErrKeyNotFound):
+		http.Error(w, fmt.Sprintf("key %q not found in %s", k[0], n), http.StatusNotFound)
+	default:
+		http.Error(w, fmt.Sprintf("failed to export value for key %q: %v", k[0], err), http.StatusInternalServerError)
+	}
+}


### PR DESCRIPTION
The PR is aimed at improving debuggability. In order to solve issues like https://github.com/pyroscope-io/pyroscope/issues/715 more efficiently we need an option to export data from the storage in a user-friendly way. We extend our `/debug` endpoints list with `/debug/storage/export/{db}` that exports values from the storage via HTTP.

Example:
```
curl -G -o /tmp/segment --data-urlencode "k=s:pyroscope.server.cpu{}" http://localhost:4040/debug/storage/export/segments
```

The request will write `s:pyroscope.server.cpu{}` segment raw bytes to /tmp/segment.

NOTE: We have set 15 seconds HTTP server timeout, and it is not configurable. I'm wondering if this should be lifted - say, a minute, or two.
