### PR TITLE
fix: CORS allow credentials

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -205,10 +205,11 @@ type AdminUser struct {
 }
 
 type CORSConfig struct {
-	AllowedOrigins []string `json:"-" deprecated:"true" def:"" desc:"" mapstructure:"allowed-origins"`
-	AllowedHeaders []string `json:"-" deprecated:"true" def:"" desc:"" mapstructure:"allowed-headers"`
-	AllowedMethods []string `json:"-" deprecated:"true" def:"" desc:"" mapstructure:"allowed-methods"`
-	MaxAge         int      `json:"-" deprecated:"true" def:"" desc:"" mapstructure:"max-age"`
+	AllowedOrigins   []string `json:"-" deprecated:"true" def:"" desc:"" mapstructure:"allowed-origins"`
+	AllowedHeaders   []string `json:"-" deprecated:"true" def:"" desc:"" mapstructure:"allowed-headers"`
+	AllowedMethods   []string `json:"-" deprecated:"true" def:"" desc:"" mapstructure:"allowed-methods"`
+	AllowCredentials bool     `json:"-" deprecated:"true" def:"" desc:"" mapstructure:"allow-credentials"`
+	MaxAge           int      `json:"-" deprecated:"true" def:"" desc:"" mapstructure:"max-age"`
 }
 
 // TODO: Maybe merge Oauth structs into one (would have to move def and desc tags somewhere else in code)

--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -175,7 +175,6 @@ func (ctrl *Controller) serverMux() (http.Handler, error) {
 
 	apiRouter.Use(
 		ctrl.drainMiddleware,
-		ctrl.corsMiddleware(),
 		ctrl.authMiddleware(nil))
 
 	if ctrl.isAuthRequired() {
@@ -203,8 +202,7 @@ func (ctrl *Controller) serverMux() (http.Handler, error) {
 	ctrl.addRoutes(r, append(insecureRoutes, []route{
 		{"/forbidden", ctrl.forbiddenHandler()},
 		{"/assets/", assetsHandler}}...),
-		ctrl.drainMiddleware,
-		ctrl.corsMiddleware())
+		ctrl.drainMiddleware)
 
 	// Protected pages:
 	// For these routes server responds with 307 and redirects to /login.
@@ -219,7 +217,6 @@ func (ctrl *Controller) serverMux() (http.Handler, error) {
 		{"/settings/{page}", ctrl.indexHandler()},
 		{"/settings/{page}/{subpage}", ctrl.indexHandler()}},
 		ctrl.drainMiddleware,
-		ctrl.corsMiddleware(),
 		ctrl.authMiddleware(ctrl.loginRedirect))
 
 	// For these routes server responds with 401.
@@ -231,7 +228,6 @@ func (ctrl *Controller) serverMux() (http.Handler, error) {
 		{"/export", ctrl.exportHandler},
 		{"/api/adhoc", ctrl.adhoc.AddRoutes(r.PathPrefix("/api/adhoc").Subrouter())}},
 		ctrl.drainMiddleware,
-		ctrl.corsMiddleware(),
 		ctrl.authMiddleware(nil))
 
 	// TODO(kolesnikovae):
@@ -339,7 +335,7 @@ func (ctrl *Controller) getHandler() (http.Handler, error) {
 		return nil, err
 	}
 
-	return gzhttpMiddleware(handler), nil
+	return ctrl.corsMiddleware()(gzhttpMiddleware(handler)), nil
 }
 
 func (ctrl *Controller) Start() error {

--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -385,11 +385,16 @@ func (ctrl *Controller) Stop() error {
 
 func (ctrl *Controller) corsMiddleware() mux.MiddlewareFunc {
 	if len(ctrl.config.CORS.AllowedOrigins) > 0 {
-		return handlers.CORS(
+		options := []handlers.CORSOption{
 			handlers.AllowedOrigins(ctrl.config.CORS.AllowedOrigins),
 			handlers.AllowedMethods(ctrl.config.CORS.AllowedMethods),
 			handlers.AllowedHeaders(ctrl.config.CORS.AllowedHeaders),
-			handlers.MaxAge(ctrl.config.CORS.MaxAge))
+			handlers.MaxAge(ctrl.config.CORS.MaxAge),
+		}
+		if ctrl.config.CORS.AllowCredentials {
+			options = append(options, handlers.AllowCredentials())
+		}
+		return handlers.CORS(options...)
 	}
 	return func(next http.Handler) http.Handler {
 		return next


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials):
> The Access-Control-Allow-Credentials header works in conjunction with the [XMLHttpRequest.withCredentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) property or with the credentials option in the [Request()](https://developer.mozilla.org/en-US/docs/Web/API/Request/Request) constructor of the Fetch API. For a CORS request with credentials, for browsers to expose the response to the frontend JavaScript code, both the server (using the Access-Control-Allow-Credentials header) and the client (by setting the credentials mode for the XHR, Fetch, or Ajax request) must indicate that they’re opting into including credentials.

Without this option, cookie credentials are not sent regardless of the cross-site cookie setup (SameSite=None;Secure) and whether 3-rd party cookies are enabled in the browser.

---

Also, CORS middleware was moved to the server level to avoid any spurious routing issues: gorilla mux passes only matching requests, and if the list of allowed methods for a handler does not include OPTIONS, the middleware won't be called, causing the 405 response code.

The change should not affect any non-CORS endpoints (e.g. /ingest, /metrics, and so on).