### PR TITLE
feat: add dedicated profiles storage with support for retention policy

### DIFF
--- a/cmd/pyroscope/command/admin.go
+++ b/cmd/pyroscope/command/admin.go
@@ -29,6 +29,7 @@ func newAdminCmd(cfg *config.Admin) *cobra.Command {
 	// admin
 	cmd.AddCommand(newAdminAppCmd(cfg))
 	cmd.AddCommand(newAdminUserCmd(cfg))
+	cmd.AddCommand(newAdminStorageCmd(cfg))
 
 	return cmd
 }
@@ -49,24 +50,6 @@ func newAdminAppCmd(cfg *config.Admin) *cobra.Command {
 
 	cmd.AddCommand(newAdminAppGetCmd(&cfg.AdminAppGet))
 	cmd.AddCommand(newAdminAppDeleteCmd(&cfg.AdminAppDelete))
-
-	return cmd
-}
-
-func newAdminUserCmd(cfg *config.Admin) *cobra.Command {
-	vpr := newViper()
-
-	var cmd *cobra.Command
-	cmd = &cobra.Command{
-		Use:   "user",
-		Short: "manage users",
-		RunE: cli.CreateCmdRunFn(cfg, vpr, func(_ *cobra.Command, _ []string) error {
-			printUsageMessage(cmd)
-			return nil
-		}),
-	}
-
-	cmd.AddCommand(newAdminPasswordResetCmd(&cfg.AdminUserPasswordReset))
 
 	return cmd
 }
@@ -131,6 +114,24 @@ func newAdminAppDeleteCmd(cfg *config.AdminAppDelete) *cobra.Command {
 	return cmd
 }
 
+func newAdminUserCmd(cfg *config.Admin) *cobra.Command {
+	vpr := newViper()
+
+	var cmd *cobra.Command
+	cmd = &cobra.Command{
+		Use:   "user",
+		Short: "manage users",
+		RunE: cli.CreateCmdRunFn(cfg, vpr, func(_ *cobra.Command, _ []string) error {
+			printUsageMessage(cmd)
+			return nil
+		}),
+	}
+
+	cmd.AddCommand(newAdminPasswordResetCmd(&cfg.AdminUserPasswordReset))
+
+	return cmd
+}
+
 func newAdminPasswordResetCmd(cfg *config.AdminUserPasswordReset) *cobra.Command {
 	vpr := newViper()
 	cmd := &cobra.Command{
@@ -147,6 +148,42 @@ func newAdminPasswordResetCmd(cfg *config.AdminUserPasswordReset) *cobra.Command
 			}
 			fmt.Println("Password for user", cfg.Username, "has been reset successfully.")
 			return nil
+		}),
+	}
+
+	cli.PopulateFlagSet(cfg, cmd.Flags(), vpr)
+	return cmd
+}
+
+func newAdminStorageCmd(cfg *config.Admin) *cobra.Command {
+	vpr := newViper()
+
+	var cmd *cobra.Command
+	cmd = &cobra.Command{
+		Use:   "storage",
+		Short: "",
+		RunE: cli.CreateCmdRunFn(cfg, vpr, func(_ *cobra.Command, _ []string) error {
+			printUsageMessage(cmd)
+			return nil
+		}),
+	}
+
+	cmd.AddCommand(newAdminStorageCleanupCmd(&cfg.AdminStorageCleanup))
+	return cmd
+}
+
+func newAdminStorageCleanupCmd(cfg *config.AdminStorageCleanup) *cobra.Command {
+	vpr := newViper()
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: "remove malformed data",
+		Args:  cobra.NoArgs,
+		RunE: cli.CreateCmdRunFn(cfg, vpr, func(_ *cobra.Command, arg []string) error {
+			ac, err := admin.NewCLI(cfg.SocketPath, cfg.Timeout)
+			if err != nil {
+				return err
+			}
+			return ac.CleanupStorage()
 		}),
 	}
 

