### PR TITLE
chore: use Admin as the default role when using oauth-mock

### DIFF
--- a/scripts/oauth-mock/pyroscope-config.yml
+++ b/scripts/oauth-mock/pyroscope-config.yml
@@ -1,5 +1,7 @@
 ---
 auth:
+  signup-default-role: Admin
+
   gitlab:
     enabled: true
     api-url: http://localhost:18080


### PR DESCRIPTION
the idea is to make it easier to test it
since most likely the test will go over the settings page
which require admin permissions