### PR TITLE
chore: add baseline profile examples

### DIFF
--- a/examples/tracing/honeycomb/go.mod
+++ b/examples/tracing/honeycomb/go.mod
@@ -4,12 +4,14 @@ go 1.17
 
 require (
 	github.com/pyroscope-io/client v0.2.0
-	github.com/pyroscope-io/otelpyroscope v0.1.0
+	github.com/pyroscope-io/otelpyroscope v0.1.1-0.20220323012158-956214c9e344
+	github.com/sirupsen/logrus v1.8.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.28.0
 	go.opentelemetry.io/otel v1.4.1
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.3.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.3.0
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.3.0
 	go.opentelemetry.io/otel/sdk v1.3.0
+	go.opentelemetry.io/otel/trace v1.4.1
 	google.golang.org/grpc v1.43.0
 )

--- a/examples/tracing/honeycomb/go.sum
+++ b/examples/tracing/honeycomb/go.sum
@@ -13,8 +13,9 @@ github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XP
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -67,10 +68,15 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/pyroscope-io/client v0.2.0 h1:zZnwMFv+EHA1Yz5fUveJ4KCdRsCmsVuyfzFIKi6SlDg=
 github.com/pyroscope-io/client v0.2.0/go.mod h1:zRdQXIGxy0H2QbKEkCmZBR6KOLLIFYLWsdzVI0MRm2E=
-github.com/pyroscope-io/otelpyroscope v0.1.0 h1:LDRYGrFhQUZT7rbJ1PCMOL0TGjNk/SNJbh3Ri7l8OFg=
-github.com/pyroscope-io/otelpyroscope v0.1.0/go.mod h1:Pjgu/PeVua81wS40W4sJ7GaS2mjGUZ7bhUAA1X+8lZ8=
+github.com/pyroscope-io/otelpyroscope v0.1.1-0.20220323004007-dcbd45cd4ab8 h1:Xp1eCF+RrywAkklEBBHFvHqy8rzrwIQdRRbRZbeMIhg=
+github.com/pyroscope-io/otelpyroscope v0.1.1-0.20220323004007-dcbd45cd4ab8/go.mod h1:Pjgu/PeVua81wS40W4sJ7GaS2mjGUZ7bhUAA1X+8lZ8=
+github.com/pyroscope-io/otelpyroscope v0.1.1-0.20220323012158-956214c9e344 h1:UWvDlQXYc7EqKC6kzumNVV5/ZzCjr1vJQgwCJMwG4x4=
+github.com/pyroscope-io/otelpyroscope v0.1.1-0.20220323012158-956214c9e344/go.mod h1:Pjgu/PeVua81wS40W4sJ7GaS2mjGUZ7bhUAA1X+8lZ8=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -131,6 +137,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/examples/tracing/honeycomb/log/log.go
+++ b/examples/tracing/honeycomb/log/log.go
@@ -1,0 +1,19 @@
+package log
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func Logger(ctx context.Context) logrus.FieldLogger {
+	logger := logrus.New()
+	if spanCtx := trace.SpanContextFromContext(ctx); spanCtx.IsValid() {
+		return logger.WithFields(logrus.Fields{
+			"trace_id": spanCtx.TraceID().String(),
+			"span_id":  spanCtx.SpanID().String(),
+		})
+	}
+	return logger
+}

