### PR TITLE
feat: add upload support in adhoc server.

### DIFF
--- a/pkg/adhoc/server/model.go
+++ b/pkg/adhoc/server/model.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"errors"
+	"path"
+	"reflect"
+	"strings"
+	"unicode"
+
+	"github.com/pyroscope-io/pyroscope/pkg/structs/flamebearer"
+)
+
+type ConverterFn func(b []byte, name string, maxNodes int) (*flamebearer.FlamebearerProfile, error)
+
+var (
+	formatConverters = map[string]ConverterFn{
+		"json":      JSONToProfileV1,
+		"pprof":     PprofToProfileV1,
+		"collapsed": CollapsedToProfileV1,
+	}
+	errTooShort = errors.New("profile is too short")
+)
+
+type Model struct {
+	Filename string `json:"filename"`
+	Profile  []byte `json:"profile"`
+	Type     string `json:"type"`
+}
+
+func (m Model) Converter() (ConverterFn, error) {
+	if f, ok := formatConverters[m.Type]; ok {
+		return f, nil
+	}
+	ext := strings.TrimPrefix(path.Ext(m.Filename), ".")
+	if f, ok := formatConverters[ext]; ok {
+		return f, nil
+	}
+	if ext == "txt" {
+		return formatConverters["collapsed"], nil
+	}
+	if len(m.Profile) < 2 {
+		return nil, errTooShort
+	}
+	if m.Profile[0] == '{' {
+		return formatConverters["json"], nil
+	}
+	if m.Profile[0] == '\x1f' && m.Profile[1] == '\x8b' {
+		// gzip magic number, assume pprof
+		return formatConverters["pprof"], nil
+	}
+	// Unclear whether it's uncompressed pprof or collapsed, let's check if all the bytes are printable
+	// This will be slow for collapsed format, but should be fast enough for pprof, which is the most usual case,
+	// but we have a reasonable upper bound just in case.
+	// TODO(abeaumont): This won't work with collapsed format with non-ascii encodings.
+	for i, b := range m.Profile {
+		if i == 100 {
+			break
+		}
+		if !unicode.IsPrint(rune(b)) && !unicode.IsSpace(rune(b)) {
+			return formatConverters["pprof"], nil
+		}
+	}
+	return formatConverters["collapsed"], nil
+}
+
+func ConverterToFormat(f ConverterFn) string {
+	switch reflect.ValueOf(f).Pointer() {
+	case reflect.ValueOf(JSONToProfileV1).Pointer():
+		return "json"
+	case reflect.ValueOf(PprofToProfileV1).Pointer():
+		return "pprof"
+	case reflect.ValueOf(CollapsedToProfileV1).Pointer():
+		return "collapsed"
+	}
+	return "unknown"
+}

--- a/pkg/adhoc/server/server_suite_test.go
+++ b/pkg/adhoc/server/server_suite_test.go
@@ -1,0 +1,13 @@
+package server_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Server Suite")
+}

