### PR TITLE
chore(frontend): load css from ~node_modules instead of relative path

### DIFF
--- a/webapp/javascript/ui/Dropdown.module.scss
+++ b/webapp/javascript/ui/Dropdown.module.scss
@@ -1,6 +1,6 @@
 @use '../../sass/variables.scss' as *;
 
-@import '../../../node_modules/@szhsin/react-menu/dist/index.css';
+@import '@szhsin/react-menu/dist/index.css';
 
 .dropdownMenu {
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.33);


### PR DESCRIPTION
Continuation of https://github.com/pyroscope-io/pyroscope/pull/750