### PR TITLE
feat(ingestion): initial support for JFR format ingestion.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/pyroscope-io/client v0.0.0-20211206204731-3fd0a4b8239c
 	github.com/pyroscope-io/dotnetdiag v1.2.1
 	github.com/pyroscope-io/goldga v0.4.2-0.20220218190441-817afcc3a7f1
+	github.com/pyroscope-io/jfr-parser v0.1.0
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rlmcpherson/s3gof3r v0.5.0
 	github.com/shirou/gopsutil v3.21.4+incompatible

--- a/go.sum
+++ b/go.sum
@@ -618,6 +618,8 @@ github.com/pyroscope-io/dotnetdiag v1.2.1 h1:3XEMrfFJnZ87BiEhozyQKmCUAuMd/Spq7KC
 github.com/pyroscope-io/dotnetdiag v1.2.1/go.mod h1:eFUEHCp4eD1TgcXMlJihC+R4MrqGf7nTRdWxNADbDHA=
 github.com/pyroscope-io/goldga v0.4.2-0.20220218190441-817afcc3a7f1 h1:T1fDdt3E3UpaGZ7tRF2IYrUFwNyuPlIWGeCOjfINp1s=
 github.com/pyroscope-io/goldga v0.4.2-0.20220218190441-817afcc3a7f1/go.mod h1:PbX5bxlj/WxyKIEAxYgNMNWUpXP4rt9GqtjfvTf8m+I=
+github.com/pyroscope-io/jfr-parser v0.1.0 h1:MUKc4jUBlKC2Cd4+aZiPbL9YJIhfR6vNE/LSaYv2uqg=
+github.com/pyroscope-io/jfr-parser v0.1.0/go.mod h1:ZMcbJjfDkOwElEK8CvUJbpetztRWRXszCmf5WU0erV8=
 github.com/pyroscope-io/revive v1.0.6-0.20210330033039-4a71146f9dc1 h1:0v9lBNgdmVtpyyk9PP/DfpJlOHkXriu5YgNlrhQw5YE=
 github.com/pyroscope-io/revive v1.0.6-0.20210330033039-4a71146f9dc1/go.mod h1:tSw34BaGZ0iF+oVKDOjq1/LuxGifgW7shaJ6+dBYFXg=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=

--- a/pkg/convert/jfr/parser.go
+++ b/pkg/convert/jfr/parser.go
@@ -1,4 +1,4 @@
-package convert
+package jfr
 
 import (
 	"fmt"

--- a/pkg/convert/jfr_parser.go
+++ b/pkg/convert/jfr_parser.go
@@ -1,0 +1,53 @@
+package convert
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pyroscope-io/jfr-parser/parser"
+
+	"github.com/pyroscope-io/pyroscope/pkg/storage"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/segment"
+)
+
+func ParseJFR(r io.Reader, cb func(name []byte, val int), pi *storage.PutInput) error {
+	// Only execution sample events are supported for now.
+	chunks, err := parser.Parse(r)
+	if err != nil {
+		return fmt.Errorf("unable to parse JFR format: %w", err)
+	}
+	event := "cpu"
+	for _, c := range chunks {
+		// TODO(abeaumont): support multiple chunks
+		for _, e := range c.Events {
+			switch e.(type) {
+			case *parser.ExecutionSample:
+				es := e.(*parser.ExecutionSample)
+				if es.StackTrace != nil {
+					frames := make([]string, 0, len(es.StackTrace.Frames))
+					for i := len(es.StackTrace.Frames) - 1; i >= 0; i-- {
+						f := es.StackTrace.Frames[i]
+						// TODO(abeaumont): Add support for line numbers.
+						if f.Method != nil && f.Method.Type != nil && f.Method.Type.Name != nil && f.Method.Name != nil {
+							frames = append(frames, f.Method.Type.Name.String+"."+f.Method.Name.String)
+						}
+					}
+					if len(frames) > 0 {
+						cb([]byte(strings.Join(frames, ";")), 1)
+					}
+				}
+			case *parser.ActiveSetting:
+				as := e.(*parser.ActiveSetting)
+				fmt.Println(as.Name, as.Value)
+				if as.Name == "event" {
+					event = as.Value
+				}
+			}
+		}
+		labels := pi.Key.Labels()
+		labels["__name__"] += "." + event
+		pi.Key = segment.NewKey(labels)
+	}
+	return nil
+}

--- a/pkg/convert/jfr_parser.go
+++ b/pkg/convert/jfr_parser.go
@@ -39,7 +39,6 @@ func ParseJFR(r io.Reader, cb func(name []byte, val int), pi *storage.PutInput) 
 				}
 			case *parser.ActiveSetting:
 				as := e.(*parser.ActiveSetting)
-				fmt.Println(as.Name, as.Value)
 				if as.Name == "event" {
 					event = as.Value
 				}

--- a/pkg/server/ingest.go
+++ b/pkg/server/ingest.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pyroscope-io/pyroscope/pkg/agent/types"
 	"github.com/pyroscope-io/pyroscope/pkg/convert"
+	"github.com/pyroscope-io/pyroscope/pkg/convert/jfr"
 	"github.com/pyroscope-io/pyroscope/pkg/convert/pprof"
 	"github.com/pyroscope-io/pyroscope/pkg/storage"
 	"github.com/pyroscope-io/pyroscope/pkg/storage/segment"
@@ -59,7 +60,7 @@ func (h ingestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case format == "lines":
 		err = convert.ParseIndividualLines(r.Body, cb)
 	case format == "jfr":
-		err = convert.ParseJFR(r.Body, cb, pi)
+		err = jfr.ParseJFR(r.Body, cb, pi)
 	case strings.Contains(contentType, "multipart/form-data"):
 		err = writePprof(h.storage, pi, r)
 	default:

--- a/pkg/server/ingest.go
+++ b/pkg/server/ingest.go
@@ -58,6 +58,8 @@ func (h ingestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		err = convert.ParseTreeNoDict(r.Body, cb)
 	case format == "lines":
 		err = convert.ParseIndividualLines(r.Body, cb)
+	case format == "jfr":
+		err = convert.ParseJFR(r.Body, cb, pi)
 	case strings.Contains(contentType, "multipart/form-data"):
 		err = writePprof(h.storage, pi, r)
 	default:


### PR DESCRIPTION
Java Flight Recorder format is a binary format integrated into Java
and used by AsyncProfiler, which is the native profiler used for our
Java integration.

It's the only AsyncProfiler format that supports profiling multiple
events concurrently and, in order to support this, we have created a
JFR parser.

This is a first iteration towards full, multi-event JFR ingestion
support. In this initial work, only CPU events (cpu, itimer, wall) are
supported. Support for other events should come later.