### PR TITLE
chore(flamegraph): remove models as a dependency

### DIFF
--- a/packages/pyroscope-flamegraph/package.json
+++ b/packages/pyroscope-flamegraph/package.json
@@ -21,8 +21,10 @@
   "peerDependencies": {
     "react": ">=16.14.0"
   },
+  "devDependencies": {
+    "@pyroscope/models": "^0.0.3"
+  },
   "dependencies": {
-    "@pyroscope/models": "^0.0.3",
     "true-myth": "^5.1.2"
   }
 }


### PR DESCRIPTION
Otherwise it fails with

```
$ yarn add -W @pyroscope/flamegraph
yarn add v1.22.17
[1/5] Validating package.json...
[2/5] Resolving packages...
warning Resolution field "browserslist@4.16.6" is incompatible with requested version "browserslist@4.14.2"
error Couldn't find package "@pyroscope/models@^0.0.3" required by "@pyroscope/flamegraph" on the "npm" registry.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```