### PR TITLE
refactor: make converted functions versioned.

### DIFF
--- a/pkg/adhoc/server/convert.go
+++ b/pkg/adhoc/server/convert.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pyroscope-io/pyroscope/pkg/structs/flamebearer"
 )
 
-func JSONToProfile(b []byte, _ string, _ int) (*flamebearer.FlamebearerProfile, error) {
+func JSONToProfileV1(b []byte, _ string, _ int) (*flamebearer.FlamebearerProfile, error) {
 	var profile flamebearer.FlamebearerProfile
 	if err := json.Unmarshal(b, &profile); err != nil {
 		return nil, fmt.Errorf("unable to unmarshall JSON: %w", err)
@@ -24,7 +24,7 @@ func JSONToProfile(b []byte, _ string, _ int) (*flamebearer.FlamebearerProfile, 
 	return &profile, nil
 }
 
-func PprofToProfile(b []byte, name string, maxNodes int) (*flamebearer.FlamebearerProfile, error) {
+func PprofToProfileV1(b []byte, name string, maxNodes int) (*flamebearer.FlamebearerProfile, error) {
 	p, err := convert.ParsePprof(bytes.NewReader(b))
 	if err != nil {
 		return nil, fmt.Errorf("parsing pprof: %w", err)
@@ -56,7 +56,7 @@ func PprofToProfile(b []byte, name string, maxNodes int) (*flamebearer.Flamebear
 	return nil, errors.New("no supported sample type found")
 }
 
-func CollapsedToProfile(b []byte, name string, maxNodes int) (*flamebearer.FlamebearerProfile, error) {
+func CollapsedToProfileV1(b []byte, name string, maxNodes int) (*flamebearer.FlamebearerProfile, error) {
 	t := tree.New()
 	for _, line := range bytes.Split(b, []byte("\n")) {
 		if len(line) == 0 {

--- a/pkg/adhoc/server/server.go
+++ b/pkg/adhoc/server/server.go
@@ -205,11 +205,11 @@ func (s *server) convert(p profile) (*flamebearer.FlamebearerProfile, error) {
 	var converter ConverterFn
 	switch ext {
 	case ".json":
-		converter = JSONToProfile
+		converter = JSONToProfileV1
 	case ".pprof":
-		converter = PprofToProfile
+		converter = PprofToProfileV1
 	case ".txt":
-		converter = CollapsedToProfile
+		converter = CollapsedToProfileV1
 	default:
 		return nil, fmt.Errorf("unsupported file extension %s", ext)
 	}


### PR DESCRIPTION
This is a follow-up to #757. After some further discussion with @eh-am
we agreed that making these functions versioned gives a safer path to
handle version changes.

This is technically a backward-incompatible change that could be
avoided by creating both versioned and unversioned variants pointing
to the same code, but I think it's quite safe to break compatibility
here and avoid that burden.