### PR TITLE
allow custom Authorization

### DIFF
--- a/pkg/agent/upstream/remote/remote.go
+++ b/pkg/agent/upstream/remote/remote.go
@@ -125,7 +125,7 @@ func (r *Remote) uploadProfile(j *upstream.UploadJob) error {
 	request.Header.Set("Content-Type", "binary/octet-stream+trie")
 
 	if r.cfg.AuthToken != "" {
-		request.Header.Set("Authorization", "Bearer "+r.cfg.AuthToken)
+		request.Header.Set("Authorization", r.cfg.AuthToken)
 	}
 
 	// do the request and get the response


### PR DESCRIPTION
   supported: OAuth2 Proxy(Bearer )
   Added support: Basic Authentication (Basic )
change:
   pkg/agent/upstream/remote/remote.go:128
     request.Header.Set("Authorization", "Bearer "+r.cfg.AuthToken)
  to:
   pkg/agent/upstream/remote/remote.go:128
       request.Header.Set("Authorization", r.cfg.AuthToken)