### PR TITLE
chore: remove redundant error message and satisfy typescript warnings

### DIFF
--- a/webapp/javascript/components/Settings/APIKeys/APIKeyAddForm.tsx
+++ b/webapp/javascript/components/Settings/APIKeys/APIKeyAddForm.tsx
@@ -97,6 +97,7 @@ function APIKeyAddForm() {
               name="name"
               value={form.name}
               onChange={handleFormChange}
+              required
             />
             <div>
               <h4>Role</h4>

--- a/webapp/javascript/components/Settings/APIKeys/APIKeyAddForm.tsx
+++ b/webapp/javascript/components/Settings/APIKeys/APIKeyAddForm.tsx
@@ -12,7 +12,11 @@ import StatusMessage from '@ui/StatusMessage';
 import { addNotification } from '@pyroscope/redux/reducers/notifications';
 import styles from './APIKeyForm.module.css';
 
-export type APIKeyAddProps = APIKey;
+// Extend the API key, but add form validation errors and ttlSeconds
+export interface APIKeyAddProps extends APIKey {
+  errors?: string[];
+  ttlSeconds?: number;
+}
 
 function APIKeyAddForm() {
   const [form, setForm]: [APIKeyAddProps, (value) => void] = useState({

--- a/webapp/javascript/components/Settings/APIKeys/APIKeyAddForm.tsx
+++ b/webapp/javascript/components/Settings/APIKeys/APIKeyAddForm.tsx
@@ -71,7 +71,6 @@ function APIKeyAddForm() {
     <>
       <h2>Add API Key</h2>
 
-      <StatusMessage type="error" message={form.errors.join(', ')} />
       <form onSubmit={handleFormSubmit}>
         {key ? (
           <div>

--- a/webapp/javascript/redux/reducers/settings.ts
+++ b/webapp/javascript/redux/reducers/settings.ts
@@ -232,7 +232,7 @@ export const deleteAPIKey = createAsyncThunk(
     thunkAPI.dispatch(
       addNotification({
         type: 'danger',
-        title: 'Failed to create API key',
+        title: 'Failed to delete API key',
         message: res.error.errors.join(', '),
       })
     );


### PR DESCRIPTION
This pull request solves #905 :
The only time the errors in the form are set is when the `createAPIKey` function throws an error, however, in `createAPIKey` an error notification is already set whenever it throws an error. This resulted in duplicated error messages. The `StatusMessage` for errors is therefore seemingly redundant. I have left the success StatusMessage in place as it still includes valuable information.
The name field has also been made required to prevent making API calls that will always fail due to an empty name.

Furthermore, there were some typescript warnings that occurred because the `APIKeyAddProps` (or more specifically the `APIKey`) was missing `errors` and `ttlSeconds` on the type. I have instead extended `APIKey` into `APIKeyAddProps` and added (optional) fields for these two.

Lastly, I noticed that one of the errors in the dispatch for deleteAPIKey used the same error text as CreateAPIKey, leading to an incorrect error message in the notification when deleting an APIKey. This has now been to say `deleted` instead of `created`.