### PR TITLE
fix: allow cache eviction while purging storage

### DIFF
--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -120,7 +120,7 @@ func (s *Storage) newBadger(name string, p prefix, codec cache.Codec) (d *db, er
 		})
 	}
 
-	s.maintenanceTask(s.badgerGCTaskInterval, func() {
+	s.periodicTask(s.badgerGCTaskInterval, func() {
 		diff := calculateDBSize(badgerPath) - d.lastGC
 		if d.lastGC == 0 || s.gcSizeDiff == 0 || diff > s.gcSizeDiff {
 			d.runGC(0.7)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -40,13 +40,8 @@ type Storage struct {
 
 	hc *health.Controller
 
-	// Maintenance tasks are executed exclusively to avoid competition:
-	// extensive writing during GC is harmful and deteriorates the
-	// overall performance. Same for write back, eviction, and retention
-	// tasks.
-	tasksMutex sync.Mutex
-	tasksWG    sync.WaitGroup
-	stop       chan struct{}
+	tasksWG sync.WaitGroup
+	stop    chan struct{}
 
 	queueWorkersWG sync.WaitGroup
 	queue          chan *PutInput
@@ -146,7 +141,7 @@ func New(c *Config, logger *logrus.Logger, reg prometheus.Registerer, hc *health
 		return nil, err
 	}
 
-	s.maintenanceTask(s.writeBackTaskInterval, s.writeBackTask)
+	s.periodicTask(s.writeBackTaskInterval, s.writeBackTask)
 	s.startQueueWorkers()
 
 	if !s.config.inMemory {
@@ -156,8 +151,8 @@ func New(c *Config, logger *logrus.Logger, reg prometheus.Registerer, hc *health
 			return nil, err
 		}
 
-		s.maintenanceTask(s.evictionTaskInterval, s.evictionTask(memTotal))
-		s.maintenanceTask(s.retentionTaskInterval, s.retentionTask)
+		s.periodicTask(s.evictionTaskInterval, s.evictionTask(memTotal))
+		s.periodicTask(s.retentionTaskInterval, s.retentionTask)
 		s.periodicTask(s.metricsUpdateTaskInterval, s.updateMetricsTask)
 	}
 
@@ -211,15 +206,6 @@ func (s *Storage) goDB(f func(*db)) {
 		}(d)
 	}
 	wg.Wait()
-}
-
-// maintenanceTask periodically runs f exclusively.
-func (s *Storage) maintenanceTask(interval time.Duration, f func()) {
-	s.periodicTask(interval, func() {
-		s.tasksMutex.Lock()
-		defer s.tasksMutex.Unlock()
-		f()
-	})
 }
 
 func (s *Storage) periodicTask(interval time.Duration, f func()) {


### PR DESCRIPTION
When a retention policy is enforced for the first time and the dataset is big, pyroscope server can go OOM because cache eviction is blocked during deleting old data.