### PR TITLE
refactor: change the way snapshot callbacks handle errors.

### DIFF
--- a/pkg/adhoc/server/convert.go
+++ b/pkg/adhoc/server/convert.go
@@ -46,8 +46,9 @@ func PprofToProfileV1(b []byte, name string, maxNodes int) (*flamebearer.Flamebe
 			}
 		}
 		t := tree.New()
-		p.Get(stype, func(_labels *spy.Labels, name []byte, val int) {
+		p.Get(stype, func(_labels *spy.Labels, name []byte, val int) error {
 			t.Insert(name, uint64(val))
+			return nil
 		})
 
 		out := &storage.GetOutput{

--- a/pkg/agent/debugspy/debugspy.go
+++ b/pkg/agent/debugspy/debugspy.go
@@ -1,3 +1,4 @@
+//go:build debugspy
 // +build debugspy
 
 package debugspy
@@ -23,9 +24,9 @@ func (s *DebugSpy) Stop() error {
 }
 
 // Snapshot calls callback function with stack-trace or error.
-func (s *DebugSpy) Snapshot(cb func(*spy.Labels, []byte, uint64, error)) {
+func (s *DebugSpy) Snapshot(cb func(*spy.Labels, []byte, uint64) error) error {
 	stacktrace := fmt.Sprintf("debug_%d;debug", s.pid)
-	cb(nil, []byte(stacktrace), 1, nil)
+	return cb(nil, []byte(stacktrace), 1)
 }
 
 func init() {

--- a/pkg/agent/dotnetspy/dotnetspy.go
+++ b/pkg/agent/dotnetspy/dotnetspy.go
@@ -1,3 +1,4 @@
+//go:build dotnetspy
 // +build dotnetspy
 
 package dotnetspy
@@ -29,12 +30,12 @@ func (s *DotnetSpy) Reset() {
 	s.reset = true
 }
 
-func (s *DotnetSpy) Snapshot(cb func(*spy.Labels, []byte, uint64, error)) {
+func (s *DotnetSpy) Snapshot(cb func(*spy.Labels, []byte, uint64) error) error {
 	if !s.reset {
-		return
+		return nil
 	}
 	s.reset = false
-	_ = s.session.flush(func(name []byte, v uint64) {
-		cb(nil, name, v, nil)
+	return s.session.flush(func(name []byte, v uint64) error {
+		return cb(nil, name, v)
 	})
 }

--- a/pkg/agent/gospy/gospy_test.go
+++ b/pkg/agent/gospy/gospy_test.go
@@ -27,8 +27,9 @@ var _ = Describe("analytics", func() {
 				}()
 
 				time.Sleep(50 * time.Millisecond)
-				s.Snapshot(func(labels *spy.Labels, name []byte, samples uint64, err error) {
+				s.Snapshot(func(labels *spy.Labels, name []byte, samples uint64) error {
 					log.Println("name", string(name))
+					return nil
 				})
 				close(done)
 			})

--- a/pkg/agent/phpspy/phpspy.go
+++ b/pkg/agent/phpspy/phpspy.go
@@ -1,3 +1,4 @@
+//go:build phpspy
 // +build phpspy
 
 // Package phpspy is a wrapper around this library called phpspy written in Rust
@@ -67,13 +68,12 @@ func (s *PhpSpy) Stop() error {
 }
 
 // Snapshot calls callback function with stack-trace or error.
-func (s *PhpSpy) Snapshot(cb func(*spy.Labels, []byte, uint64, error)) {
+func (s *PhpSpy) Snapshot(cb func(*spy.Labels, []byte, uint64) error) error {
 	r := C.phpspy_snapshot(C.int(s.pid), s.dataPtr, C.int(bufferLength), s.errorPtr, C.int(bufferLength))
 	if r < 0 {
-		cb(nil, nil, 0, errors.New(string(s.errorBuf[:-r])))
-	} else {
-		cb(nil, trimSemicolon(s.dataBuf[:r]), 1, nil)
+		return errors.New(string(s.errorBuf[:-r]))
 	}
+	return cb(nil, trimSemicolon(s.dataBuf[:r]), 1)
 }
 
 func init() {

--- a/pkg/agent/rbspy/rbspy.go
+++ b/pkg/agent/rbspy/rbspy.go
@@ -1,3 +1,4 @@
+//go:build rbspy
 // +build rbspy
 
 // Package rbspy is a wrapper around this library called rbspy written in Rust
@@ -74,13 +75,12 @@ func (s *RbSpy) Stop() error {
 }
 
 // Snapshot calls callback function with stack-trace or error.
-func (s *RbSpy) Snapshot(cb func(*spy.Labels, []byte, uint64, error)) {
+func (s *RbSpy) Snapshot(cb func(*spy.Labels, []byte, uint64) error) error {
 	r := C.rbspy_snapshot(C.int(s.pid), s.dataPtr, C.int(bufferLength), s.errorPtr, C.int(bufferLength))
 	if r < 0 {
-		cb(nil, nil, 0, errors.New(string(s.errorBuf[:-r])))
-	} else {
-		cb(nil, s.dataBuf[:r], 1, nil)
+		return errors.New(string(s.errorBuf[:-r]))
 	}
+	return cb(nil, s.dataBuf[:r], 1)
 }
 
 func init() {

--- a/pkg/agent/spy/spy.go
+++ b/pkg/agent/spy/spy.go
@@ -7,7 +7,7 @@ import (
 
 type Spy interface {
 	Stop() error
-	Snapshot(cb func(*Labels, []byte, uint64, error))
+	Snapshot(cb func(*Labels, []byte, uint64) error) error
 }
 
 type Resettable interface {

--- a/pkg/convert/parser_test.go
+++ b/pkg/convert/parser_test.go
@@ -24,8 +24,9 @@ var _ = Describe("convert", func() {
 			p, err := ParsePprof(g)
 			Expect(err).ToNot(HaveOccurred())
 
-			p.Get("samples", func(labels *spy.Labels, name []byte, val int) {
+			p.Get("samples", func(labels *spy.Labels, name []byte, val int) error {
 				result = append(result, fmt.Sprintf("%s %d", name, val))
+				return nil
 			})
 			Expect(result).To(ContainElement("runtime.main;main.work 1"))
 		})

--- a/pkg/convert/profile_extra_bench_test.go
+++ b/pkg/convert/profile_extra_bench_test.go
@@ -15,7 +15,7 @@ func BenchmarkProfile_Get(b *testing.B) {
 	buf, _ := os.ReadFile("testdata/cpu.pprof")
 	g, _ := gzip.NewReader(bytes.NewReader(buf))
 	p, _ := ParsePprof(g)
-	noop := func(labels *spy.Labels, name []byte, val int) {}
+	noop := func(labels *spy.Labels, name []byte, val int) error { return nil }
 	b.ResetTimer()
 
 	b.Run("ByteBufferPool", func(b *testing.B) {

--- a/pkg/server/ingest.go
+++ b/pkg/server/ingest.go
@@ -245,12 +245,16 @@ func pprofToTries(originalAppName, sampleTypeStr string, pprof *tree.Profile) ma
 	labelsCache := map[string]string{}
 
 	// callbacks := map[*spy.Labels]func([]byte, int){}
-	pprof.Get(sampleTypeStr, func(labels *spy.Labels, name []byte, val int) {
+	pprof.Get(sampleTypeStr, func(labels *spy.Labels, name []byte, val int) error {
 		appName := originalAppName
 		if labels != nil {
 			if newAppName, ok := labelsCache[labels.ID()]; ok {
 				appName = newAppName
-			} else if newAppName, err := mergeTagsWithAppName(appName, labels.Tags()); err == nil {
+			} else {
+				newAppName, err := mergeTagsWithAppName(appName, labels.Tags())
+				if err != nil {
+					return fmt.Errorf("error setting tags: %w", err)
+				}
 				appName = newAppName
 				labelsCache[labels.ID()] = appName
 			}
@@ -259,6 +263,7 @@ func pprofToTries(originalAppName, sampleTypeStr string, pprof *tree.Profile) ma
 			tries[appName] = transporttrie.New()
 		}
 		tries[appName].Insert(name, uint64(val), true)
+		return nil
 	})
 
 	return tries

--- a/pkg/storage/tree/profile_extra.go
+++ b/pkg/storage/tree/profile_extra.go
@@ -69,7 +69,7 @@ func (c *cache) pprofLabelsToSpyLabels(x *Profile, pprofLabels []*Label) *spy.La
 	return l
 }
 
-func (x *Profile) Get(sampleType string, cb func(labels *spy.Labels, name []byte, val int)) error {
+func (x *Profile) Get(sampleType string, cb func(labels *spy.Labels, name []byte, val int) error) error {
 	valueIndex := 0
 	if sampleType != "" {
 		for i, v := range x.SampleType {
@@ -98,7 +98,9 @@ func (x *Profile) Get(sampleType string, cb func(labels *spy.Labels, name []byte
 		}
 
 		labels := labelsCache.pprofLabelsToSpyLabels(x, s.Label)
-		cb(labels, b.Bytes(), int(s.Value[valueIndex]))
+		if err := cb(labels, b.Bytes(), int(s.Value[valueIndex])); err != nil {
+			return err
+		}
 
 		b.Reset()
 	}


### PR DESCRIPTION
Currently snapshot callbacks receive any error happening during data
gathering in the snapshot and they are in charge of handling them.

This inverts the usual responsibility chain where the caller should be
responsible to handle the errors of the called code, and instead
errors are passed between two unrelated code blocks.

This decision has two consequences:
- It violates the principle of least surprise. Code behaves
unexpectedly, which is arguably bad by itself.
- It reduces the flexibility in error handling. Making the callback
responsible of error handling is good enough to handle errors that
happen before the callback is called or during the callback call, but
it cannot handle the errors that happen after the callback finishes
but before the control is returned back to the caller, and this is
actually happening in our codebase (e.g. #849).

This commit changes the error handling to follow the usual flow of
making the caller responsible of handling the callee errors, and
allowing the callbacks to return those errors instead of handling
them.

This fixes #849.