### PR TITLE
chore: Update commit so baseline profiles appear in jaeger ui

### DIFF
--- a/examples/tracing/jaeger/jaeger-ui/Dockerfile
+++ b/examples/tracing/jaeger/jaeger-ui/Dockerfile
@@ -4,7 +4,9 @@ RUN apk add --no-cache git
 
 WORKDIR /opt/jaeger-ui
 
-RUN git clone https://github.com/pyroscope-io/jaeger-ui.git /opt/jaeger-ui && git checkout c32127fdb7cf8a4c88541ebc7bd3703437d2f121
+# RUN git clone https://github.com/pyroscope-io/jaeger-ui.git /opt/jaeger-ui && git checkout 0b4bdd6a488c0d73265578f1dcb006affb76d4bd
+RUN git clone https://github.com/pyroscope-io/jaeger-ui.git /opt/jaeger-ui && git checkout 11733cf166622281ac89e3485ca836a72c689fbd
+
 
 RUN yarn install || true
 ENV HOST=0.0.0.0


### PR DESCRIPTION
This adds a diff from the baseline to the jaeger ui (not interesting in this picture because all requests are the same):

![image](https://user-images.githubusercontent.com/23323466/165552588-bc434472-82fe-4c94-b0c0-b7129587efae.png)
