### PR TITLE
feat(flamegraph): publish FlamegraphRenderer for nodejs

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlamegraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlamegraphRenderer.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore: Until we rewrite FlamegraphRenderer in typescript this will do
+import { Profile } from '@pyroscope/models';
+import FlameGraphRenderer from './FlameGraph/FlameGraphRenderer';
+
+const overrideProps = {
+  //  showPyroscopeLogo: !process.env.PYROSCOPE_HIDE_LOGO as any, // this is injected by webpack
+  showPyroscopeLogo: false,
+};
+
+export type FlamegraphRendererProps = {
+  profile: Profile;
+} & any;
+// TODO: type props
+export const FlamegraphRenderer = (props: FlamegraphRendererProps) => {
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  return <FlameGraphRenderer {...props} {...overrideProps} />;
+};

--- a/packages/pyroscope-flamegraph/src/FlamegraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlamegraphRenderer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { Profile } from '@pyroscope/models';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Until we rewrite FlamegraphRenderer in typescript this will do
-import { Profile } from '@pyroscope/models';
 import FlameGraphRenderer from './FlameGraph/FlameGraphRenderer';
 
 const overrideProps = {

--- a/packages/pyroscope-flamegraph/src/index.node.ts
+++ b/packages/pyroscope-flamegraph/src/index.node.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import Flamegraph from './FlameGraph/FlameGraphComponent/Flamegraph';
 import { DefaultPalette } from './FlameGraph/FlameGraphComponent/colorPalette';
+import { FlamegraphRenderer } from './FlamegraphRenderer';
 
-export { Flamegraph, DefaultPalette };
+export { Flamegraph, DefaultPalette, FlamegraphRenderer };

--- a/packages/pyroscope-flamegraph/src/index.tsx
+++ b/packages/pyroscope-flamegraph/src/index.tsx
@@ -1,19 +1,7 @@
 /* eslint-disable react/react-in-jsx-scope */
 /* eslint-disable react/jsx-props-no-spreading */
-import React from 'react';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore: Until we rewrite FlamegraphRenderer in typescript this will do
-import FlameGraphRenderer from './FlameGraph/FlameGraphRenderer';
+
 import Flamegraph from './FlameGraph/FlameGraphComponent/Flamegraph';
-
-const overrideProps = {
-  //  showPyroscopeLogo: !process.env.PYROSCOPE_HIDE_LOGO as any, // this is injected by webpack
-  showPyroscopeLogo: false,
-};
-
-// TODO: type props
-const FlamegraphRenderer = (props: any) => {
-  return <FlameGraphRenderer {...props} {...overrideProps} />;
-};
+import { FlamegraphRenderer } from './FlamegraphRenderer';
 
 export { FlamegraphRenderer, Flamegraph };

--- a/scripts/webpack/webpack.flamegraph.ts
+++ b/scripts/webpack/webpack.flamegraph.ts
@@ -81,6 +81,11 @@ export default [
       libraryTarget: 'commonjs',
       filename: 'index.node.js',
     },
+
+    externals: {
+      react: 'react',
+      reactDom: 'react-dom',
+    },
   },
   {
     ...common,


### PR DESCRIPTION
Since people may run the component in nodejs environments (think testing), they should be able to import the component.

It's not super simple to use outside the browser, but for testing we present a couple alternatives in the following example:
https://github.com/pyroscope-io/flamegraph-renderer-example