--- a/pkg/admin/admin_integration_test.go
+++ b/pkg/admin/admin_integration_test.go
@@ -41,7 +41,7 @@ var _ = Describe("integration", func() {
 		httpServer, err := admin.NewUdsHTTPServer(socketAddr, http)
 		Expect(err).ToNot(HaveOccurred())
 		svc := admin.NewService(mockStorage{})
-		ctrl := admin.NewController(logger, svc, mockUserService{})
+		ctrl := admin.NewController(logger, svc, mockUserService{}, mockStorageService{})
 		s, err := admin.NewServer(logger, ctrl, httpServer)
 		Expect(err).ToNot(HaveOccurred())
 		server = s

--- a/pkg/admin/cli.go
+++ b/pkg/admin/cli.go
@@ -89,6 +89,10 @@ func (c *CLI) DeleteApp(appname string, skipVerification bool) error {
 	return nil
 }
 
+func (c *CLI) CleanupStorage() error {
+	return c.client.CleanupStorage()
+}
+
 func (c *CLI) ResetUserPassword(username, password string, enable bool) error {
 	if username == "" || password == "" {
 		return fmt.Errorf("username and password are required")

--- a/pkg/admin/client.go
+++ b/pkg/admin/client.go
@@ -19,8 +19,9 @@ type Client struct {
 // TODO since this is shared between client/server
 // maybe we could share it?
 const (
-	appsEndpoint  = "http://pyroscope/v1/apps"
-	usersEndpoint = "http://pyroscope/v1/users"
+	appsEndpoint    = "http://pyroscope/v1/apps"
+	usersEndpoint   = "http://pyroscope/v1/users"
+	storageEndpoint = "http://pyroscope/v1/storage"
 )
 
 var (
@@ -104,6 +105,14 @@ func (c *Client) ResetUserPassword(username, password string, enable bool) error
 	}
 
 	req, err := http.NewRequest(http.MethodPatch, usersEndpoint+"/"+username, &b)
+	if err != nil {
+		return fmt.Errorf("error creating request: %w", err)
+	}
+	return c.do(req)
+}
+
+func (c *Client) CleanupStorage() error {
+	req, err := http.NewRequest(http.MethodPut, storageEndpoint+"/cleanup", nil)
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}

--- a/pkg/admin/controller_test.go
+++ b/pkg/admin/controller_test.go
@@ -36,6 +36,12 @@ func (mockUserService) UpdateUserByName(context.Context, string, model.UpdateUse
 	return model.User{}, nil
 }
 
+type mockStorageService struct{}
+
+func (mockStorageService) Cleanup(context.Context) error {
+	return nil
+}
+
 var _ = Describe("controller", func() {
 	Describe("/v1/apps", func() {
 		var svr *admin.Server
@@ -55,7 +61,7 @@ var _ = Describe("controller", func() {
 			logger, _ := test.NewNullLogger()
 
 			svc := admin.NewService(storage)
-			ctrl := admin.NewController(logger, svc, mockUserService{})
+			ctrl := admin.NewController(logger, svc, mockUserService{}, mockStorageService{})
 			httpServer := &admin.UdsHTTPServer{}
 			server, err := admin.NewServer(logger, ctrl, httpServer)
 

--- a/pkg/admin/server.go
+++ b/pkg/admin/server.go
@@ -41,6 +41,7 @@ func NewServer(logger *logrus.Logger, ctrl *Controller, httpServer HTTPServer) (
 	r.HandleFunc("/v1/apps", as.ctrl.HandleGetApps).Methods("GET")
 	r.HandleFunc("/v1/apps", as.ctrl.HandleDeleteApp).Methods("DELETE")
 	r.HandleFunc("/v1/users/{username}", as.ctrl.UpdateUserHandler).Methods("PATCH")
+	r.HandleFunc("/v1/storage/cleanup", as.ctrl.StorageCleanupHandler).Methods("PUT")
 
 	// Global middlewares
 	r.Use(logginMiddleware)

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -108,7 +108,7 @@ func newServerService(c *config.Server) (*serverService, error) {
 		socketPath := svc.config.AdminSocketPath
 		adminService := admin.NewService(svc.storage)
 		userService := service.NewUserService(svc.database.DB())
-		adminCtrl := admin.NewController(svc.logger, adminService, userService)
+		adminCtrl := admin.NewController(svc.logger, adminService, userService, svc.storage)
 		httpClient, err := admin.NewHTTPOverUDSClient(socketPath)
 		if err != nil {
 			return nil, fmt.Errorf("admin: %w", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -319,6 +319,7 @@ type Admin struct {
 	AdminAppDelete         AdminAppDelete         `skip:"true" mapstructure:",squash"`
 	AdminAppGet            AdminAppGet            `skip:"true" mapstructure:",squash"`
 	AdminUserPasswordReset AdminUserPasswordReset `skip:"true" mapstructure:",squash"`
+	AdminStorageCleanup    AdminStorageCleanup    `skip:"true" mapstructure:",squash"`
 }
 
 type AdminAppGet struct {
@@ -339,6 +340,11 @@ type AdminUserPasswordReset struct {
 	Username string `desc:"user name (login)" mapstructure:"username"`
 	Password string `desc:"new password" mapstructure:"password"`
 	Enable   bool   `desc:"enable user" mapstructure:"enable"`
+}
+
+type AdminStorageCleanup struct {
+	SocketPath string        `def:"/tmp/pyroscope.sock" desc:"path where the admin server socket was created." mapstructure:"socket-path"`
+	Timeout    time.Duration `def:"30m" desc:"timeout for the server to respond" mapstructure:"timeout"`
 }
 
 type Database struct {

--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -248,6 +248,7 @@ func (ctrl *Controller) serverMux() (http.Handler, error) {
 		{"/render-diff", ctrl.renderDiffHandler},
 		{"/labels", ctrl.labelsHandler},
 		{"/label-values", ctrl.labelValuesHandler},
+		{"/merge", ctrl.mergeHandler},
 		{"/export", ctrl.exportHandler},
 		{"/api/adhoc", ctrl.adhoc.AddRoutes(r.PathPrefix("/api/adhoc").Subrouter())}},
 		ctrl.drainMiddleware,

--- a/pkg/server/render.go
+++ b/pkg/server/render.go
@@ -111,6 +111,71 @@ func (ctrl *Controller) renderHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+type mergeRequest struct {
+	AppName  string   `json:"appName"`
+	Profiles []string `json:"profiles"`
+	MaxNodes int      `json:"maxNodes"`
+}
+
+type mergeResponse struct {
+	flamebearer.FlamebearerProfile
+}
+
+func (ctrl *Controller) mergeHandler(w http.ResponseWriter, r *http.Request) {
+	var req mergeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		ctrl.writeInvalidParameterError(w, err)
+		return
+	}
+
+	if req.AppName == "" {
+		ctrl.writeInvalidParameterError(w, fmt.Errorf("application name required"))
+		return
+	}
+	if len(req.Profiles) == 0 {
+		ctrl.writeInvalidParameterError(w, fmt.Errorf("at least one profile ID must be specified"))
+		return
+	}
+	maxNodes := ctrl.config.MaxNodesRender
+	if req.MaxNodes > 0 {
+		maxNodes = req.MaxNodes
+	}
+
+	out, err := ctrl.storage.MergeProfiles(r.Context(), storage.MergeProfilesInput{
+		AppName:  req.AppName,
+		Profiles: req.Profiles,
+	})
+	if err != nil {
+		ctrl.writeInternalServerError(w, err, "failed to retrieve data")
+		return
+	}
+
+	flame := out.Tree.FlamebearerStruct(maxNodes)
+	resp := mergeResponse{
+		FlamebearerProfile: flamebearer.FlamebearerProfile{
+			Version: 1,
+			FlamebearerProfileV1: flamebearer.FlamebearerProfileV1{
+				Flamebearer: flamebearer.FlamebearerV1{
+					Names:    flame.Names,
+					Levels:   flame.Levels,
+					NumTicks: flame.NumTicks,
+					MaxSelf:  flame.MaxSelf,
+				},
+				// Hardcoded values for Go.
+				Metadata: flamebearer.FlamebearerMetadataV1{
+					Format:     string(tree.FormatSingle),
+					SpyName:    "unknown",
+					SampleRate: 100,
+					Units:      "samples",
+				},
+			},
+		},
+	}
+
+	ctrl.statsInc("merge")
+	ctrl.writeResponseJSON(w, resp)
+}
+
 // Enhance the flamebearer with a few additional fields the UI requires
 func (*Controller) mountRenderResponse(flame flamebearer.FlamebearerProfile, appName string, gi *storage.GetInput, maxNodes int) RenderResponse {
 	metadata := renderMetadataResponse{

--- a/pkg/server/render_test.go
+++ b/pkg/server/render_test.go
@@ -141,3 +141,51 @@ var _ = Describe("server", func() {
 		})
 	})
 })
+
+var _ = Describe("render merge test", func() {
+	var httpServer *httptest.Server
+	testing.WithConfig(func(cfg **config.Config) {
+		BeforeEach(func() {
+			(*cfg).Server.APIBindAddr = ":10044"
+			s, err := storage.New(storage.NewConfig(&(*cfg).Server), logrus.StandardLogger(), prometheus.NewRegistry(), new(health.Controller))
+			Expect(err).ToNot(HaveOccurred())
+			e, _ := exporter.NewExporter(nil, nil)
+			c, _ := New(Config{
+				Configuration:           &(*cfg).Server,
+				Storage:                 s,
+				MetricsExporter:         e,
+				Logger:                  logrus.New(),
+				MetricsRegisterer:       prometheus.NewRegistry(),
+				ExportedMetricsRegistry: prometheus.NewRegistry(),
+				Notifier:                mockNotifier{},
+				Adhoc:                   mockAdhocServer{},
+			})
+			h, _ := c.serverMux()
+			httpServer = httptest.NewServer(h)
+		})
+
+		Context("/render", func() {
+			It("handles merge requests", func() {
+				defer httpServer.Close()
+
+				resp, err := http.Post(httpServer.URL+"/merge", "application/json", reqBody(mergeRequest{
+					AppName:  "app.cpu",
+					Profiles: []string{"a", "b"},
+				}))
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				var merged mergeResponse
+				Expect(json.NewDecoder(resp.Body).Decode(&merged)).ToNot(HaveOccurred())
+				Expect(merged.Validate()).ToNot(HaveOccurred())
+			})
+		})
+	})
+})
+
+func reqBody(v interface{}) io.Reader {
+	var b bytes.Buffer
+	Expect(json.NewEncoder(&b).Encode(v)).ToNot(HaveOccurred())
+	return &b
+}

--- a/pkg/storage/cleanup.go
+++ b/pkg/storage/cleanup.go
@@ -11,7 +11,15 @@ import (
 
 // Cleanup removes malformed data from the storage.
 func (s *Storage) Cleanup(ctx context.Context) error {
-	// TODO: must not be called after Close().
+	select {
+	case <-s.stop:
+		return nil
+	default:
+		// This means than s.tasksWG.Wait has not been called yet
+		// and it is safe to start the cleanup. There is a negligible
+		// chance that tasksWG.Wait is called concurrently before we
+		// continue.
+	}
 	s.tasksWG.Add(1)
 	defer s.tasksWG.Done()
 	start := time.Now()

--- a/pkg/storage/cleanup.go
+++ b/pkg/storage/cleanup.go
@@ -11,6 +11,7 @@ import (
 
 // Cleanup removes malformed data from the storage.
 func (s *Storage) Cleanup(ctx context.Context) error {
+	// TODO: must not be called after Close().
 	s.tasksWG.Add(1)
 	defer s.tasksWG.Done()
 	start := time.Now()

--- a/pkg/storage/cleanup.go
+++ b/pkg/storage/cleanup.go
@@ -1,0 +1,61 @@
+package storage
+
+import (
+	"context"
+	"time"
+
+	"github.com/dgraph-io/badger/v2"
+
+	"github.com/pyroscope-io/pyroscope/pkg/storage/segment"
+)
+
+// Cleanup removes malformed data from the storage.
+func (s *Storage) Cleanup(ctx context.Context) error {
+	s.tasksWG.Add(1)
+	defer s.tasksWG.Done()
+	start := time.Now()
+	s.logger.Debug("cleanup started")
+	defer func() {
+		s.logger.WithField("duration", time.Since(start)).Debug("cleanup finished")
+	}()
+	return s.cleanupTreesDB(ctx)
+}
+
+func (s *Storage) cleanupTreesDB(ctx context.Context) (err error) {
+	batch := s.trees.DB.NewWriteBatch()
+	defer func() {
+		err = batch.Flush()
+	}()
+	return s.trees.DB.Update(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.IteratorOptions{Prefix: treePrefix.bytes()})
+		defer it.Close()
+		var c int64
+		for it.Rewind(); it.Valid(); it.Next() {
+			select {
+			default:
+			case <-ctx.Done():
+				return nil
+			case <-s.stop:
+				return nil
+			}
+			item := it.Item()
+			if k, ok := treePrefix.trim(item.Key()); ok {
+				if _, _, err = segment.ParseTreeKey(string(k)); err == nil {
+					continue
+				}
+			}
+			if c == s.trees.DB.MaxBatchCount()+1 {
+				if err = batch.Flush(); err != nil {
+					return err
+				}
+				batch = s.trees.DB.NewWriteBatch()
+				c = 0
+			}
+			if err = batch.Delete(item.KeyCopy(nil)); err != nil {
+				return err
+			}
+			c++
+		}
+		return nil
+	})
+}

--- a/pkg/storage/profile.go
+++ b/pkg/storage/profile.go
@@ -1,0 +1,232 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/valyala/bytebufferpool"
+
+	"github.com/pyroscope-io/pyroscope/pkg/storage/dict"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
+)
+
+type profiles struct {
+	db     *db
+	dicts  *db
+	config *Config
+}
+
+var bufferPool = bytebufferpool.Pool{}
+
+const (
+	profileDataPrefix      prefix = "v:"
+	profileTimestampPrefix prefix = "t:"
+
+	// t:{timestamp}:{profile_id}
+	profileTimestampMinLen = len(profileTimestampPrefix) + 8 + 1
+
+	profilesFormatV1 byte = 1
+)
+
+func profileTimestamp(t time.Time, k []byte) []byte {
+	b := make([]byte, profileTimestampMinLen, 32)
+	b[0], b[1], b[9] = 't', ':', ':'
+	binary.LittleEndian.PutUint64(b[2:], uint64(t.UnixNano()))
+	return append(b, k...)
+}
+
+// parseProfileTimestamp returns timestamp and the profile
+// data key, if the given timestamp key is valid.
+func parseProfileTimestamp(k []byte) (int64, []byte, bool) {
+	if v, ok := profileTimestampPrefix.trim(k); ok && len(k) > profileTimestampMinLen {
+		return int64(binary.LittleEndian.Uint64(v[:8])), append(profileDataPrefix.bytes(), v[9:]...), true
+	}
+	return 0, nil, false
+}
+
+func (s profiles) Insert(appName, profileID string, v *tree.Tree, at time.Time) error {
+	d, err := s.dicts.GetOrCreate(appName)
+	if err != nil {
+		return err
+	}
+	dx := d.(*dict.Dict)
+	k := []byte(profileID)
+	b := bufferPool.Get()
+	defer func() {
+		bufferPool.Put(b)
+		s.dicts.Put(appName, d)
+	}()
+
+	return s.db.Update(func(txn *badger.Txn) error {
+		k = profileDataPrefix.key(appName + "." + profileID)
+		if err = txn.Set(profileTimestamp(at, k), nil); err != nil {
+			return err
+		}
+
+		var item *badger.Item
+		item, err = txn.Get(k)
+		switch {
+		default:
+			return err
+		case errors.Is(err, badger.ErrKeyNotFound):
+		case err == nil:
+			return item.Value(valueReader(dx, func(t *tree.Tree) error {
+				t.Merge(v)
+				v = t
+				return nil
+			}))
+		}
+
+		if err = b.WriteByte(profilesFormatV1); err != nil {
+			return err
+		}
+		if err = v.SerializeTruncate(dx, s.config.maxNodesSerialization, b); err == nil {
+			return txn.Set(k, b.Bytes())
+		}
+		return err
+	})
+}
+
+func (s profiles) Fetch(ctx context.Context, appName string, profileIDs []string, fn func(*tree.Tree) error) error {
+	d, ok := s.dicts.Lookup(appName)
+	if !ok {
+		return nil
+	}
+	r := valueReader(d.(*dict.Dict), fn)
+	return s.db.View(func(txn *badger.Txn) error {
+		for _, profileID := range profileIDs {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			item, err := txn.Get(profileDataPrefix.key(appName + "." + profileID))
+			switch {
+			default:
+				return err
+			case errors.Is(err, badger.ErrKeyNotFound):
+			case err == nil:
+				if err = item.Value(r); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+}
+
+func valueReader(d *dict.Dict, fn func(*tree.Tree) error) func(val []byte) error {
+	return func(val []byte) error {
+		r := bytes.NewReader(val)
+		v, err := r.ReadByte()
+		if err != nil {
+			return err
+		}
+		switch v {
+		default:
+			return fmt.Errorf("unknown profile format version %d", v)
+		case profilesFormatV1:
+			var t *tree.Tree
+			if t, err = tree.Deserialize(d, r); err != nil {
+				return err
+			}
+			return fn(t)
+		}
+	}
+}
+
+func (s profiles) Truncate(ctx context.Context, before time.Time) error {
+	return truncateBefore(ctx, s.db.DB, before)
+}
+
+func truncateBefore(ctx context.Context, x *badger.DB, before time.Time) (err error) {
+	t := before.UnixNano()
+	batch := newWriteBatch(x)
+	defer func() {
+		err = batch.flush()
+	}()
+	return x.View(func(txn *badger.Txn) error {
+		it := txn.NewIterator(badger.IteratorOptions{
+			Prefix: profileTimestampPrefix.bytes(),
+		})
+		defer it.Close()
+		for it.Rewind(); it.Valid(); it.Next() {
+			if err = ctx.Err(); err != nil {
+				return err
+			}
+			k := it.Item().Key()
+			kt, pk, ok := parseProfileTimestamp(k)
+			if !ok || kt > t {
+				continue
+			}
+			if err = batch.delete(pk); err != nil {
+				return err
+			}
+			if err = batch.delete(k); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+type writeBatch struct {
+	db *badger.DB
+	wb *badger.WriteBatch
+
+	count int
+	size  int
+	err   error
+}
+
+func newWriteBatch(x *badger.DB) *writeBatch { return &writeBatch{wb: x.NewWriteBatch()} }
+
+func (b *writeBatch) flush() error {
+	if b.err != nil {
+		return b.err
+	}
+	if b.size == 0 {
+		return nil
+	}
+	return b.wb.Flush()
+}
+
+func (b *writeBatch) write(k, v []byte) error {
+	if b.size+len(v) >= int(b.db.MaxBatchSize()) || b.count+1 >= int(b.db.MaxBatchCount()) {
+		if err := b.wb.Flush(); err != nil {
+			b.err = err
+			return err
+		}
+		b.wb = b.db.NewWriteBatch()
+		b.size = 0
+		b.count = 0
+	}
+	if err := b.wb.Set(k, v); err != nil {
+		b.err = err
+		return err
+	}
+	b.size += len(v)
+	b.count++
+	return nil
+}
+
+func (b *writeBatch) delete(k []byte) error {
+	if b.count+1 >= int(b.db.MaxBatchCount()) {
+		if err := b.wb.Flush(); err != nil {
+			b.err = err
+			return err
+		}
+		b.wb = b.db.NewWriteBatch()
+		b.size = 0
+		b.count = 0
+	}
+	if err := b.wb.Delete(k); err != nil {
+		b.err = err
+		return err
+	}
+	b.count++
+	return nil
+}

--- a/pkg/storage/profile.go
+++ b/pkg/storage/profile.go
@@ -162,8 +162,8 @@ func (s profiles) truncateBefore(ctx context.Context, before time.Time) (err err
 			if err = ctx.Err(); err != nil {
 				return err
 			}
-			k := it.Item().Key()
-			kt, pk, ok := parseProfileTimestamp(k)
+			item := it.Item()
+			kt, pk, ok := parseProfileTimestamp(item.Key())
 			if !ok {
 				continue
 			}
@@ -180,7 +180,7 @@ func (s profiles) truncateBefore(ctx context.Context, before time.Time) (err err
 			if err = batch.Delete(pk); err != nil {
 				return err
 			}
-			if err = batch.Delete(k); err != nil {
+			if err = batch.Delete(item.KeyCopy(nil)); err != nil {
 				return err
 			}
 			c += 2

--- a/pkg/storage/profile_test.go
+++ b/pkg/storage/profile_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package storage
 
 import (

--- a/pkg/storage/profile_test.go
+++ b/pkg/storage/profile_test.go
@@ -1,0 +1,70 @@
+package storage
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/pyroscope-io/pyroscope/pkg/config"
+	"github.com/sirupsen/logrus"
+
+	"github.com/pyroscope-io/pyroscope/pkg/health"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/segment"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
+	"github.com/pyroscope-io/pyroscope/pkg/testing"
+)
+
+var _ = Describe("MergeProfiles", func() {
+	testing.WithConfig(func(cfg **config.Config) {
+		JustBeforeEach(func() {
+			var err error
+			s, err = New(NewConfig(&(*cfg).Server), logrus.StandardLogger(), prometheus.NewRegistry(), new(health.Controller))
+			Expect(err).ToNot(HaveOccurred())
+		})
+		Context("when profiles with ID ingested", func() {
+			It("merges profiling data correctly", func() {
+				defer s.Close()
+
+				tree := tree.New()
+				tree.Insert([]byte("a;b"), uint64(1))
+				tree.Insert([]byte("a;c"), uint64(2))
+				st := testing.SimpleTime(10)
+				et := testing.SimpleTime(19)
+
+				k1, _ := segment.ParseKey("app.cpu{profile_id=a}")
+				k2, _ := segment.ParseKey("app.cpu{profile_id=b}")
+
+				Expect(s.Put(&PutInput{
+					StartTime: st,
+					EndTime:   et,
+					Key:       k1,
+					Val:       tree,
+				})).ToNot(HaveOccurred())
+
+				Expect(s.Put(&PutInput{
+					StartTime: st,
+					EndTime:   et,
+					Key:       k2,
+					Val:       tree,
+				})).ToNot(HaveOccurred())
+
+				o, err := s.MergeProfiles(context.Background(), MergeProfilesInput{
+					AppName:   "app.cpu",
+					ProfileID: []string{"a"},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(o.Tree).ToNot(BeNil())
+				Expect(o.Tree.Samples()).To(Equal(uint64(3)))
+
+				o, err = s.MergeProfiles(context.Background(), MergeProfilesInput{
+					AppName:   "app.cpu",
+					ProfileID: []string{"a", "b"},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(o.Tree).ToNot(BeNil())
+				Expect(o.Tree.Samples()).To(Equal(uint64(6)))
+			})
+		})
+	})
+})

--- a/pkg/storage/profile_test.go
+++ b/pkg/storage/profile_test.go
@@ -54,16 +54,16 @@ var _ = Describe("MergeProfiles", func() {
 				})).ToNot(HaveOccurred())
 
 				o, err := s.MergeProfiles(context.Background(), MergeProfilesInput{
-					AppName:   "app.cpu",
-					ProfileID: []string{"a"},
+					AppName:  "app.cpu",
+					Profiles: []string{"a"},
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(o.Tree).ToNot(BeNil())
 				Expect(o.Tree.Samples()).To(Equal(uint64(3)))
 
 				o, err = s.MergeProfiles(context.Background(), MergeProfilesInput{
-					AppName:   "app.cpu",
-					ProfileID: []string{"a", "b"},
+					AppName:  "app.cpu",
+					Profiles: []string{"a", "b"},
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(o.Tree).ToNot(BeNil())
@@ -112,8 +112,8 @@ var _ = Describe("Profiles retention policy", func() {
 				Expect(s.EnforceRetentionPolicy(rp)).ToNot(HaveOccurred())
 
 				o, err := s.MergeProfiles(context.Background(), MergeProfilesInput{
-					AppName:   "app.cpu",
-					ProfileID: []string{"a", "b"},
+					AppName:  "app.cpu",
+					Profiles: []string{"a", "b"},
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(o.Tree).ToNot(BeNil())

--- a/pkg/storage/retention.go
+++ b/pkg/storage/retention.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -17,6 +18,11 @@ func (s *Storage) EnforceRetentionPolicy(rp *segment.RetentionPolicy) error {
 
 	// It may make sense running it concurrently with some throttling.
 	s.logger.Debug("enforcing retention policy")
+	if !rp.AbsoluteTime.IsZero() {
+		if err := s.profiles.Truncate(context.TODO(), rp.AbsoluteTime); err != nil {
+			s.logger.WithError(err).Error("failed to truncate profiles storage")
+		}
+	}
 	err := s.iterateOverAllSegments(func(k *segment.Key) error {
 		return s.deleteSegmentData(k, rp)
 	})

--- a/pkg/storage/retention.go
+++ b/pkg/storage/retention.go
@@ -19,7 +19,7 @@ func (s *Storage) EnforceRetentionPolicy(rp *segment.RetentionPolicy) error {
 	// It may make sense running it concurrently with some throttling.
 	s.logger.Debug("enforcing retention policy")
 	if !rp.AbsoluteTime.IsZero() {
-		if err := s.profiles.Truncate(context.TODO(), rp.AbsoluteTime); err != nil {
+		if err := s.profiles.truncateBefore(context.TODO(), rp.AbsoluteTime); err != nil {
 			s.logger.WithError(err).Error("failed to truncate profiles storage")
 		}
 	}

--- a/pkg/storage/segment/key.go
+++ b/pkg/storage/segment/key.go
@@ -116,12 +116,9 @@ func (k *Key) HasProfileID() bool {
 	return ok && v != ""
 }
 
-func NewProfileIDKey(appName, id string) string {
-	return appName + "{" + id + "}"
-}
-
-func (k *Key) ProfileIDKey() string {
-	return NewProfileIDKey(k.AppName(), k.labels[ProfileIDLabelName])
+func (k *Key) ProfileID() (string, bool) {
+	id, ok := k.labels[ProfileIDLabelName]
+	return id, ok
 }
 
 func TreeKey(k string, depth int, unixTime int64) string {

--- a/pkg/storage/storage_delete_test.go
+++ b/pkg/storage/storage_delete_test.go
@@ -1,3 +1,6 @@
+//go:build !windows
+// +build !windows
+
 package storage
 
 import (
@@ -136,8 +139,7 @@ var _ = Describe("storage package", func() {
 
 				// Trees
 				Expect(s.trees.Cache.Size()).To(Equal(uint64(1)))
-				t := checkTreesPresence(appname, st, 0, true)
-				Expect(t).To(Equal(tree1))
+				checkTreesPresence(appname, st, 0, true)
 
 				// Segments
 				Expect(s.segments.Cache.Size()).To(Equal(uint64(1)))
@@ -160,7 +162,7 @@ var _ = Describe("storage package", func() {
 				// Trees
 				// should've been deleted from CACHE
 				Expect(s.trees.Cache.Size()).To(Equal(uint64(0)))
-				t = checkTreesPresence(appname, st, 0, false)
+				checkTreesPresence(appname, st, 0, false)
 
 				// Dimensions
 				Expect(s.dimensions.Cache.Size()).To(Equal(uint64(0)))

--- a/pkg/storage/storage_get.go
+++ b/pkg/storage/storage_get.go
@@ -91,7 +91,7 @@ func (s *Storage) GetContext(ctx context.Context, gi *GetInput) (*GetOutput, err
 				SampleRate: 100,
 				Tree:       tree.New(),
 			}
-			err := s.profiles.Fetch(ctx, gi.Query.AppName, ids, func(t *tree.Tree) error {
+			err := s.profiles.fetch(ctx, gi.Query.AppName, ids, func(t *tree.Tree) error {
 				o.Tree.Merge(t)
 				return nil
 			})

--- a/pkg/storage/storage_merge.go
+++ b/pkg/storage/storage_merge.go
@@ -7,8 +7,8 @@ import (
 )
 
 type MergeProfilesInput struct {
-	AppName   string
-	ProfileID []string
+	AppName  string
+	Profiles []string
 }
 
 type MergeProfilesOutput struct {
@@ -17,7 +17,7 @@ type MergeProfilesOutput struct {
 
 func (s *Storage) MergeProfiles(ctx context.Context, mi MergeProfilesInput) (o MergeProfilesOutput, err error) {
 	o.Tree = tree.New()
-	return o, s.profiles.fetch(ctx, mi.AppName, mi.ProfileID, func(t *tree.Tree) error {
+	return o, s.profiles.fetch(ctx, mi.AppName, mi.Profiles, func(t *tree.Tree) error {
 		o.Tree.Merge(t)
 		return nil
 	})

--- a/pkg/storage/storage_merge.go
+++ b/pkg/storage/storage_merge.go
@@ -17,7 +17,7 @@ type MergeProfilesOutput struct {
 
 func (s *Storage) MergeProfiles(ctx context.Context, mi MergeProfilesInput) (o MergeProfilesOutput, err error) {
 	o.Tree = tree.New()
-	return o, s.profiles.Fetch(ctx, mi.AppName, mi.ProfileID, func(t *tree.Tree) error {
+	return o, s.profiles.fetch(ctx, mi.AppName, mi.ProfileID, func(t *tree.Tree) error {
 		o.Tree.Merge(t)
 		return nil
 	})

--- a/pkg/storage/storage_merge.go
+++ b/pkg/storage/storage_merge.go
@@ -1,0 +1,24 @@
+package storage
+
+import (
+	"context"
+
+	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
+)
+
+type MergeProfilesInput struct {
+	AppName   string
+	ProfileID []string
+}
+
+type MergeProfilesOutput struct {
+	Tree *tree.Tree
+}
+
+func (s *Storage) MergeProfiles(ctx context.Context, mi MergeProfilesInput) (o MergeProfilesOutput, err error) {
+	o.Tree = tree.New()
+	return o, s.profiles.Fetch(ctx, mi.AppName, mi.ProfileID, func(t *tree.Tree) error {
+		o.Tree.Merge(t)
+		return nil
+	})
+}

--- a/pkg/storage/storage_put.go
+++ b/pkg/storage/storage_put.go
@@ -45,7 +45,7 @@ func (s *Storage) Put(pi *PutInput) error {
 	}).Debug("storage.Put")
 
 	if id, ok := pi.Key.ProfileID(); ok {
-		return s.profiles.Insert(pi.Key.AppName(), id, pi.Val, pi.EndTime)
+		return s.profiles.insert(pi.Key.AppName(), id, pi.Val, pi.EndTime)
 	}
 
 	for k, v := range pi.Key.Labels() {

--- a/pkg/storage/storage_put.go
+++ b/pkg/storage/storage_put.go
@@ -44,14 +44,8 @@ func (s *Storage) Put(pi *PutInput) error {
 		"aggregationType": pi.AggregationType,
 	}).Debug("storage.Put")
 
-	if pi.Key.HasProfileID() {
-		k := pi.Key.ProfileIDKey()
-		// Slightly racy, but OK for experiments.
-		if v, ok := s.trees.Lookup(k); ok {
-			pi.Val.Merge(v.(*tree.Tree))
-		}
-		s.trees.Put(k, pi.Val)
-		return nil
+	if id, ok := pi.Key.ProfileID(); ok {
+		return s.profiles.Insert(pi.Key.AppName(), id, pi.Val, pi.EndTime)
 	}
 
 	for k, v := range pi.Key.Labels() {


### PR DESCRIPTION
## Note that this is still an experimental feature and is not ready for general use.

The PR adds a dedicated storage for trace profiles with support for time-based retention policy. See the retention policy configuration docs to learn how to set the data retention period: https://pyroscope.io/docs/data-retention/#time-based-retention-policy.

The change is not backward compatible: trace profiles created by previous versions are not accessible in the new version and are not removed automatically. Prior to the change, we did not store time information for profiles, therefore they can't be migrated automatically, but you can remove the data via admin CLI (depending on the number of saved profiles, cleaning may take a long time - 15 minutes and more):
```
# pyroscope admin storage cleanup
```

---

We also extended the HTTP API with a new `/merge` endpoint:
```
# curl --header "Content-Type: application/json" \
  --request POST \
  --data '{"appName":"ride-sharing-app.cpu","profiles": ["e7a2b7876b66341a", "e5bc646093e173b9"]}' \
  http://localhost:4040/merge
```

The response carries `FlameBearer` JSON payload:
<details>
 <summary>Response</summary>

```json
{
  "version": 1,
  "flamebearer": {
    "names": [
      "total",
      "time.now",
      "net/http.(*conn).serve",
      "net/http.serverHandler.ServeHTTP",
      "net/http.(*ServeMux).ServeHTTP",
      "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*Handler).ServeHTTP",
      "net/http.HandlerFunc.ServeHTTP",
      "main.carRoute",
      "rideshare/car.OrderCar",
      "rideshare/ride.FindNearestVehicle",
      "rideshare/ride.checkDriverAvailability",
      "rideshare/ride.burnCPU",
      "time.Now"
    ],
    "levels": [
      [
        0,
        417,
        0,
        0
      ],
      [
        0,
        409,
        0,
        2,
        0,
        8,
        8,
        1
      ],
      [
        0,
        409,
        0,
        3
      ],
      [
        0,
        409,
        0,
        4
      ],
      [
        0,
        409,
        0,
        5
      ],
      [
        0,
        409,
        0,
        6
      ],
      [
        0,
        409,
        0,
        7
      ],
      [
        0,
        409,
        0,
        8
      ],
      [
        0,
        409,
        0,
        9
      ],
      [
        0,
        320,
        0,
        11,
        0,
        89,
        0,
        10
      ],
      [
        0,
        320,
        320,
        12,
        0,
        89,
        0,
        11
      ],
      [
        320,
        89,
        89,
        12
      ]
    ],
    "numTicks": 417,
    "maxSelf": 320
  },
  "metadata": {
    "format": "single",
    "spyName": "unknown",
    "sampleRate": 100,
    "units": "samples",
    "name": ""
  },
  "timeline": null
}
```
</details>