### PR TITLE
feat(frontend): export diff to flamegraph.com

### DIFF
--- a/webapp/javascript/components/AdhocComparison.tsx
+++ b/webapp/javascript/components/AdhocComparison.tsx
@@ -23,6 +23,7 @@ import {
 import 'react-tabs/style/react-tabs.css';
 import styles from './ComparisonApp.module.css';
 import adhocStyles from './Adhoc.module.scss';
+import useExportToFlamegraphDotCom from './exportToFlamegraphDotCom.hook';
 import ExportData from './ExportData';
 
 function AdhocComparison(props) {
@@ -45,6 +46,8 @@ function AdhocComparison(props) {
     setAdhocRightFile,
     setAdhocRightProfile,
   } = actions;
+  const exportToFlamegraphDotComLeftFn = useExportToFlamegraphDotCom(leftRaw);
+  const exportToFlamegraphDotComRightFn = useExportToFlamegraphDotCom(rightRaw);
 
   useEffect(() => {
     actions.fetchAdhocProfiles();
@@ -105,7 +108,14 @@ function AdhocComparison(props) {
                 flamebearer={leftFlamebearer}
                 data-testid="flamegraph-renderer-left"
                 display="both"
-                ExportData={<ExportData flamebearer={leftRaw} exportJSON />}
+                ExportData={
+                  <ExportData
+                    flamebearer={leftRaw}
+                    exportJSON
+                    exportFlamegraphDotCom
+                    exportFlamegraphDotComFn={exportToFlamegraphDotComLeftFn}
+                  />
+                }
               />
             )}
           </Box>
@@ -142,7 +152,14 @@ function AdhocComparison(props) {
                 flamebearer={rightFlamebearer}
                 data-testid="flamegraph-renderer-right"
                 display="both"
-                ExportData={<ExportData flamebearer={rightRaw} exportJSON />}
+                ExportData={
+                  <ExportData
+                    flamebearer={rightRaw}
+                    exportJSON
+                    exportFlamegraphDotCom
+                    exportFlamegraphDotComFn={exportToFlamegraphDotComRightFn}
+                  />
+                }
               />
             )}
           </Box>

--- a/webapp/javascript/components/AdhocComparisonDiff.tsx
+++ b/webapp/javascript/components/AdhocComparisonDiff.tsx
@@ -19,6 +19,7 @@ import {
 import styles from './ComparisonApp.module.css';
 import 'react-tabs/style/react-tabs.css';
 import adhocStyles from './Adhoc.module.scss';
+import useExportToFlamegraphDotCom from './exportToFlamegraphDotCom.hook';
 import ExportData from './ExportData';
 
 function AdhocComparisonDiff(props) {
@@ -31,6 +32,7 @@ function AdhocComparisonDiff(props) {
     raw,
   } = props;
   const { setAdhocLeftProfile, setAdhocRightProfile } = actions;
+  const exportToFlamegraphDotComFn = useExportToFlamegraphDotCom(raw);
 
   useEffect(() => {
     actions.fetchAdhocProfiles();
@@ -95,7 +97,14 @@ function AdhocComparisonDiff(props) {
               display="both"
               viewType="diff"
               flamebearer={flamebearer}
-              ExportData={<ExportData flamebearer={raw} exportJSON />}
+              ExportData={
+                <ExportData
+                  flamebearer={raw}
+                  exportJSON
+                  exportFlamegraphDotCom
+                  exportFlamegraphDotComFn={exportToFlamegraphDotComFn}
+                />
+              }
             />
           )}
         </Box>

--- a/webapp/javascript/components/AdhocSingle.jsx
+++ b/webapp/javascript/components/AdhocSingle.jsx
@@ -20,11 +20,13 @@ import {
 } from '../redux/actions';
 import 'react-tabs/style/react-tabs.css';
 import adhocStyles from './Adhoc.module.scss';
+import useExportToFlamegraphDotCom from './exportToFlamegraphDotCom.hook';
 import ExportData from './ExportData';
 
 function AdhocSingle(props) {
   const { actions, file, profile, flamebearer, isProfileLoading, raw } = props;
   const { setAdhocFile, setAdhocProfile } = actions;
+  const exportToFlamegraphDotComFn = useExportToFlamegraphDotCom(raw);
 
   useEffect(() => {
     actions.fetchAdhocProfiles();
@@ -72,7 +74,14 @@ function AdhocSingle(props) {
               flamebearer={flamebearer}
               viewType="single"
               display="both"
-              ExportData={<ExportData flamebearer={raw} exportJSON />}
+              ExportData={
+                <ExportData
+                  flamebearer={raw}
+                  exportJSON
+                  exportFlamegraphDotCom
+                  exportFlamegraphDotComFn={exportToFlamegraphDotComFn}
+                />
+              }
             />
           )}
         </Box>

--- a/webapp/javascript/components/ComparisonApp.jsx
+++ b/webapp/javascript/components/ComparisonApp.jsx
@@ -16,6 +16,7 @@ import {
 } from '../redux/actions';
 import InstructionText from './FlameGraph/InstructionText';
 import ExportData from './ExportData';
+import useExportToFlamegraphDotCom from './exportToFlamegraphDotCom.hook';
 import styles from './ComparisonApp.module.css';
 
 // See docs here: https://github.com/flot/flot/blob/master/API.md
@@ -24,6 +25,8 @@ function ComparisonApp(props) {
   const { actions, renderURL, leftRenderURL, rightRenderURL, comparison } =
     props;
   const { rawLeft, rawRight } = comparison;
+  const exportToFlamegraphDotComLeftFn = useExportToFlamegraphDotCom(rawLeft);
+  const exportToFlamegraphDotComRightFn = useExportToFlamegraphDotCom(rawRight);
 
   useEffect(() => {
     actions.fetchComparisonAppData(leftRenderURL, 'left');
@@ -70,6 +73,7 @@ function ComparisonApp(props) {
                   exportHTML
                   exportPprof
                   exportFlamegraphDotCom
+                  exportFlamegraphDotComFn={exportToFlamegraphDotComLeftFn}
                 />
               }
             >
@@ -99,6 +103,7 @@ function ComparisonApp(props) {
                   exportHTML
                   exportPprof
                   exportFlamegraphDotCom
+                  exportFlamegraphDotComFn={exportToFlamegraphDotComRightFn}
                 />
               }
             >

--- a/webapp/javascript/components/ComparisonDiffApp.jsx
+++ b/webapp/javascript/components/ComparisonDiffApp.jsx
@@ -9,11 +9,13 @@ import TimelineChartWrapper from './TimelineChartWrapper';
 import { buildDiffRenderURL } from '../util/updateRequests';
 import { fetchNames, fetchComparisonDiffAppData } from '../redux/actions';
 import InstructionText from './FlameGraph/InstructionText';
+import useExportToFlamegraphDotCom from './exportToFlamegraphDotCom.hook';
 import ExportData from './ExportData';
 
 function ComparisonDiffApp(props) {
   const { actions, diffRenderURL, diff } = props;
   const prevPropsRef = useRef();
+  const exportToFlamegraphDotComFn = useExportToFlamegraphDotCom(diff.raw);
 
   useEffect(() => {
     if (prevPropsRef.diffRenderURL !== diffRenderURL) {
@@ -29,6 +31,8 @@ function ComparisonDiffApp(props) {
       exportPNG
       exportHTML
       fetchUrlFunc={() => diffRenderURL}
+      exportFlamegraphDotCom
+      exportFlamegraphDotComFn={exportToFlamegraphDotComFn}
     />
   );
 

--- a/webapp/javascript/components/PyroscopeApp.jsx
+++ b/webapp/javascript/components/PyroscopeApp.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 import { connect } from 'react-redux';
 import 'react-dom';
-
 import { bindActionCreators } from 'redux';
 import Box from '@ui/Box';
 import FlameGraphRenderer from './FlameGraph';
@@ -15,10 +14,12 @@ import {
   abortTimelineRequest,
 } from '../redux/actions';
 import ExportData from './ExportData';
+import useExportToFlamegraphDotCom from './exportToFlamegraphDotCom.hook';
 
 function PyroscopeApp(props) {
   const { actions, renderURL, single, raw } = props;
   const prevPropsRef = useRef();
+  const exportToFlamegraphDotComFn = useExportToFlamegraphDotCom(raw);
 
   useEffect(() => {
     if (prevPropsRef.renderURL !== renderURL) {
@@ -52,6 +53,7 @@ function PyroscopeApp(props) {
                 exportPprof
                 exportHTML
                 exportFlamegraphDotCom
+                exportFlamegraphDotComFn={exportToFlamegraphDotComFn}
               />
             }
           />

--- a/webapp/javascript/components/exportToFlamegraphDotCom.hook.ts
+++ b/webapp/javascript/components/exportToFlamegraphDotCom.hook.ts
@@ -1,0 +1,21 @@
+import { RawFlamebearerProfile } from '@models/flamebearer';
+import { shareWithFlamegraphDotcom } from '@pyroscope/services/share';
+import { useAppDispatch } from '@pyroscope/redux/hooks';
+import handleError from '../util/handleError';
+
+export default function useExportToFlamegraphDotCom(
+  flamebearer: RawFlamebearerProfile
+) {
+  const dispatch = useAppDispatch();
+
+  return async () => {
+    const res = await shareWithFlamegraphDotcom({ flamebearer });
+
+    if (res.isErr) {
+      handleError(dispatch, 'Failed to export to flamegraph.com', res.error);
+      return null;
+    }
+
+    return res.value.url;
+  };
+}

--- a/webapp/javascript/models/flamegraphDotComResponse.ts
+++ b/webapp/javascript/models/flamegraphDotComResponse.ts
@@ -1,0 +1,15 @@
+import { z, ZodError } from 'zod';
+import { Result } from '@utils/fp';
+import { modelToResult } from './utils';
+
+export const flamegraphDotComResponseScheme = z.object({
+  url: z.string(),
+});
+
+export type FlamegraphDotComResponse = z.infer<
+  typeof flamegraphDotComResponseScheme
+>;
+
+export function parse(a: unknown): Result<FlamegraphDotComResponse, ZodError> {
+  return modelToResult(flamegraphDotComResponseScheme, a);
+}

--- a/webapp/javascript/services/TestData.ts
+++ b/webapp/javascript/services/TestData.ts
@@ -1,0 +1,40 @@
+import { RawFlamebearerProfile } from '@models/flamebearer';
+import { Units } from '@utils/format';
+
+export default {
+  flamebearer: {
+    names: [
+      'total',
+      'runtime.main',
+      'main.slowFunction',
+      'main.work',
+      'main.main',
+      'main.fastFunction',
+    ],
+    levels: [
+      [0, 988, 0, 0],
+      [0, 988, 0, 1],
+      [0, 214, 0, 5, 0, 3, 2, 4, 0, 771, 0, 2],
+      [0, 214, 214, 3, 2, 1, 1, 5, 0, 771, 771, 3],
+    ],
+    numTicks: 988,
+    maxSelf: 771,
+    spyName: 'gospy',
+    sampleRate: 100,
+    units: 'samples' as Units,
+    format: 'single' as const,
+  },
+  metadata: {
+    format: 'single' as const,
+    sampleRate: 100,
+    spyName: 'gospy',
+    units: 'samples' as Units,
+  },
+  timeline: {
+    startTime: 1632335270,
+    samples: [989],
+    durationDelta: 10,
+  },
+
+  version: 1,
+} as RawFlamebearerProfile;

--- a/webapp/javascript/services/share.spec.ts
+++ b/webapp/javascript/services/share.spec.ts
@@ -1,8 +1,9 @@
 import { Result } from '@utils/fp';
+import { ZodError } from 'zod';
 import { shareWithFlamegraphDotcom } from './share';
 import { setupServer, rest } from './testUtils';
 // TODO move this testData to somewhere else
-import TestData from '../components/FlameGraph/FlameGraphComponent/testData';
+import TestData from './TestData';
 
 describe('Share', () => {
   let server: ReturnType<typeof setupServer> | null;
@@ -17,23 +18,15 @@ describe('Share', () => {
   describe('shareWithFlamegraphDotcom', () => {
     it('works', async () => {
       server = setupServer(
-        rest.get(`http://localhost/export`, (req, res, ctx) => {
-          // TODO check query params
-          //
-          return res(
-            ctx.status(200),
-
-            ctx.json({
-              url: 'http://myurl.com',
-            })
-          );
+        rest.post(`http://localhost/export`, (req, res, ctx) => {
+          return res(ctx.status(200), ctx.json({ url: 'http://myurl.com' }));
         })
       );
 
       server.listen();
       const res = await shareWithFlamegraphDotcom({
         name: 'myname',
-        flamebearer: TestData.SimpleTree,
+        flamebearer: TestData,
       });
 
       expect(res).toMatchObject(
@@ -41,6 +34,21 @@ describe('Share', () => {
           url: 'http://myurl.com',
         })
       );
+    });
+
+    it('fails if response doesnt contain the key', async () => {
+      server = setupServer(
+        rest.post(`http://localhost/export`, (req, res, ctx) => {
+          return res(ctx.status(200), ctx.json({}));
+        })
+      );
+      server.listen();
+
+      const res = await shareWithFlamegraphDotcom({
+        name: 'myname',
+        flamebearer: TestData,
+      });
+      expect(res.error).toBeInstanceOf(ZodError);
     });
   });
 });

--- a/webapp/javascript/services/share.spec.ts
+++ b/webapp/javascript/services/share.spec.ts
@@ -1,0 +1,46 @@
+import { Result } from '@utils/fp';
+import { shareWithFlamegraphDotcom } from './share';
+import { setupServer, rest } from './testUtils';
+// TODO move this testData to somewhere else
+import TestData from '../components/FlameGraph/FlameGraphComponent/testData';
+
+describe('Share', () => {
+  let server: ReturnType<typeof setupServer> | null;
+
+  afterEach(() => {
+    if (server) {
+      server.close();
+    }
+    server = null;
+  });
+
+  describe('shareWithFlamegraphDotcom', () => {
+    it('works', async () => {
+      server = setupServer(
+        rest.get(`http://localhost/export`, (req, res, ctx) => {
+          // TODO check query params
+          //
+          return res(
+            ctx.status(200),
+
+            ctx.json({
+              url: 'http://myurl.com',
+            })
+          );
+        })
+      );
+
+      server.listen();
+      const res = await shareWithFlamegraphDotcom({
+        name: 'myname',
+        flamebearer: TestData.SimpleTree,
+      });
+
+      expect(res).toMatchObject(
+        Result.ok({
+          url: 'http://myurl.com',
+        })
+      );
+    });
+  });
+});

--- a/webapp/javascript/services/share.ts
+++ b/webapp/javascript/services/share.ts
@@ -11,7 +11,7 @@ import { request } from './base';
 
 interface shareWithFlamegraphDotcomProps {
   flamebearer: RawFlamebearerProfile;
-  name: string;
+  name?: string;
 }
 
 export async function shareWithFlamegraphDotcom({

--- a/webapp/javascript/services/share.ts
+++ b/webapp/javascript/services/share.ts
@@ -21,6 +21,7 @@ export async function shareWithFlamegraphDotcom({
   Result<FlamegraphDotComResponse, RequestError | ZodError>
 > {
   const response = await request('/export', {
+    method: 'POST',
     body: JSON.stringify({
       name,
       // TODO:

--- a/webapp/javascript/services/share.ts
+++ b/webapp/javascript/services/share.ts
@@ -1,0 +1,38 @@
+/* eslint-disable import/prefer-default-export */
+import { Result } from '@utils/fp';
+import type { ZodError } from 'zod';
+import { RawFlamebearerProfile } from '@models/flamebearer';
+import {
+  FlamegraphDotComResponse,
+  parse,
+} from '@models/flamegraphDotComResponse';
+import type { RequestError } from './base';
+import { request } from './base';
+
+interface shareWithFlamegraphDotcomProps {
+  flamebearer: RawFlamebearerProfile;
+  name: string;
+}
+
+export async function shareWithFlamegraphDotcom({
+  flamebearer,
+  name,
+}: shareWithFlamegraphDotcomProps): Promise<
+  Result<FlamegraphDotComResponse, RequestError | ZodError>
+> {
+  const response = await request('/export', {
+    body: JSON.stringify({
+      name,
+      // TODO:
+      // use buf.toString
+      profile: btoa(JSON.stringify(flamebearer)),
+      type: 'application/json',
+    }),
+  });
+
+  if (response.isOk) {
+    return parse(response.value);
+  }
+
+  return Result.err<FlamegraphDotComResponse, RequestError>(response.error);
+}

--- a/webapp/javascript/util/handleError.ts
+++ b/webapp/javascript/util/handleError.ts
@@ -1,0 +1,32 @@
+import type { RequestError } from '@pyroscope/services/base';
+import { ZodError } from 'zod';
+import { addNotification } from '@pyroscope/redux/reducers/notifications';
+import { useAppDispatch } from '@pyroscope/redux/hooks';
+
+/**
+ * handleError handles service errors
+ */
+export default async function handleError(
+  dispatch: ReturnType<useAppDispatch>,
+  message: string,
+  error: ZodError | RequestError
+): Promise<void> {
+  // We log the error in case a tech-savy user wants to debug themselves
+  console.error(error);
+
+  let errorMessage = error.message;
+
+  // a ZodError means its format is not what we expect
+  if (error instanceof ZodError) {
+    errorMessage = 'response not in the expected format';
+  }
+
+  // display a notification
+  dispatch(
+    addNotification({
+      title: 'Error',
+      message: [message, errorMessage].join('\n'),
+      type: 'danger',
+    })
+  );
+}


### PR DESCRIPTION
* Add support for exporting to flamegraph.com for all adhoc pages and diff
* Add a notification for when request fails
* Lift the state up so that the export to flamegraph.com functionality can be implemented for the grafana plugins
* Support custom base url (not tested, but should work)