### PR TITLE
fix(flamegraph): fix table contrast

### DIFF
--- a/webapp/sass/profile.scss
+++ b/webapp/sass/profile.scss
@@ -294,6 +294,9 @@ $pane-width: 6px;
     span {
       // mix-blend-mode: exclusion;
       text-shadow: 0 0 2px var(--ps-c-black-light-2);
+      &:not(.color-reference) {
+        mix-blend-mode: difference;
+      }
     }
 
     &:first-child {


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/1049
![image](https://user-images.githubusercontent.com/6951209/164481354-90f00e38-8314-4bbf-8a1a-487a4140b627.png)

This solution uses https://developer.mozilla.org/en-US/docs/Web/CSS/mix-blend-mode which should be supported in the majority of modern browsers.

Be aware that this solution is not super great for a few colors (see example below), but it's definitely an improvement from what we previously had
![image](https://user-images.githubusercontent.com/6951209/164481206-95be9caf-498f-4f59-8062-d4222408dfc9.png)
