### PR TITLE
fix(pull-mode): makes it so that memory profiles in pull mode report an average instead of sum

### DIFF
--- a/pkg/convert/pprof/pprof_test.go
+++ b/pkg/convert/pprof/pprof_test.go
@@ -103,11 +103,11 @@ var _ = Describe("custom pprof parsing", func() {
 		w := NewProfileWriter(ingester, labels, map[string]*tree.SampleTypeConfig{
 			"objects": {
 				Units:       "objects",
-				Aggregation: "avg",
+				Aggregation: "average",
 			},
 			"space": {
 				Units:       "bytes",
-				Aggregation: "avg",
+				Aggregation: "average",
 			},
 		})
 

--- a/pkg/scrape/config/config.go
+++ b/pkg/scrape/config/config.go
@@ -58,7 +58,7 @@ func DefaultConfig() *Config {
 				SampleTypes: map[string]*profile.SampleTypeConfig{
 					"inuse_objects": {
 						Units:       "objects",
-						Aggregation: "avg",
+						Aggregation: "average",
 					},
 					"alloc_objects": {
 						Units:      "objects",
@@ -66,7 +66,7 @@ func DefaultConfig() *Config {
 					},
 					"inuse_space": {
 						Units:       "bytes",
-						Aggregation: "avg",
+						Aggregation: "average",
 					},
 					"alloc_space": {
 						Units:      "bytes",

--- a/pkg/storage/storage_get.go
+++ b/pkg/storage/storage_get.go
@@ -118,7 +118,8 @@ func (s *Storage) Get(ctx context.Context, gi *GetInput) (*GetOutput, error) {
 		}
 
 		st := res.(*segment.Segment)
-		if st.AggregationType() == averageAggregationType {
+		switch st.AggregationType() {
+		case averageAggregationType, "avg":
 			aggregationType = averageAggregationType
 		}
 

--- a/pkg/storage/tree/pprof.go
+++ b/pkg/storage/tree/pprof.go
@@ -20,7 +20,7 @@ var DefaultSampleTypeMapping = map[string]*SampleTypeConfig{
 	},
 	"inuse_objects": {
 		Units:       "objects",
-		Aggregation: "avg",
+		Aggregation: "average",
 	},
 	"alloc_objects": {
 		Units:      "objects",
@@ -28,7 +28,7 @@ var DefaultSampleTypeMapping = map[string]*SampleTypeConfig{
 	},
 	"inuse_space": {
 		Units:       "bytes",
-		Aggregation: "avg",
+		Aggregation: "average",
 	},
 	"alloc_space": {
 		Units:      "bytes",


### PR DESCRIPTION
In pull mode, the aggregation type is always `sum` because of the incorrect default configuration. This means that profiles that imply `average` value (for example, Go `inuse_objects` and `inuse_space`) report wrong data.

The PR fixes the default configuration and makes it so that already deployed configurations will also be handled properly.