### PR TITLE
fix: remove force compation

### DIFF
--- a/pkg/storage/exemplars.go
+++ b/pkg/storage/exemplars.go
@@ -304,9 +304,6 @@ func (e *exemplars) truncateBefore(ctx context.Context, before time.Time) (err e
 }
 
 func (e *exemplars) truncateN(before time.Time, count int) (bool, error) {
-	if err := e.db.Flatten(2); err != nil {
-		return false, err
-	}
 	beforeTs := before.UnixNano()
 	keys := make([][]byte, 0, 2*count)
 	err := e.db.View(func(txn *badger.Txn) error {


### PR DESCRIPTION
A regression has been introduced in https://github.com/pyroscope-io/pyroscope/pull/1018: BadgerDB `Flatten` call that is performed before dropping old exemplars in order to speed up the iterator causes huge overhead if the database is big.