--- a/examples/tracing/honeycomb/ride/ride.go
+++ b/examples/tracing/honeycomb/ride/ride.go
@@ -5,14 +5,24 @@ import (
 	"os"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+
+	"rideshare/log"
 )
 
 func FindNearestVehicle(ctx context.Context, searchRadius int64, vehicle string) {
 	ctx, span := otel.GetTracerProvider().Tracer("").Start(ctx, "FindNearestVehicle")
 	span.SetAttributes(attribute.String("vehicle", vehicle))
 	defer span.End()
+
+	logger := log.Logger(ctx).WithFields(logrus.Fields{
+		"radius":  searchRadius,
+		"vehicle": vehicle,
+	})
+
+	logger.Info("looking for nearest vehicle")
 	burnCPU(searchRadius)
 	if vehicle == "car" {
 		checkDriverAvailability(ctx, searchRadius)
@@ -22,19 +32,27 @@ func FindNearestVehicle(ctx context.Context, searchRadius int64, vehicle string)
 func checkDriverAvailability(ctx context.Context, n int64) {
 	ctx, span := otel.GetTracerProvider().Tracer("").Start(ctx, "CheckDriverAvailability")
 	defer span.End()
+
+	region := os.Getenv("REGION")
+	logger := log.Logger(ctx).WithField("region", region)
+	logger.Info("checking for driver availability")
+
 	burnCPU(n / 2)
 	// Every 4 minutes this will artificially make requests in us-west-1 region slow
 	// this is just for demonstration purposes to show how performance impacts show
 	// up in the flamegraph.
-	if os.Getenv("REGION") == "us-west-1" && time.Now().Minute()*4%8 == 0 {
-		burnCPU(n * 10)
+	if region == "us-west-1" && time.Now().Minute()*4%8 == 0 {
+		burnCPU(n * 2)
 	}
+
+	logger.Info("vehicle found")
 }
 
 func burnCPU(n int64) {
-	var i int64 = 0
-	st := time.Now().Unix()
-	for (time.Now().Unix() - st) < n {
-		i++
+	var v int
+	for i := int64(0); i < n*2; i++ {
+		for j := 0; j < 1<<30; j++ {
+			v++
+		}
 	}
 }

--- a/examples/tracing/honeycomb/rideshare/rideshare.go
+++ b/examples/tracing/honeycomb/rideshare/rideshare.go
@@ -26,6 +26,7 @@ type Config struct {
 	HoneycombDataset       string
 	HoneycombAPIKey        string
 	UseDebugTracer         bool
+	Tags                   map[string]string
 }
 
 func ReadConfig() Config {
@@ -35,6 +36,9 @@ func ReadConfig() Config {
 		HoneycombDataset:       os.Getenv("HONEYCOMB_DATASET"),
 		HoneycombAPIKey:        os.Getenv("HONEYCOMB_API_KEY"),
 		UseDebugTracer:         os.Getenv("DEBUG_TRACER") == "1",
+		Tags: map[string]string{
+			"region": os.Getenv("REGION"),
+		},
 	}
 
 	if !c.UseDebugTracer {
@@ -86,8 +90,13 @@ func TracerProvider(c Config) (tp *sdktrace.TracerProvider, err error) {
 	// We wrap the tracer provider to also annotate goroutines with Span ID so
 	// that pprof would add corresponding labels to profiling samples.
 	otel.SetTracerProvider(otelpyroscope.NewTracerProvider(tp,
-		otelpyroscope.WithDefaultProfileURLBuilder(c.PyroscopeProfileURL, c.AppName),
+		otelpyroscope.WithAppName(c.AppName),
 		otelpyroscope.WithRootSpanOnly(true),
+		otelpyroscope.WithAddSpanName(true),
+		otelpyroscope.WithPyroscopeURL(c.PyroscopeProfileURL),
+		otelpyroscope.WithProfileBaselineLabels(c.Tags),
+		otelpyroscope.WithProfileBaselineURL(true),
+		otelpyroscope.WithProfileURL(true),
 	))
 
 	// Register the trace context and baggage propagators so data is propagated across services/processes.
@@ -104,9 +113,7 @@ func Profiler(c Config) (*pyroscope.Profiler, error) {
 		ApplicationName: c.AppName,
 		ServerAddress:   c.PyroscopeServerAddress,
 		Logger:          pyroscope.StandardLogger,
-		// In this scenario, labels should be set at tracing level:
-		// Pyroscope won't store the labels other than profile_id.
-		// Tags: map[string]string{"region": os.Getenv("REGION")},
+		Tags:            c.Tags,
 	})
 }
 

--- a/examples/tracing/jaeger/go.mod
+++ b/examples/tracing/jaeger/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/pyroscope-io/client v0.2.0
-	github.com/pyroscope-io/otelpyroscope v0.1.0
+	github.com/pyroscope-io/otelpyroscope v0.1.1-0.20220323012158-956214c9e344
 	github.com/sirupsen/logrus v1.8.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.28.0
 	go.opentelemetry.io/otel v1.4.1

--- a/examples/tracing/jaeger/go.sum
+++ b/examples/tracing/jaeger/go.sum
@@ -19,6 +19,10 @@ github.com/pyroscope-io/client v0.2.0 h1:zZnwMFv+EHA1Yz5fUveJ4KCdRsCmsVuyfzFIKi6
 github.com/pyroscope-io/client v0.2.0/go.mod h1:zRdQXIGxy0H2QbKEkCmZBR6KOLLIFYLWsdzVI0MRm2E=
 github.com/pyroscope-io/otelpyroscope v0.1.0 h1:LDRYGrFhQUZT7rbJ1PCMOL0TGjNk/SNJbh3Ri7l8OFg=
 github.com/pyroscope-io/otelpyroscope v0.1.0/go.mod h1:Pjgu/PeVua81wS40W4sJ7GaS2mjGUZ7bhUAA1X+8lZ8=
+github.com/pyroscope-io/otelpyroscope v0.1.1-0.20220323004007-dcbd45cd4ab8 h1:Xp1eCF+RrywAkklEBBHFvHqy8rzrwIQdRRbRZbeMIhg=
+github.com/pyroscope-io/otelpyroscope v0.1.1-0.20220323004007-dcbd45cd4ab8/go.mod h1:Pjgu/PeVua81wS40W4sJ7GaS2mjGUZ7bhUAA1X+8lZ8=
+github.com/pyroscope-io/otelpyroscope v0.1.1-0.20220323012158-956214c9e344 h1:UWvDlQXYc7EqKC6kzumNVV5/ZzCjr1vJQgwCJMwG4x4=
+github.com/pyroscope-io/otelpyroscope v0.1.1-0.20220323012158-956214c9e344/go.mod h1:Pjgu/PeVua81wS40W4sJ7GaS2mjGUZ7bhUAA1X+8lZ8=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=

--- a/examples/tracing/jaeger/ride/ride.go
+++ b/examples/tracing/jaeger/ride/ride.go
@@ -42,16 +42,17 @@ func checkDriverAvailability(ctx context.Context, n int64) {
 	// this is just for demonstration purposes to show how performance impacts show
 	// up in the flamegraph.
 	if region == "us-west-1" && time.Now().Minute()*4%8 == 0 {
-		burnCPU(n * 10)
+		burnCPU(n * 2)
 	}
 
 	logger.Info("vehicle found")
 }
 
 func burnCPU(n int64) {
-	var i int64 = 0
-	st := time.Now().Unix()
-	for (time.Now().Unix() - st) < n {
-		i++
+	var v int
+	for i := int64(0); i < n*2; i++ {
+		for j := 0; j < 1<<30; j++ {
+			v++
+		}
 	}
 }

--- a/pkg/storage/profile.go
+++ b/pkg/storage/profile.go
@@ -83,11 +83,14 @@ func (s profiles) insert(appName, profileID string, v *tree.Tree, at time.Time) 
 			return err
 		case errors.Is(err, badger.ErrKeyNotFound):
 		case err == nil:
-			return item.Value(valueReader(dx, func(t *tree.Tree) error {
+			err = item.Value(valueReader(dx, func(t *tree.Tree) error {
 				t.Merge(v)
 				v = t
 				return nil
 			}))
+			if err != nil {
+				return err
+			}
 		}
 
 		if err = b.WriteByte(profilesFormatV1); err != nil {

--- a/pkg/storage/profile_test.go
+++ b/pkg/storage/profile_test.go
@@ -45,6 +45,13 @@ var _ = Describe("MergeProfiles", func() {
 					Val:       tree,
 				})).ToNot(HaveOccurred())
 
+				Expect(s.Put(&PutInput{
+					StartTime: st,
+					EndTime:   et,
+					Key:       k1,
+					Val:       tree,
+				})).ToNot(HaveOccurred())
+
 				k2, _ := segment.ParseKey("app.cpu{profile_id=b}")
 				Expect(s.Put(&PutInput{
 					StartTime: st,
@@ -59,7 +66,7 @@ var _ = Describe("MergeProfiles", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(o.Tree).ToNot(BeNil())
-				Expect(o.Tree.Samples()).To(Equal(uint64(3)))
+				Expect(o.Tree.Samples()).To(Equal(uint64(6)))
 
 				o, err = s.MergeProfiles(context.Background(), MergeProfilesInput{
 					AppName:  "app.cpu",
@@ -67,7 +74,7 @@ var _ = Describe("MergeProfiles", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(o.Tree).ToNot(BeNil())
-				Expect(o.Tree.Samples()).To(Equal(uint64(6)))
+				Expect(o.Tree.Samples()).To(Equal(uint64(9)))
 			})
 		})
 	})

--- a/pkg/storage/storage_get.go
+++ b/pkg/storage/storage_get.go
@@ -86,7 +86,7 @@ func (s *Storage) GetContext(ctx context.Context, gi *GetInput) (*GetOutput, err
 		}
 		if len(ids) > 0 {
 			o := GetOutput{
-				SpyName:    "unknown",
+				SpyName:    "gospy",
 				Units:      "samples",
 				SampleRate: 100,
 				Tree:       tree.New(),

--- a/pkg/storage/tree/profile_extra.go
+++ b/pkg/storage/tree/profile_extra.go
@@ -179,9 +179,14 @@ func (x *Profile) ResolveSampleType(v int64) (*ValueType, bool) {
 
 type Labels []*Label
 
+func (l Labels) Len() int           { return len(l) }
+func (l Labels) Less(i, j int) bool { return l[i].Key < l[j].Key }
+func (l Labels) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+
 func (l Labels) Hash() uint64 {
 	h := xxhash.New()
 	t := make([]byte, 16)
+	sort.Sort(l)
 	for _, x := range l {
 		if x.Str == 0 {
 			continue


### PR DESCRIPTION
The PR adds examples of tracing integration with support for baseline profiles.

Depends on https://github.com/pyroscope-io/otelpyroscope/pull/1 - otelpyroscope is referenced by the commit hash. Must be updated before merge. Until the release of the server, you can use the dev build for docker-compose:
```
PYROSCOPE_IMAGE=pyroscope/pyroscope-dev:git-111d45ec49ca9fbe00dfec7ee015e586783c9bd1
```
