### PR TITLE
fix(frontend): only inline svg if imported via react

### DIFF
--- a/scripts/webpack/webpack.common.ts
+++ b/scripts/webpack/webpack.common.ts
@@ -111,8 +111,12 @@ export default {
           name: '[name].[hash:8].[ext]',
         },
       },
+
+      // for SVG used via react
+      // we simply inline them as if they were normal react components
       {
         test: /\.svg$/,
+        issuer: /\.(j|t)sx?$/,
         use: [
           { loader: 'babel-loader' },
           {


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/854