### PR TITLE
fix: delete data in batches instead of using badgerDB DropPrefix

### DIFF
--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -336,7 +336,7 @@ func (s *Storage) retentionPolicy() *segment.RetentionPolicy {
 	}
 	return segment.NewRetentionPolicy().
 		SetAbsolutePeriod(s.config.retention).
-		SetExemplarsRetentionPeriod(s.config.retentionExemplars).
+		SetExemplarsRetentionPeriod(exemplarsRetention).
 		SetLevels(
 			s.config.retentionLevels.Zero,
 			s.config.retentionLevels.One,

--- a/pkg/storage/storage_delete.go
+++ b/pkg/storage/storage_delete.go
@@ -19,14 +19,9 @@ func (s *Storage) Delete(_ context.Context, di *DeleteInput) error {
 
 func (s *Storage) deleteSegmentAndRelatedData(k *segment.Key) error {
 	sk := k.SegmentKey()
-
-	// Drop trees from disk.
-	if err := s.trees.DropPrefix(treePrefix.key(sk)); err != nil {
+	if err := s.trees.DiscardPrefix(sk); err != nil {
 		return err
 	}
-	// Discarding cached items is necessary because otherwise
-	// those would be written back to disk on eviction.
-	s.trees.DiscardPrefix(sk)
 	for key, value := range k.Labels() {
 		d, ok := s.lookupDimensionKV(key, value)
 		if !ok {


### PR DESCRIPTION
Pyroscope server uses BadgerDB [`DropPrefix`](https://github.com/dgraph-io/badger/blob/156819ccb106bbeb207e985f561780e2929344bc/db.go#L1646-L1656) call to delete all the application keys (for example, when an application is removed or when a series ceased to exist because of the retention policy). The problem is that it blocks writes and forces LSM compaction which affects overall performance.

The fix removes the call - instead, keys are iterated and removed in batches in an explicit way.