### PR TITLE
Swap default tabs in adhoc mode

### DIFF
--- a/webapp/javascript/components/AdhocComparison.tsx
+++ b/webapp/javascript/components/AdhocComparison.tsx
@@ -112,21 +112,21 @@ function AdhocComparison(props) {
           <Box className={styles.comparisonPane}>
             <Tabs>
               <TabList>
-                <Tab>Pyroscope data</Tab>
                 <Tab>Upload</Tab>
+                <Tab>Pyroscope data</Tab>
               </TabList>
-              <TabPanel>
-                <FileList
-                  className={adhocStyles.tabPanel}
-                  profile={rightProfile}
-                  setProfile={setAdhocRightProfile}
-                />
-              </TabPanel>
               <TabPanel>
                 <FileUploader
                   className={adhocStyles.tabPanel}
                   file={rightFile}
                   setFile={setAdhocRightFile}
+                />
+              </TabPanel>
+              <TabPanel>
+                <FileList
+                  className={adhocStyles.tabPanel}
+                  profile={rightProfile}
+                  setProfile={setAdhocRightProfile}
                 />
               </TabPanel>
             </Tabs>

--- a/webapp/javascript/components/AdhocComparison.tsx
+++ b/webapp/javascript/components/AdhocComparison.tsx
@@ -79,17 +79,17 @@ function AdhocComparison(props) {
                 <Tab>Upload</Tab>
               </TabList>
               <TabPanel>
-                <FileList
-                  className={adhocStyles.tabPanel}
-                  profile={leftProfile}
-                  setProfile={setAdhocLeftProfile}
-                />
-              </TabPanel>
-              <TabPanel>
                 <FileUploader
                   className={adhocStyles.tabPanel}
                   file={leftFile}
                   setFile={setAdhocLeftFile}
+                />
+              </TabPanel>
+              <TabPanel>
+                <FileList
+                  className={adhocStyles.tabPanel}
+                  profile={leftProfile}
+                  setProfile={setAdhocLeftProfile}
                 />
               </TabPanel>
             </Tabs>

--- a/webapp/javascript/components/AdhocComparison.tsx
+++ b/webapp/javascript/components/AdhocComparison.tsx
@@ -75,8 +75,8 @@ function AdhocComparison(props) {
           <Box className={styles.comparisonPane}>
             <Tabs>
               <TabList>
-                <Tab>Pyroscope data</Tab>
                 <Tab>Upload</Tab>
+                <Tab>Pyroscope data</Tab>
               </TabList>
               <TabPanel>
                 <FileUploader

--- a/webapp/javascript/components/AdhocComparisonDiff.tsx
+++ b/webapp/javascript/components/AdhocComparisonDiff.tsx
@@ -57,6 +57,7 @@ function AdhocComparisonDiff(props) {
                 <Tab>Pyroscope data</Tab>
                 <Tab disabled>Upload</Tab>
               </TabList>
+              <TabPanel />
               <TabPanel>
                 <FileList
                   className={adhocStyles.tabPanel}
@@ -64,7 +65,6 @@ function AdhocComparisonDiff(props) {
                   setProfile={setAdhocLeftProfile}
                 />
               </TabPanel>
-              <TabPanel />
             </Tabs>
           </Box>
           <Box className={styles.comparisonPane}>
@@ -73,6 +73,7 @@ function AdhocComparisonDiff(props) {
                 <Tab>Pyroscope data</Tab>
                 <Tab disabled>Upload</Tab>
               </TabList>
+              <TabPanel />
               <TabPanel>
                 <FileList
                   className={adhocStyles.tabPanel}
@@ -80,7 +81,6 @@ function AdhocComparisonDiff(props) {
                   setProfile={setAdhocRightProfile}
                 />
               </TabPanel>
-              <TabPanel />
             </Tabs>
           </Box>
         </div>

--- a/webapp/javascript/components/AdhocComparisonDiff.tsx
+++ b/webapp/javascript/components/AdhocComparisonDiff.tsx
@@ -57,7 +57,6 @@ function AdhocComparisonDiff(props) {
                 <Tab>Pyroscope data</Tab>
                 <Tab disabled>Upload</Tab>
               </TabList>
-              <TabPanel />
               <TabPanel>
                 <FileList
                   className={adhocStyles.tabPanel}
@@ -65,6 +64,7 @@ function AdhocComparisonDiff(props) {
                   setProfile={setAdhocLeftProfile}
                 />
               </TabPanel>
+              <TabPanel />
             </Tabs>
           </Box>
           <Box className={styles.comparisonPane}>
@@ -73,7 +73,6 @@ function AdhocComparisonDiff(props) {
                 <Tab>Pyroscope data</Tab>
                 <Tab disabled>Upload</Tab>
               </TabList>
-              <TabPanel />
               <TabPanel>
                 <FileList
                   className={adhocStyles.tabPanel}
@@ -81,6 +80,7 @@ function AdhocComparisonDiff(props) {
                   setProfile={setAdhocRightProfile}
                 />
               </TabPanel>
+              <TabPanel />
             </Tabs>
           </Box>
         </div>

--- a/webapp/javascript/components/AdhocSingle.jsx
+++ b/webapp/javascript/components/AdhocSingle.jsx
@@ -44,8 +44,8 @@ function AdhocSingle(props) {
         <Box>
           <Tabs>
             <TabList>
-              <Tab>Pyroscope data</Tab>
               <Tab>Upload</Tab>
+              <Tab>Pyroscope data</Tab>
             </TabList>
             <TabPanel>
               <FileUploader

--- a/webapp/javascript/components/AdhocSingle.jsx
+++ b/webapp/javascript/components/AdhocSingle.jsx
@@ -48,17 +48,17 @@ function AdhocSingle(props) {
               <Tab>Upload</Tab>
             </TabList>
             <TabPanel>
-              <FileList
-                className={adhocStyles.tabPanel}
-                profile={profile}
-                setProfile={setAdhocProfile}
-              />
-            </TabPanel>
-            <TabPanel>
               <FileUploader
                 className={adhocStyles.tabPanel}
                 file={file}
                 setFile={setAdhocFile}
+              />
+            </TabPanel>
+            <TabPanel>
+              <FileList
+                className={adhocStyles.tabPanel}
+                profile={profile}
+                setProfile={setAdhocProfile}
               />
             </TabPanel>
           </Tabs>


### PR DESCRIPTION
Currently tabs default to `~/.pyroscope`, but when we first release this that director will be empty. However, I suspect that people will have some pprof files laying around which they can use with Pyroscope adhoc mode, so lets default to the drag and drop view instead