### PR TITLE
chore: bump pyroscope-models to 0.0.7

### DIFF
--- a/packages/pyroscope-models/package.json
+++ b/packages/pyroscope-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pyroscope/models",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
I've noticed npm publish job is failing (eg https://github.com/pyroscope-io/pyroscope/runs/6159562890?check_suite_focus=true) not quite sure how the tag already exists though.