### PR TITLE
fix: remove unsafe string conversion and support empty strings.

### DIFF
--- a/pkg/storage/tree/tree.go
+++ b/pkg/storage/tree/tree.go
@@ -176,26 +176,32 @@ func (n *treeNode) removeAt(i int) {
 
 func (n *treeNode) insertString(targetLabel string) *treeNode {
 	i, j := 0, len(n.ChildrenNodes)
-	for i < j {
-		m := (i + j) >> 1
-		for k, b := range []byte(targetLabel) {
-			if k >= len(n.ChildrenNodes[m].Name) || b > n.ChildrenNodes[m].Name[k] {
-				// targetLabel > n.ChildrenNodes[m].Name
-				i = m + 1
-				break
-			}
-			if b < n.ChildrenNodes[m].Name[k] {
-				// targetLabel < n.ChildrenNodes[m].Name
-				j = m
-				break
-			}
-			if k == len(targetLabel)-1 {
-				if len(targetLabel) == len(n.ChildrenNodes[m].Name) {
-					// targetLabel == n.ChildrenNodes[m].Name
-					return n.ChildrenNodes[m]
+	if targetLabel == "" {
+		if j > 0 && len(n.ChildrenNodes[0].Name) == 0 {
+			return n.ChildrenNodes[0]
+		}
+	} else {
+		for i < j {
+			m := (i + j) >> 1
+			for k, b := range []byte(targetLabel) {
+				if k >= len(n.ChildrenNodes[m].Name) || b > n.ChildrenNodes[m].Name[k] {
+					// targetLabel > n.ChildrenNodes[m].Name
+					i = m + 1
+					break
 				}
-				// targetLabel < n.ChildrenNodes[m].Name
-				j = m
+				if b < n.ChildrenNodes[m].Name[k] {
+					// targetLabel < n.ChildrenNodes[m].Name
+					j = m
+					break
+				}
+				if k == len(targetLabel)-1 {
+					if len(targetLabel) == len(n.ChildrenNodes[m].Name) {
+						// targetLabel == n.ChildrenNodes[m].Name
+						return n.ChildrenNodes[m]
+					}
+					// targetLabel < n.ChildrenNodes[m].Name
+					j = m
+				}
 			}
 		}
 	}

--- a/pkg/storage/tree/tree_profile.go
+++ b/pkg/storage/tree/tree_profile.go
@@ -2,8 +2,6 @@ package tree
 
 import (
 	"encoding/binary"
-	"reflect"
-	"unsafe"
 
 	"github.com/cespare/xxhash/v2"
 )
@@ -106,7 +104,7 @@ func (r *ProfileReader) readTrees(x *Profile, c labelsCache, f Finder) {
 	if len(indexes) == 0 {
 		return
 	}
-	stack := make([][]byte, 0, 16)
+	stack := make([]string, 0, 16)
 	for _, s := range x.Sample {
 		for i := len(s.LocationId) - 1; i >= 0; i-- {
 			// Resolve stack.
@@ -128,21 +126,17 @@ func (r *ProfileReader) readTrees(x *Profile, c labelsCache, f Finder) {
 				if !ok {
 					continue
 				}
-				stack = append(stack, unsafeStrToSlice(x.StringTable[fn.Name]))
+				stack = append(stack, x.StringTable[fn.Name])
 			}
 		}
 		// Insert tree nodes.
 		for i, vi := range indexes {
 			if v := uint64(s.Value[vi]); v != 0 {
-				c.getOrCreate(types[i], s.Label).InsertStack(stack, v)
+				c.getOrCreate(types[i], s.Label).InsertStackString(stack, v)
 			}
 		}
 		stack = stack[:0]
 	}
-}
-
-func unsafeStrToSlice(s string) []byte {
-	return (*[0x7fff0000]byte)(unsafe.Pointer((*reflect.StringHeader)(unsafe.Pointer(&s)).Data))[:len(s):len(s)]
 }
 
 // sample type -> labels hash -> entry

--- a/pkg/storage/tree/tree_test.go
+++ b/pkg/storage/tree/tree_test.go
@@ -202,6 +202,35 @@ var _ = Describe("tree package", func() {
 		})
 	})
 
+	Context("InsertStackString with empty names", func() {
+		tree := New()
+		tree.InsertStackString([]string{"a", ""}, uint64(1))
+		tree.InsertStackString([]string{"a", "b"}, uint64(2))
+		tree.InsertStackString([]string{"", ""}, uint64(4))
+
+		It("properly sets up a tree", func() {
+			Expect(tree.root.ChildrenNodes).To(HaveLen(2))
+			Expect(tree.root.ChildrenNodes[0].ChildrenNodes).To(HaveLen(1))
+			Expect(tree.root.ChildrenNodes[0].Self).To(Equal(uint64(0)))
+			Expect(tree.root.ChildrenNodes[0].Total).To(Equal(uint64(4)))
+			Expect(string(tree.root.ChildrenNodes[0].Name)).To(Equal(""))
+			Expect(tree.root.ChildrenNodes[1].ChildrenNodes).To(HaveLen(2))
+			Expect(tree.root.ChildrenNodes[1].Self).To(Equal(uint64(0)))
+			Expect(tree.root.ChildrenNodes[1].Total).To(Equal(uint64(3)))
+			Expect(string(tree.root.ChildrenNodes[1].Name)).To(Equal("a"))
+			Expect(tree.root.ChildrenNodes[0].ChildrenNodes[0].Self).To(Equal(uint64(4)))
+			Expect(tree.root.ChildrenNodes[0].ChildrenNodes[0].Total).To(Equal(uint64(4)))
+			Expect(string(tree.root.ChildrenNodes[0].ChildrenNodes[0].Name)).To(Equal(""))
+			Expect(tree.root.ChildrenNodes[1].ChildrenNodes[0].Self).To(Equal(uint64(1)))
+			Expect(tree.root.ChildrenNodes[1].ChildrenNodes[0].Total).To(Equal(uint64(1)))
+			Expect(string(tree.root.ChildrenNodes[1].ChildrenNodes[0].Name)).To(Equal(""))
+			Expect(tree.root.ChildrenNodes[1].ChildrenNodes[1].Self).To(Equal(uint64(2)))
+			Expect(tree.root.ChildrenNodes[1].ChildrenNodes[1].Total).To(Equal(uint64(2)))
+			Expect(string(tree.root.ChildrenNodes[1].ChildrenNodes[1].Name)).To(Equal("b"))
+			Expect(tree.String()).To(Equal("; 4\na; 1\na;b 2\n"))
+		})
+	})
+
 	Context("Merge", func() {
 		Context("similar trees", func() {
 			treeA := New()


### PR DESCRIPTION
This is a different approach to PR #772. Instead of filtering out
empty strings in one of the possible insertion paths, we handle it
properly to prevent problems both from this or other insertion paths:
- We remove the unsafe string to bytes conversion, using instead the
insertion functions that handle strings.
- We handle the corner case of empty strings properly to prevent an
infinite loop.