--- a/pkg/adhoc/server/server_test.go
+++ b/pkg/adhoc/server/server_test.go
@@ -1,0 +1,531 @@
+package server_test
+
+import (
+	"reflect"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pyroscope-io/pyroscope/pkg/adhoc/server"
+)
+
+var _ = Describe("Server", func() {
+	Describe("Detecting format", func() {
+		Context("with a valid pprof type", func() {
+			When("there's only type", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Type: "pprof",
+					}
+				})
+				It("should return pprof as type is be enough to detect the type", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.PprofToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+			When("there's pprof type and json filename", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.json",
+						Type:     "pprof",
+					}
+				})
+				It("should return pprof as type takes precedence over filename", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.PprofToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+
+			When("there's pprof type and json profile contents", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Profile: []byte(`{"flamebearer":""}`),
+						Type:    "pprof",
+					}
+				})
+				It("should return pprof as type takes precedence over profile contents", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.PprofToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+		})
+
+		Context("with no (valid) type and a valid pprof filename", func() {
+			When("there's pprof filename and json profile contents", func() {
+				var m server.Model
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.pprof",
+						Profile:  []byte(`{"flamebearer":""}`),
+					}
+				})
+
+				It("should return pprof as filename takes precedence over profile contents", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.PprofToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+			When("there's pprof filename and an unsupported type", func() {
+				var m server.Model
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.pprof",
+						Type:     "unsupported",
+					}
+				})
+
+				It("should return pprof as unsupported type is ignored", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.PprofToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+		})
+
+		Context("with no (valid) type and filename, a valid pprof profile", func() {
+			When("there's a profile with uncompressed pprof content", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Profile: []byte{0x0a, 0x04},
+					}
+				})
+
+				It("should return pprof", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.PprofToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+
+			When("there's a profile with compressed pprof content", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Profile: []byte{0x1f, 0x8b},
+					}
+				})
+
+				It("should return pprof", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.PprofToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+
+			When("there's a profile with compressed pprof content and an unsupported type", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Profile: []byte{0x1f, 0x8b},
+						Type:    "unsupported",
+					}
+				})
+
+				It("should return pprof as unsupported types are ignored", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.PprofToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+
+			When("there's a profile with compressed pprof content and unsupported filename", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.unsupported",
+						Profile:  []byte{0x1f, 0x8b},
+					}
+				})
+
+				It("should return pprof as unsupported filenames are ignored", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.PprofToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+		})
+
+		Context("with a valid json type", func() {
+			When("there's only type", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Type: "json",
+					}
+				})
+				It("should return json as type is be enough to detect the type", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.JSONToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+			When("there's json type and pprof filename", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.pprof",
+						Type:     "json",
+					}
+				})
+				It("should return json as type takes precedence over filename", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.JSONToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+
+			When("there's json type and pprof profile contents", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Profile: []byte{0x1f, 0x8b},
+						Type:    "json",
+					}
+				})
+				It("should return json as type takes precedence over profile contents", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.JSONToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+		})
+
+		Context("with no (valid) type and a valid json filename", func() {
+			When("there's json filename and pprof profile contents", func() {
+				var m server.Model
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.json",
+						Profile:  []byte{0x1f, 0x8b},
+					}
+				})
+
+				It("should return json as filename takes precedence over profile contents", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.JSONToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+			When("there's json filename and an unsupported type", func() {
+				var m server.Model
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.json",
+						Type:     "unsupported",
+					}
+				})
+
+				It("should return json as unsupported type is ignored", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.JSONToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+		})
+
+		Context("with no (valid) type and filename, a valid json profile", func() {
+			When("there's a profile with json content", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Profile: []byte(`{"flamebearer":""}`),
+					}
+				})
+
+				It("should return json", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.JSONToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+
+			When("there's a profile with json content and an unsupported type", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Profile: []byte(`{"flamebearer":""}`),
+						Type:    "unsupported",
+					}
+				})
+
+				It("should return json as unsupported types are ignored", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.JSONToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+
+			When("there's a profile with json content and unsupported filename", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.unsupported",
+						Profile:  []byte(`{"flamebearer":""}`),
+					}
+				})
+
+				It("should return json as unsupported filenames are ignored", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.JSONToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+		})
+
+		Context("with a valid collapsed type", func() {
+			When("there's only type", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Type: "collapsed",
+					}
+				})
+				It("should return collapsed as type is be enough to detect the type", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.CollapsedToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+			When("there's collapsed type and pprof filename", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.pprof",
+						Type:     "collapsed",
+					}
+				})
+				It("should return collapsed as type takes precedence over filename", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.CollapsedToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+
+			When("there's json type and pprof profile contents", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Profile: []byte{0x1f, 0x8b},
+						Type:    "collapsed",
+					}
+				})
+				It("should return collapsed as type takes precedence over profile contents", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.CollapsedToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+		})
+
+		Context("with no (valid) type and a valid collapsed filename", func() {
+			When("there's collapsed filename and pprof profile contents", func() {
+				var m server.Model
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.collapsed",
+						Profile:  []byte{0x1f, 0x8b},
+					}
+				})
+
+				It("should return collapsed as filename takes precedence over profile contents", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.CollapsedToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+			When("there's collapsed filename and an unsupported type", func() {
+				var m server.Model
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.collapsed",
+						Type:     "unsupported",
+					}
+				})
+
+				It("should return collapsed as unsupported type is ignored", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.CollapsedToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+
+			When("there's collapsed text filename and an unsupported type", func() {
+				var m server.Model
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.collapsed.txt",
+						Type:     "unsupported",
+					}
+				})
+
+				It("should return collapsed as unsupported type is ignored", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.CollapsedToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+		})
+
+		Context("with no (valid) type and filename, a valid collapsed profile", func() {
+			When("there's a profile with collapsed content", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Profile: []byte("fn1 1\nfn2 2"),
+					}
+				})
+
+				It("should return collapsed", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.CollapsedToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+
+			When("there's a profile with collapsed content and an unsupported type", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Profile: []byte("fn1 1\nfn2 2"),
+						Type:    "unsupported",
+					}
+				})
+
+				It("should return collapsed as unsupported types are ignored", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.CollapsedToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+
+			When("there's a profile with collapsed content and unsupported filename", func() {
+				var m server.Model
+
+				BeforeEach(func() {
+					m = server.Model{
+						Filename: "profile.unsupported",
+						Profile:  []byte("fn1 1\nfn2 2"),
+					}
+				})
+
+				It("should return collapsed as unsupported filenames are ignored", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(server.CollapsedToProfileV1).Pointer()
+					f, err := m.Converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+		})
+	})
+
+	Context("with an empty model", func() {
+		var m server.Model
+		It("should return an error", func() {
+			_, err := m.Converter()
+			Expect(err).ToNot(Succeed())
+		})
+	})
+
+})


### PR DESCRIPTION
This is an initial step towards improving the upload functionality in
adhoc. This allows the frontend to upload profiles in other supported
formats (frontend work still pending).

This still won't work for diff uploads, that will come later.

This is part of #784 