### PR TITLE
chore: Make email not required on Edit Profile page

### DIFF
--- a/webapp/javascript/components/Settings/Preferences/index.tsx
+++ b/webapp/javascript/components/Settings/Preferences/index.tsx
@@ -72,7 +72,6 @@ function Preferences(props) {
           type="text"
           placeholder="email"
           value={form?.email}
-          required
           name="email"
           onChange={handleFormChange}
         />


### PR DESCRIPTION
Solves #907

This pull request removes the required attribute from the email field on the Edit Profile page (/settings).

The initial issue also states that the Full Name field has a non-empty requirement, however, this does not seem to be the case on the latest build.