### PR TITLE
fix: store "total" in name cache, and make tests more rigurous.

### DIFF
--- a/pkg/storage/tree/flamebearer.go
+++ b/pkg/storage/tree/flamebearer.go
@@ -53,10 +53,10 @@ func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 			var ok bool
 			if i, ok = nameLocationCache[name]; !ok {
 				i = len(res.Names)
-				nameLocationCache[name] = i
 				if i == 0 {
 					name = "total"
 				}
+				nameLocationCache[name] = i
 				res.Names = append(res.Names, name)
 			}
 

--- a/pkg/storage/tree/flamebearer_test.go
+++ b/pkg/storage/tree/flamebearer_test.go
@@ -16,7 +16,7 @@ var _ = Describe("FlamebearerStruct", func() {
 			tree.Insert([]byte("a;c"), uint64(2))
 
 			f := tree.FlamebearerStruct(1024)
-			Expect(f.Names).To(ConsistOf("total", "a", "b", "c"))
+			Expect(f.Names).To(Equal([]string{"total", "a", "c", "b"}))
 			Expect(f.Levels).To(Equal([][]int{
 				// i+0 = x offset (delta encoded)
 				// i+1 = total

--- a/pkg/structs/flamebearer/flamebearer_test.go
+++ b/pkg/structs/flamebearer/flamebearer_test.go
@@ -45,7 +45,7 @@ var _ = Describe("FlamebearerProfile", func() {
 			p := NewProfile(out, maxNodes)
 
 			// Flamebearer
-			Expect(p.Flamebearer.Names).To(ConsistOf("total", "a", "b", "c"))
+			Expect(p.Flamebearer.Names).To(Equal([]string{"total", "a", "c", "b"}))
 			Expect(p.Flamebearer.Levels).To(Equal([][]int{
 				{0, 3, 0, 0},
 				{0, 3, 0, 1},
@@ -103,7 +103,7 @@ var _ = Describe("FlamebearerProfile", func() {
 			p := NewCombinedProfile(out, left, right, maxNodes)
 
 			// Flamebearer
-			Expect(p.Flamebearer.Names).To(ConsistOf("total", "a", "b", "c"))
+			Expect(p.Flamebearer.Names).To(Equal([]string{"total", "a", "c", "b"}))
 			Expect(p.Flamebearer.Levels).To(Equal([][]int{
 				{0, 3, 0, 0, 12, 0, 0},
 				{0, 3, 0, 0, 12, 0, 1},


### PR DESCRIPTION
This is a minor fix, it just avoids having the name twice in the worst
case.

Also, name order is checked in the flamebearer tests. While the order
of the names is not important, the correspondence between name index
and name is, which means that without proper order checks it's not
possible to evaluate if the expectations are correct.

Related to #820 