### PR TITLE
fix: Do not allow querying in the future #722

### DIFF
--- a/webapp/javascript/components/CustomDatePicker.tsx
+++ b/webapp/javascript/components/CustomDatePicker.tsx
@@ -10,6 +10,7 @@ function CustomDatePicker({ setRange, dispatch, setDateRange }) {
   const from = useSelector((state: RootState) => state.root.from);
   const until = useSelector((state: RootState) => state.root.until);
   const [warning, setWarning] = useState(false);
+  const [isFutureDate, setFutureDate] = useState(false);
   const [selectedDate, setSelectedDate] = useState({
     from: formatAsOBject(from),
     until: formatAsOBject(until),
@@ -22,7 +23,7 @@ function CustomDatePicker({ setRange, dispatch, setDateRange }) {
     ) {
       return setWarning(true);
     }
-
+    
     dispatch(
       setDateRange(
         Math.round(selectedDate.from / 1000),
@@ -31,6 +32,15 @@ function CustomDatePicker({ setRange, dispatch, setDateRange }) {
     );
     return setWarning(false);
   };
+
+  const checkFutureDate= (date: Date) => {
+    let dateToday = new Date(Date.now())
+    
+    if(isAfter(date, dateToday)) {
+      return setFutureDate(true)
+    }
+    return setFutureDate(false)
+  }
 
   useEffect(() => {
     setSelectedDate({
@@ -65,6 +75,8 @@ function CustomDatePicker({ setRange, dispatch, setDateRange }) {
           id="datepicker-until"
           selected={selectedDate.until}
           onChange={(date) => {
+            console.log(date);
+            checkFutureDate(date);
             setSelectedDate({ ...selectedDate, until: date });
           }}
           selectsEnd
@@ -76,8 +88,9 @@ function CustomDatePicker({ setRange, dispatch, setDateRange }) {
         />
       </div>
       {warning && <p style={{ color: 'red' }}>Warning: invalid date Range</p>}
+      {isFutureDate && <p style={{ color: 'yellow' }}>Warning: Until can not be a future date</p>}
 
-      <Button type="submit" kind="primary" onClick={() => updateDateRange()}>
+      <Button type="submit" kind="primary" disabled={isFutureDate ? true: false} onClick={() => updateDateRange()}>
         Apply range
       </Button>
     </div>


### PR DESCRIPTION
Hello @eh-am 

fix: [#722](https://github.com/pyroscope-io/pyroscope/issues/722)

Greetings! I managed to work out a solution for querying a future date regression as mentioned in this [#722](https://github.com/pyroscope-io/pyroscope/issues/722)

- Add check to `CustomDatePicker` component to check if the select date is into the future by comparing date selected to the current date constructed from timestamp
- Toggle `disabled` prop of `Button` component in `CustomDatePicker` based whether the `Until` input is into a future date

Preview:
https://user-images.githubusercontent.com/37052032/154798372-33ae1aa4-bf60-4634-99e1-aa01b985468b.mp4

Please let me know of any issues,
Best,

Naftali
