### PR TITLE
fix: Solve panic on an empty profile ingest

### DIFF
--- a/pkg/convert/parser.go
+++ b/pkg/convert/parser.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"strconv"
 
@@ -34,8 +35,9 @@ func ParsePprof(r io.Reader) (*tree.Profile, error) {
 	bufioReader := bufio.NewReader(r)
 	header, err := bufioReader.Peek(2)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to read profile file header: %w", err)
 	}
+
 	if header[0] == gzipMagicBytes[0] && header[1] == gzipMagicBytes[1] {
 		r, err = gzip.NewReader(bufioReader)
 		if err != nil {
@@ -49,10 +51,12 @@ func ParsePprof(r io.Reader) (*tree.Profile, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	profile := &tree.Profile{}
 	if err := proto.Unmarshal(b, profile); err != nil {
 		return nil, err
 	}
+
 	return profile, nil
 }
 

--- a/pkg/server/ingest.go
+++ b/pkg/server/ingest.go
@@ -65,16 +65,27 @@ func (h ingestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			var profile *tree.Profile
 			var prevProfile *tree.Profile
+
 			f, _, err := r.FormFile("profile")
-			if err == nil {
-				profile, err = convert.ParsePprof(f)
+			if err != nil {
+				WriteError(h.log, w, http.StatusInternalServerError, err, "error happened while getting profile file")
+				return
 			}
+
+			profile, err = convert.ParsePprof(f)
+			if err != nil {
+				WriteError(h.log, w, http.StatusInternalServerError, err, "error happened while parsing profile file")
+				return
+			}
+
 			f, _, err = r.FormFile("prev_profile")
 			if err == nil {
 				prevProfile, err = convert.ParsePprof(f)
+				if err != nil {
+					WriteError(h.log, w, http.StatusInternalServerError, err, "error happened while parsing prev_profile file")
+					return
+				}
 			}
-
-			// TODO: add error handling for all of these
 
 			for _, sampleTypeStr := range profile.SampleTypes() {
 				var t *tree.SampleTypeConfig


### PR DESCRIPTION
I created a very basic app (below) and noticed that it causes panic (below), at least in v0.8.0.

I dug in and found out that is caused by an empty profile, that is sent just when the app started.

Here is my proposal to fix it.

```go
package main

import (
	"net/http"
	"time"

	"github.com/pyroscope-io/client/pyroscope"
	"github.com/sirupsen/logrus"
)

func main() {
	logger := logrus.New()
	logger.Level = logrus.TraceLevel

	pyroscope.Start(pyroscope.Config{
		ApplicationName: "test-crash",
		ServerAddress:   "http://localhost:4040",
		Logger:          logger,
	})

	http.ListenAndServe(":8081", nil)
}
```

```
http: panic serving 172.22.0.1:55336: runtime error: invalid memory address or nil pointer dereference
goroutine 678 [running]:
net/http.(*conn).serve.func1()
	net/http/server.go:1801 +0xb9
panic({0x1ed2e80, 0x37d72a0})
	runtime/panic.go:1047 +0x266
github.com/pyroscope-io/pyroscope/pkg/storage/tree.(*Profile).SampleTypes(0x0)
	github.com/pyroscope-io/pyroscope/pkg/storage/tree/profile_extra.go:111 +0x20
github.com/pyroscope-io/pyroscope/pkg/server.ingestHandler.ServeHTTP({0xc000148000, 0xc0005ab360, {0x287b160, 0xc000010368}, 0xc000236620, 0xc000074970}, {0x28971b0, 0xc01a778c00}, 0xc000197100)
	github.com/pyroscope-io/pyroscope/pkg/server/ingest.go:79 +0x485
net/http.HandlerFunc.ServeHTTP(...)
	net/http/server.go:2046
github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).drainMiddleware.func1({0x28971b0, 0xc01a778c00}, 0xc0002f3598)
	github.com/pyroscope-io/pyroscope/pkg/server/controller.go:326 +0x4a
net/http.HandlerFunc.ServeHTTP(0x5facb34, {0x28971b0, 0xc01a778c00}, 0x4deb57)
	net/http/server.go:2046 +0x2f
github.com/slok/go-http-metrics/middleware/std.Handler.func1.1()
	github.com/slok/go-http-metrics@v0.9.0/middleware/std/std.go:27 +0x31
github.com/slok/go-http-metrics/middleware.Middleware.Measure({{{0x2897180, 0xc0001265b8}, {0x0, 0x0}, 0x0, 0x0, 0x0}}, {0x20ec9aa, 0x7}, {0x28c3b78, ...}, ...)
	github.com/slok/go-http-metrics@v0.9.0/middleware/middleware.go:117 +0x30e
github.com/slok/go-http-metrics/middleware/std.Handler.func1({0x28a1830, 0xc00036c540}, 0xc000197100)
	github.com/slok/go-http-metrics@v0.9.0/middleware/std/std.go:26 +0x1ce
net/http.HandlerFunc.ServeHTTP(0x1e126a0, {0x28a1830, 0xc00036c540}, 0xc0000fcb40)
	net/http/server.go:2046 +0x2f
net/http.HandlerFunc.ServeHTTP(0xc000197000, {0x28a1830, 0xc00036c540}, 0xc0005a2888)
	net/http/server.go:2046 +0x2f
github.com/gorilla/mux.(*Router).ServeHTTP(0xc0005223c0, {0x28a1830, 0xc00036c540}, 0xc0000f4100)
	github.com/gorilla/mux@v1.8.0/mux.go:210 +0x1cf
github.com/klauspost/compress/gzhttp.NewWrapper.func1.1({0x28a1440, 0xc0005147e0}, 0xc0002c2a90)
	github.com/klauspost/compress@v1.13.5/gzhttp/gzip.go:382 +0x2d9
net/http.HandlerFunc.ServeHTTP(0xc00047487d, {0x28a1440, 0xc0005147e0}, 0x86dfc0)
	net/http/server.go:2046 +0x2f
net/http.serverHandler.ServeHTTP({0x28953f8}, {0x28a1440, 0xc0005147e0}, 0xc0000f4100)
	net/http/server.go:2878 +0x43b
net/http.(*conn).serve(0xc0002dc140, {0x28aab18, 0xc0003f0c90})
	net/http/server.go:1929 +0xb08
created by net/http.(*Server).Serve
	net/http/server.go:3033 +0x4e8"
```