### PR TITLE
ci: fetch pull request

### DIFF
--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -24,9 +24,10 @@ jobs:
         if: github.event_name == 'pull_request'
         # For PRs check the actual commit
         # https://github.com/actions/checkout/issues/124#issuecomment-586664611
+        # https://github.com/actions/checkout/issues/518#issuecomment-890401887
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: 'refs/pull/${{ github.event.number }}/merge'
 
       # pull all tags since they are required when generating locally
       # https://github.com/lerna/lerna/issues/2542

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -10,7 +10,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # Don't run for forks
-    #if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       #######################
       #      Checkout      #
@@ -105,7 +104,8 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish Pull Request
-        if: github.event_name == 'pull_request'
+        # Only publish if it comes from the main repo
+        if: github.event_name == 'pull_request' and github.event.pull_request.head.repo.full_name == github.repository
         run: |
           yarn run lerna publish from-git \
             --skip-git \

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -31,7 +31,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
 
-
       # pull all tags since they are required when generating locally
       # https://github.com/lerna/lerna/issues/2542
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Don't run for forks
+    #if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       #######################
       #      Checkout      #
@@ -24,10 +26,12 @@ jobs:
         if: github.event_name == 'pull_request'
         # For PRs check the actual commit
         # https://github.com/actions/checkout/issues/124#issuecomment-586664611
-        # https://github.com/actions/checkout/issues/518#issuecomment-890401887
+        # https://github.com/actions/checkout/issues/455#issuecomment-792228083
         with:
           fetch-depth: 0
-          ref: 'refs/pull/${{ github.event.number }}/merge'
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
 
       # pull all tags since they are required when generating locally
       # https://github.com/lerna/lerna/issues/2542


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/913

* don't publish Pull Requests from forks, since the NPM_TOKEN  is not available.