### PR TITLE
chore(webapp): don't serialize errors

### DIFF
--- a/webapp/javascript/redux/async-thunk.ts
+++ b/webapp/javascript/redux/async-thunk.ts
@@ -1,0 +1,23 @@
+import {
+  createAsyncThunk as libCreateAsyncThunk,
+  AsyncThunkPayloadCreator,
+  AsyncThunk,
+  SerializedError,
+} from '@reduxjs/toolkit';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface ThunkAPIConfig {}
+
+// https://github.com/reduxjs/redux-toolkit/issues/486
+// eslint-disable-next-line import/prefer-default-export
+export const createAsyncThunk = <Returned, ThunkArg = any>(
+  type: string,
+  thunk: AsyncThunkPayloadCreator<Returned, ThunkArg>
+): AsyncThunk<Returned, ThunkArg, ThunkAPIConfig> => {
+  return libCreateAsyncThunk<Returned, ThunkArg, ThunkAPIConfig>(type, thunk, {
+    // Return the error as is (without)
+    // So that the components can use features like instanceof, and accessing other fields that would otherwise be ignored
+    // https://github.com/reduxjs/redux-toolkit/blob/db0d7dc20939b62f8c59631cc030575b78642296/packages/toolkit/src/createAsyncThunk.ts#L94
+    serializeError: (x) => x as SerializedError,
+  });
+};

--- a/webapp/javascript/redux/async-thunk.ts
+++ b/webapp/javascript/redux/async-thunk.ts
@@ -1,20 +1,17 @@
+/* eslint-disable import/prefer-default-export */
 import {
   createAsyncThunk as libCreateAsyncThunk,
-  AsyncThunkPayloadCreator,
-  AsyncThunk,
   SerializedError,
 } from '@reduxjs/toolkit';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface ThunkAPIConfig {}
