### PR TITLE
chore(flamegraph): disable sourcemap

### DIFF
--- a/scripts/webpack/webpack.flamegraph.ts
+++ b/scripts/webpack/webpack.flamegraph.ts
@@ -6,7 +6,12 @@ import { getAlias, getJsLoader, getStyleLoaders } from './shared';
 
 const common = {
   mode: 'production',
-  devtool: 'source-map',
+  // Had to disable sourcemaps due to it sometimes failing while building
+  // devtool: 'source-map',
+  // 33.29 ERROR in ../packages/pyroscope-flamegraph/dist/index.css (../node_modules/css-loader/dist/cjs.js!../packages/pyroscope-flamegraph/dist/index.css)
+  // 33.29 Module build failed (from ../node_modules/css-loader/dist/cjs.js):
+  // 33.29 SyntaxError: Unexpected token d in JSON at position 18904
+  // 33.29     at JSON.parse (<anonymous>)
 
   resolve: {
     extensions: ['.ts', '.tsx', '.es6', '.js', '.jsx', '.json', '.svg'],


### PR DESCRIPTION
I noticed the build is sometimes failing with the following error:

```
#55 33.29 $ yarn run clean && yarn run build:standalone && yarn run build:webapp
#55 33.29 $ rm -rf public/assets && rm -rf public/*.html
#55 33.29 $ webpack --config ../scripts/webpack/webpack.standalone.ts
#55 33.29 assets by status 1.07 MiB [cached] 3 assets
#55 33.29 Entrypoint app = app.d504bc01b763df4f5fb9.css 0 bytes app.js
#55 33.29 Entrypoint styles = styles.d504bc01b763df4f5fb9.css 0 bytes styles.js
#55 33.29 orphan modules 234 KiB (javascript) 2.75 KiB (runtime) [orphan] 30 modules
#55 33.29 runtime modules 663 bytes 3 modules
#55 33.29 cacheable modules 745 KiB (javascript) 76.1 KiB (css/mini-extract)
#55 33.29   modules by path ../ 740 KiB (javascript) 47.9 KiB (css/mini-extract)
#55 33.29     javascript modules 740 KiB 15 modules
#55 33.29     css modules 47.9 KiB
#55 33.29       modules by path ../node_modules/sanitize.css/*.css 3.57 KiB 3 modules
#55 33.29       modules by path ../node_modules/react-datepicker/dist/*.css 44.3 KiB 2 modules
#55 33.29   modules by path ./ 28.1 KiB (css/mini-extract) 5.23 KiB (javascript)
#55 33.29     css modules 28.1 KiB
#55 33.29       modules by path ./javascript/ 284 bytes 2 modules
#55 33.29       modules by path ./sass/ 27.9 KiB 2 modules
#55 33.29     javascript modules 5.23 KiB
#55 33.29       ./javascript/standalone.tsx + 6 modules 5.18 KiB [built] [code generated]
#55 33.29       ./sass/standalone.scss 50 bytes [built] [code generated]
#55 33.29 
#55 33.29 ERROR in ../packages/pyroscope-flamegraph/dist/index.css (../node_modules/css-loader/dist/cjs.js!../packages/pyroscope-flamegraph/dist/index.css)
#55 33.29 Module build failed (from ../node_modules/css-loader/dist/cjs.js):
#55 33.29 SyntaxError: Unexpected token d in JSON at position 18904
#55 33.29     at JSON.parse (<anonymous>)
#55 33.29     at Object.parseSourceMapInput (/opt/pyroscope/node_modules/source-map/lib/util.js:433:15)
#55 33.29     at new SourceMapConsumer (/opt/pyroscope/node_modules/source-map/lib/source-map-consumer.js:17:22)
#55 33.29     at PreviousMap.consumer (/opt/pyroscope/node_modules/css-loader/node_modules/postcss/lib/previous-map.es6:54:28)
#55 33.29     at new Input (/opt/pyroscope/node_modules/css-loader/node_modules/postcss/lib/input.es6:77:22)
#55 33.29     at parser (/opt/pyroscope/node_modules/css-loader/node_modules/postcss/lib/parse.es6:5:15)
#55 33.29     at new LazyResult (/opt/pyroscope/node_modules/css-loader/node_modules/postcss/lib/lazy-result.es6:41:16)
#55 33.29     at Processor.<anonymous> (/opt/pyroscope/node_modules/css-loader/node_modules/postcss/lib/processor.es6:109:12)
#55 33.29     at Processor.process (/opt/pyroscope/node_modules/css-loader/node_modules/postcss/lib/processor.js:121:23)
#55 33.29     at Object.loader (/opt/pyroscope/node_modules/css-loader/dist/index.js:140:51)
#55 33.29  @ ../packages/pyroscope-flamegraph/dist/index.css 8:6-105 22:17-24 26:0-75 26:0-75 27:22-29 27:33-47 27:50-64
#55 33.29  @ ./javascript/standalone.tsx 6:0-46
#55 33.29 
#55 33.29 webpack 5.69.1 compiled with 1 error in 12541 ms
#55 33.29 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
#55 33.29 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
#55 33.29 lerna ERR! yarn run build stderr:
#55 33.29 (node:175) [DEP_WEBPACK_TEMPLATE_PATH_PLUGIN_REPLACE_PATH_VARIABLES_HASH] DeprecationWarning: [hash] is now [fullhash] (also consider using [chunkhash] or [contenthash], see documentation for details)
#55 33.29 (Use `node --trace-deprecation ...` to show where the warning was created)
#55 33.29 error Command failed with exit code 1.
#55 33.29 error Command failed with exit code 1.
#55 33.29 lerna ERR! yarn run build exited 1 in '@pyroscope/webapp'
#55 33.30 error Command failed with exit code 1.
#55 33.30 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
#55 33.33 error Command failed with exit code 1.
#55 33.33 info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
#55 33.34 make: *** [Makefile:177: assets-release] Error 1
#55 ERROR: executor failed running [/bin/sh -c EXTRA_METADATA=$EXTRA_METADATA make assets-release]: exit code: 2
```

Which I could not reproduce.

So let's try disabling sourcemap for now.