### PR TITLE
fix(frontend): fix coloring for pull mode

### DIFF
--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/color.spec.ts
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/color.spec.ts
@@ -229,4 +229,31 @@ describe('getPackageNameFromStackTrace', () => {
       });
     });
   });
+
+  describe('scrape (pull mode)', () => {
+    describe.each([
+      ['bufio.(*Reader).fill', 'bufio.'],
+      ['cmpbody', 'cmpbody'],
+      ['bytes.Compare', 'bytes.'],
+      ['crypto/tls.(*Conn).clientHandshake', 'crypto/tls.'],
+      [
+        'github.com/DataDog/zstd._Cfunc_ZSTD_compress_wrapper',
+        'github.com/DataDog/zstd.',
+      ],
+      [
+        'github.com/dgraph-io/badger/v2.(*DB).calculateSize',
+        'github.com/dgraph-io/badger/v2.',
+      ],
+      [
+        'github.com/dgraph-io/badger/v2/table.(*blockIterator).next',
+        'github.com/dgraph-io/badger/v2/table.',
+      ],
+      ['path/filepath.walk', 'path/filepath.'],
+      ['os.(*File).write', 'os.'],
+    ])(`.getPackageNameFromStackTrace('%s')`, (a, expected) => {
+      it(`returns '${expected}'`, () => {
+        expect(getPackageNameFromStackTrace('scrape', a)).toBe(expected);
+      });
+    });
+  });
 });

--- a/webapp/javascript/components/FlameGraph/FlameGraphComponent/color.ts
+++ b/webapp/javascript/components/FlameGraph/FlameGraphComponent/color.ts
@@ -85,11 +85,13 @@ export function getPackageNameFromStackTrace(
     ebpfspy: /^(?<packageName>.+)$/,
     // tested with pyroscope stacktraces here: https://regex101.com/r/99KReq/1
     gospy: /^(?<packageName>.*?\/.*?\.|.*?\.|.+)(?<functionName>.*)$/,
+    // assume scrape is golang, since that's the only language we support right now
+    scrape: /^(?<packageName>.*?\/.*?\.|.*?\.|.+)(?<functionName>.*)$/,
+
     phpspy: /^(?<packageName>(.*\/)*)(?<filename>.*\.php+)(?<line_info>.*)$/,
     pyspy: /^(?<packageName>(.*\/)*)(?<filename>.*\.py+)(?<line_info>.*)$/,
     rbspy: /^(?<packageName>(.*\/)*)(?<filename>.*\.rb+)(?<line_info>.*)$/,
     'pyroscope-rs': /^(?<packageName>[^::]+)/,
-    //    'pyroscope-rs': /^(?<packageName>[a-zA-Z0-9]+)(::)?/,
   };
 
   if (stackTrace.length === 0) {


### PR DESCRIPTION
pull mode returns a spy named 'scrape'
for now we just assume it's most likely golang and use the same coloring
mode