-
-// https://github.com/reduxjs/redux-toolkit/issues/486
-// eslint-disable-next-line import/prefer-default-export
-export const createAsyncThunk = <Returned, ThunkArg = any>(
-  type: string,
-  thunk: AsyncThunkPayloadCreator<Returned, ThunkArg>
-): AsyncThunk<Returned, ThunkArg, ThunkAPIConfig> => {
-  return libCreateAsyncThunk<Returned, ThunkArg, ThunkAPIConfig>(type, thunk, {
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+export const createAsyncThunk: typeof libCreateAsyncThunk = (
+  ...args: Parameters<typeof libCreateAsyncThunk>
+) => {
+  const [typePrefix, payloadCreator, options] = args;
+  return libCreateAsyncThunk(typePrefix, payloadCreator, {
+    ...options,
     // Return the error as is (without)
     // So that the components can use features like instanceof, and accessing other fields that would otherwise be ignored
     // https://github.com/reduxjs/redux-toolkit/blob/db0d7dc20939b62f8c59631cc030575b78642296/packages/toolkit/src/createAsyncThunk.ts#L94

--- a/webapp/javascript/redux/reducers/continuous.ts
+++ b/webapp/javascript/redux/reducers/continuous.ts
@@ -1,5 +1,5 @@
 import { Profile } from '@pyroscope/models';
-import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { AppNames } from '@webapp/models/appNames';
 import { Query, brandQuery, queryToAppName } from '@webapp/models/query';
 import { fetchAppNames } from '@webapp/services/appNames';
@@ -13,6 +13,7 @@ import { Timeline } from '@webapp/models/timeline';
 import * as tagsService from '@webapp/services/tags';
 import type { RootState } from '../store';
 import { addNotification } from './notifications';
+import { createAsyncThunk } from '../async-thunk';
 
 type SingleView =
   | { type: 'pristine'; profile?: Profile }

--- a/webapp/javascript/redux/reducers/notifications.ts
+++ b/webapp/javascript/redux/reducers/notifications.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
-import { createAsyncThunk } from '@reduxjs/toolkit';
 import { store } from '@webapp/ui/Notifications';
 import type { NotificationOptions } from '@webapp/ui/Notifications';
+import { createAsyncThunk } from '../async-thunk';
 
 export const addNotification = createAsyncThunk(
   'notifications/add',

--- a/webapp/javascript/redux/reducers/serviceDiscovery.ts
+++ b/webapp/javascript/redux/reducers/serviceDiscovery.ts
@@ -1,8 +1,9 @@
 import { Target } from '@webapp/models/targets';
 import { fetchTargets } from '@webapp/services/serviceDiscovery';
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 import { addNotification } from './notifications';
 import type { RootState } from '../store';
+import { createAsyncThunk } from '../async-thunk';
 
 export const loadTargets = createAsyncThunk(
   'serviceDiscovery/loadTargets',

--- a/webapp/javascript/redux/reducers/settings.ts
+++ b/webapp/javascript/redux/reducers/settings.ts
@@ -1,8 +1,4 @@
-import {
-  createSlice,
-  createAsyncThunk,
-  combineReducers,
-} from '@reduxjs/toolkit';
+import { createSlice, combineReducers } from '@reduxjs/toolkit';
 import { Users, type User } from '@webapp/models/users';
 import { APIKey, APIKeys } from '@webapp/models/apikeys';
 
@@ -21,6 +17,7 @@ import {
 } from '@webapp/services/apiKeys';
 import type { RootState } from '../store';
 import { addNotification } from './notifications';
+import { createAsyncThunk } from '../async-thunk';
 
 type UsersState = {
   type: 'pristine' | 'loading' | 'loaded' | 'failed';

--- a/webapp/javascript/redux/reducers/user.ts
+++ b/webapp/javascript/redux/reducers/user.ts
@@ -1,6 +1,6 @@
 /* eslint-disable prettier/prettier */
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
-import { Users, type User } from '@webapp/models/users';
+import { createSlice } from '@reduxjs/toolkit';
+import { type User } from '@webapp/models/users';
 import { connect } from 'react-redux';
 
 import {
@@ -10,6 +10,7 @@ import {
 } from '@webapp/services/users';
 import type { RootState } from '../store';
 import { addNotification } from './notifications';
+import { createAsyncThunk } from '../async-thunk';
 
 interface UserRootState {
   type: 'loading' | 'loaded' | 'failed';
@@ -23,7 +24,7 @@ const initialState: UserRootState = {
 };
 
 export const loadCurrentUser = createAsyncThunk(
-  'newRoot/loadCurrentUser',
+  'users/loadCurrentUser',
   async (_, thunkAPI) => {
     const res = await loadCurrentUserAPI();
     if (res.isOk) {

--- a/webapp/javascript/redux/store.ts
+++ b/webapp/javascript/redux/store.ts
@@ -42,18 +42,7 @@ const reducer = combineReducers({
 export const logErrorMiddleware: Middleware = () => (next) => (action) => {
   next(action);
   if (action?.error) {
-    // since redux-toolkit serializes errors
-    // we should deserialize them back
-    // https://github.com/reduxjs/redux-toolkit/blob/db0d7dc20939b62f8c59631cc030575b78642296/packages/toolkit/src/createAsyncThunk.ts#L94
-    try {
-      const deserialized = deserializeError(action.error);
-      console.error(deserialized);
-
-      // TODO: report error to server?
-    } catch (e) {
-      // we failed to deserialize it, which means it may not be a valid Error object
-      console.error(action.error);
-    }
+    console.error(action.error);
   }
 };
 
@@ -62,6 +51,8 @@ const store = configureStore({
   middleware: (getDefaultMiddleware) => [
     ...getDefaultMiddleware({
       serializableCheck: {
+        ignoredActionPaths: ['error'],
+
         // Based on this issue: https://github.com/rt2zz/redux-persist/issues/988
         // and this guide https://redux-toolkit.js.org/usage/usage-guide#use-with-redux-persist
         ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],

--- a/webapp/javascript/services/base.ts
+++ b/webapp/javascript/services/base.ts
@@ -120,7 +120,7 @@ export async function request(
       // Usually it's a feedback on user's actions like form validation
       if ('errors' in data && Array.isArray(data.errors)) {
         return Result.err(
-          new RequestNotOkWithErrorsList(response.status, data.errors)
+          new RequestNotOkWithErrorsList(String(response.status), data.errors)
         );
       }
 

--- a/webapp/javascript/services/base.ts
+++ b/webapp/javascript/services/base.ts
@@ -120,7 +120,7 @@ export async function request(
       // Usually it's a feedback on user's actions like form validation
       if ('errors' in data && Array.isArray(data.errors)) {
         return Result.err(
-          new RequestNotOkWithErrorsList(String(response.status), data.errors)
+          new RequestNotOkWithErrorsList(response.status, data.errors)
         );
       }
 


### PR DESCRIPTION
The problem:

Sometimes components require access to the underlying error, so that we can do stuff like `error instanceof RequestIncompleteError` or `error.code == 401`. However, redux by default serializes/normalizes the error, making us lose these fields (https://github.com/reduxjs/redux-toolkit/blob/db0d7dc20939b62f8c59631cc030575b78642296/packages/toolkit/src/createAsyncThunk.ts#L98).

Also it's nice to have access to the underlying error when reporting to for example, sentry.

The solution
This PR creates a wrapper around `createAsyncThunk`, which then bakes an identity function `(x => x)` to the `serializeError`. We also need to skip serializable checks to the `error` field.
