### PR TITLE
Add loki for logging and derived fields in tracing example

### DIFF
--- a/examples/tracing/jaeger/docker-compose.yml
+++ b/examples/tracing/jaeger/docker-compose.yml
@@ -7,6 +7,10 @@ services:
       - '6831:6831/udp'
       - '16686:16686'
       - '14268:14268'
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/loki/api/v1/push'
 
   pyroscope:
     image: '${PYROSCOPE_IMAGE:-pyroscope/pyroscope-dev:main}'
@@ -19,6 +23,10 @@ services:
       - ./pyroscope.yaml:/pyroscope.yaml
     command:
       - 'server'
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/loki/api/v1/push'
 
   grafana:
     image: pyroscope/grafana:dev
@@ -29,6 +37,10 @@ services:
       - 'GF_INSTALL_PLUGINS=pyroscope-datasource,pyroscope-panel'
     ports:
       - '3000:3000'
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/loki/api/v1/push'
 
   us-east-1:
     env_file:
@@ -37,6 +49,10 @@ services:
       - REGION=us-east-1
     build:
       context: ''
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/loki/api/v1/push'
 
   us-west-1:
     env_file:
@@ -45,6 +61,10 @@ services:
       - REGION=us-west-1
     build:
       context: ''
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/loki/api/v1/push'
 
   eu-west-1:
     env_file:
@@ -53,6 +73,10 @@ services:
       - REGION=eu-west-1
     build:
       context: ''
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/loki/api/v1/push'
 
   load-generator:
     env_file:
@@ -64,6 +88,10 @@ services:
       - eu-west-1
       - us-west-1
       - us-east-1
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/loki/api/v1/push'
 
   jaeger-ui:
     build:
@@ -71,3 +99,12 @@ services:
       dockerfile: jaeger-ui/Dockerfile
     ports:
       - '4000:3000'
+
+  loki:
+    image: 'grafana/loki:2.5.0'
+    ports:
+      - '3100:3100'
+    logging:
+      driver: loki
+      options:
+        loki-url: 'http://localhost:3100/loki/api/v1/push'

--- a/examples/tracing/jaeger/grafana/provisioning/datasources/datasources.yml
+++ b/examples/tracing/jaeger/grafana/provisioning/datasources/datasources.yml
@@ -16,3 +16,15 @@ datasources:
     uid: pyroscope
     jsonData:
       path: http://pyroscope:4040
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: true
+    jsonData:
+      derivedFields:
+        - name: 'traceID'
+          matcherRegex: "trace_id=(\\w+)"
+          url: '$${__value.raw}'
+          datasourceUid: jaeger


### PR DESCRIPTION
The goal is to eventually add a derived field for pyroscope in addition to jaeger:

For example this configuration:
![Screen Shot 2022-04-19 at 10 52 39 AM](https://user-images.githubusercontent.com/23323466/164068695-9433d8d7-c30f-4c64-bbc7-2f22a4064487.png)

Allows us to cick directly on a log and create a query on the opposite side with the `trace_id` in the query box for jaeger
![2022-04-19 11 13 26](https://user-images.githubusercontent.com/23323466/164069125-a1566003-6843-416d-8c72-68d408786ce3.gif)

We'd like to be able to do the same thing eventually with Pyroscope i.e.
![image](https://user-images.githubusercontent.com/23323466/164071231-f2cff55a-9c02-47a0-8b13-142c8e89a67e.png)


Note: This will be slightly broken at first because not all spans have corresponding profiles (only the root spans do)



cc/ @pavelpashkovsky 