### PR TITLE
fix(server): always returns timeline even if there's not data

### DIFF
--- a/pkg/server/render.go
+++ b/pkg/server/render.go
@@ -96,9 +96,11 @@ func (rh *RenderHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		WriteInternalServerError(rh.log, w, err, "failed to retrieve data")
 		return
 	}
-	// TODO: handle properly
 	if out == nil {
-		out = &storage.GetOutput{Tree: tree.New()}
+		out = &storage.GetOutput{
+			Tree:     tree.New(),
+			Timeline: segment.GenerateTimeline(p.gi.StartTime, p.gi.EndTime),
+		}
 	}
 
 	switch p.format {


### PR DESCRIPTION
See my comment [here](https://github.com/pyroscope-io/pyroscope/pull/1004#issuecomment-1092346973) for more context.

I intentionally added it to the controller (presentation layer), and not storage, because there's value in distinguishing between outputs like:
* successful reads, `out != nil`
* no data reads, `out == nil`

