### PR TITLE
chore: storage api changes

### DIFF
--- a/pkg/storage/cleanup.go
+++ b/pkg/storage/cleanup.go
@@ -31,11 +31,11 @@ func (s *Storage) Cleanup(ctx context.Context) error {
 }
 
 func (s *Storage) cleanupTreesDB(ctx context.Context) (err error) {
-	batch := s.trees.DB.NewWriteBatch()
+	batch := s.trees.NewWriteBatch()
 	defer func() {
 		err = batch.Flush()
 	}()
-	return s.trees.DB.Update(func(txn *badger.Txn) error {
+	return s.trees.Update(func(txn *badger.Txn) error {
 		it := txn.NewIterator(badger.IteratorOptions{Prefix: treePrefix.bytes()})
 		defer it.Close()
 		var c int64
@@ -53,11 +53,11 @@ func (s *Storage) cleanupTreesDB(ctx context.Context) (err error) {
 					continue
 				}
 			}
-			if c == s.trees.DB.MaxBatchCount()+1 {
+			if c == s.trees.MaxBatchCount()+1 {
 				if err = batch.Flush(); err != nil {
 					return err
 				}
-				batch = s.trees.DB.NewWriteBatch()
+				batch = s.trees.NewWriteBatch()
 				c = 0
 			}
 			if err = batch.Delete(item.KeyCopy(nil)); err != nil {

--- a/pkg/storage/config.go
+++ b/pkg/storage/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/pyroscope-io/pyroscope/pkg/config"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/cache"
 	"github.com/sirupsen/logrus"
 )
 
@@ -19,6 +20,8 @@ type Config struct {
 	retention             time.Duration
 	retentionExemplars    time.Duration
 	retentionLevels       config.RetentionLevels
+
+	NewBadger func(name string, p Prefix, codec cache.Codec) (BadgerDBWithCache, error)
 }
 
 // NewConfig returns a new storage config from a server config

--- a/pkg/storage/debug.go
+++ b/pkg/storage/debug.go
@@ -20,7 +20,7 @@ func (s *Storage) DebugExport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	n := mux.Vars(r)["db"]
-	var d *db
+	var d BadgerDBWithCache
 	switch n {
 	case "segments":
 		d = s.segments
@@ -44,7 +44,7 @@ func (s *Storage) DebugExport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/octet-stream")
-	err := d.DB.View(func(txn *badger.Txn) error {
+	err := d.View(func(txn *badger.Txn) error {
 		item, err := txn.Get([]byte(k[0]))
 		if err != nil {
 			return err

--- a/pkg/storage/exemplars.go
+++ b/pkg/storage/exemplars.go
@@ -21,8 +21,8 @@ import (
 // TODO(kolesnikovae): decouple from Storage.
 
 const (
-	exemplarDataPrefix      prefix = "v:"
-	exemplarTimestampPrefix prefix = "t:"
+	exemplarDataPrefix      Prefix = "v:"
+	exemplarTimestampPrefix Prefix = "t:"
 	exemplarsFormatV1       byte   = 1
 
 	exemplarBatches       = 5
@@ -34,8 +34,8 @@ type exemplars struct {
 	logger  *logrus.Logger
 	config  *Config
 	metrics *metrics
-	db      *db
-	dicts   *db
+	db      BadgerDBWithCache
+	dicts   BadgerDBWithCache
 
 	once         sync.Once
 	mu           sync.Mutex
@@ -52,7 +52,7 @@ type exemplarsBatch struct {
 
 	config  *Config
 	metrics *metrics
-	dicts   *db
+	dicts   BadgerDBWithCache
 }
 
 type exemplarsBatchEntry struct {
@@ -72,7 +72,7 @@ func (e *exemplars) newExemplarsBatch() *exemplarsBatch {
 	}
 }
 
-func (s *Storage) initExemplarsStorage(db *db) {
+func (s *Storage) initExemplarsStorage(db BadgerDBWithCache) {
 	e := exemplars{
 		logger:  s.logger,
 		config:  s.config,

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -33,11 +33,11 @@ type Storage struct {
 	logger *logrus.Logger
 	*metrics
 
-	segments   *db
-	dimensions *db
-	dicts      *db
-	trees      *db
-	main       *db
+	segments   BadgerDBWithCache
+	dimensions BadgerDBWithCache
+	dicts      BadgerDBWithCache
+	trees      BadgerDBWithCache
+	main       BadgerDBWithCache
 	labels     *labels.Labels
 	exemplars  *exemplars
 
@@ -88,6 +88,7 @@ type SampleObserver interface {
 }
 
 func New(c *Config, logger *logrus.Logger, reg prometheus.Registerer, hc *health.Controller) (*Storage, error) {
+
 	s := &Storage{
 		config: c,
 		storageOptions: &storageOptions{
@@ -117,32 +118,36 @@ func New(c *Config, logger *logrus.Logger, reg prometheus.Registerer, hc *health
 		stop:    make(chan struct{}),
 	}
 
+	if c.NewBadger == nil {
+		c.NewBadger = s.newBadger
+	}
+
 	s.queue = make(chan *putInputWithCtx, s.queueLen)
 
 	var err error
-	if s.main, err = s.newBadger("main", "", nil); err != nil {
+	if s.main, err = c.NewBadger("main", "", nil); err != nil {
 		return nil, err
 	}
-	if s.dicts, err = s.newBadger("dicts", dictionaryPrefix, dictionaryCodec{}); err != nil {
+	if s.dicts, err = c.NewBadger("dicts", dictionaryPrefix, dictionaryCodec{}); err != nil {
 		return nil, err
 	}
-	if s.dimensions, err = s.newBadger("dimensions", dimensionPrefix, dimensionCodec{}); err != nil {
+	if s.dimensions, err = c.NewBadger("dimensions", dimensionPrefix, dimensionCodec{}); err != nil {
 		return nil, err
 	}
-	if s.segments, err = s.newBadger("segments", segmentPrefix, segmentCodec{}); err != nil {
+	if s.segments, err = c.NewBadger("segments", segmentPrefix, segmentCodec{}); err != nil {
 		return nil, err
 	}
-	if s.trees, err = s.newBadger("trees", treePrefix, treeCodec{s}); err != nil {
+	if s.trees, err = c.NewBadger("trees", treePrefix, treeCodec{s}); err != nil {
 		return nil, err
 	}
 
-	pdb, err := s.newBadger("profiles", exemplarDataPrefix, nil)
+	pdb, err := c.NewBadger("profiles", exemplarDataPrefix, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	s.initExemplarsStorage(pdb)
-	s.labels = labels.New(s.main.DB)
+	s.labels = labels.New(s.main.DBInstance())
 
 	if err = s.migrate(); err != nil {
 		return nil, err
@@ -174,19 +179,19 @@ func (s *Storage) Close() error {
 	s.tasksWG.Wait()
 	s.logger.Debug("storage tasks finished")
 	// Dictionaries DB has to close last because trees and profiles DBs depend on it.
-	s.goDB(func(d *db) {
+	s.goDB(func(d BadgerDBWithCache) {
 		if d != s.dicts {
-			d.close()
+			d.Close()
 		}
 	})
-	s.dicts.close()
+	s.dicts.Close()
 	return nil
 }
 
 func (s *Storage) DiskUsage() map[string]bytesize.ByteSize {
 	m := make(map[string]bytesize.ByteSize)
 	for _, d := range s.databases() {
-		m[d.name] = d.size()
+		m[d.Name()] = d.Size()
 	}
 	return m
 }
@@ -194,8 +199,8 @@ func (s *Storage) DiskUsage() map[string]bytesize.ByteSize {
 func (s *Storage) CacheStats() map[string]uint64 {
 	m := make(map[string]uint64)
 	for _, d := range s.databases() {
-		if d.Cache != nil {
-			m[d.name] = d.Cache.Size()
+		if d.CacheInstance() != nil {
+			m[d.Name()] = d.CacheSize()
 		}
 	}
 	return m
@@ -215,12 +220,12 @@ func (s *Storage) withContext(fn func(context.Context)) {
 }
 
 // goDB runs f for all DBs concurrently.
-func (s *Storage) goDB(f func(*db)) {
+func (s *Storage) goDB(f func(BadgerDBWithCache)) {
 	dbs := s.databases()
 	wg := new(sync.WaitGroup)
 	wg.Add(len(dbs))
 	for _, d := range dbs {
-		go func(db *db) {
+		go func(db BadgerDBWithCache) {
 			defer wg.Done()
 			f(db)
 		}(d)
@@ -298,7 +303,7 @@ func (s *Storage) writeBackTask() {
 	timer := prometheus.NewTimer(prometheus.ObserverFunc(s.metrics.writeBackTaskDuration.Observe))
 	defer timer.ObserveDuration()
 	for _, d := range s.databases() {
-		if d.Cache != nil {
+		if d.CacheInstance() != nil {
 			d.WriteBack()
 		}
 	}
@@ -306,9 +311,9 @@ func (s *Storage) writeBackTask() {
 
 func (s *Storage) updateMetricsTask() {
 	for _, d := range s.databases() {
-		s.metrics.dbSize.WithLabelValues(d.name).Set(float64(d.size()))
-		if d.Cache != nil {
-			s.metrics.cacheSize.WithLabelValues(d.name).Set(float64(d.Cache.Size()))
+		s.metrics.dbSize.WithLabelValues(d.Name()).Set(float64(d.Size()))
+		if d.CacheInstance() != nil {
+			s.metrics.cacheSize.WithLabelValues(d.Name()).Set(float64(d.CacheSize()))
 		}
 	}
 }
@@ -345,8 +350,8 @@ func (s *Storage) retentionPolicy() *segment.RetentionPolicy {
 			s.config.retentionLevels.Two)
 }
 
-func (s *Storage) databases() []*db {
-	return []*db{
+func (s *Storage) databases() []BadgerDBWithCache {
+	return []BadgerDBWithCache{
 		s.main,
 		s.dimensions,
 		s.segments,
@@ -357,17 +362,17 @@ func (s *Storage) databases() []*db {
 }
 
 func (s *Storage) SegmentsInternals() (*badger.DB, *cache.Cache) {
-	return s.segments.DB, s.segments.Cache
+	return s.segments.DBInstance(), s.segments.CacheInstance()
 }
 func (s *Storage) DimensionsInternals() (*badger.DB, *cache.Cache) {
-	return s.dimensions.DB, s.dimensions.Cache
+	return s.dimensions.DBInstance(), s.dimensions.CacheInstance()
 }
 func (s *Storage) DictsInternals() (*badger.DB, *cache.Cache) {
-	return s.dicts.DB, s.dicts.Cache
+	return s.dicts.DBInstance(), s.dicts.CacheInstance()
 }
 func (s *Storage) TreesInternals() (*badger.DB, *cache.Cache) {
-	return s.trees.DB, s.trees.Cache
+	return s.trees.DBInstance(), s.trees.CacheInstance()
 }
 func (s *Storage) MainInternals() (*badger.DB, *cache.Cache) {
-	return s.main.DB, s.main.Cache
+	return s.main.DBInstance(), s.main.CacheInstance()
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -88,7 +88,6 @@ type SampleObserver interface {
 }
 
 func New(c *Config, logger *logrus.Logger, reg prometheus.Registerer, hc *health.Controller) (*Storage, error) {
-
 	s := &Storage{
 		config: c,
 		storageOptions: &storageOptions{

--- a/pkg/storage/storage_delete_test.go
+++ b/pkg/storage/storage_delete_test.go
@@ -41,7 +41,7 @@ var _ = Describe("storage package", func() {
 			Expect(err).ToNot(HaveOccurred())
 			segmentKeyStr := segmentKey.SegmentKey()
 			Expect(segmentKeyStr).To(Equal(appname + "{}"))
-			_, ok := s.segments.Cache.Lookup(segmentKeyStr)
+			_, ok := s.segments.Lookup(segmentKeyStr)
 
 			if presence {
 				Expect(ok).To(BeTrue())
@@ -65,7 +65,7 @@ var _ = Describe("storage package", func() {
 			key, err := segment.ParseKey(appname)
 			Expect(err).ToNot(HaveOccurred())
 			treeKeyName := key.TreeKey(depth, st)
-			t, ok := s.trees.Cache.Lookup(treeKeyName)
+			t, ok := s.trees.Lookup(treeKeyName)
 			if presence {
 				Expect(ok).To(BeTrue())
 			} else {
@@ -76,7 +76,7 @@ var _ = Describe("storage package", func() {
 		}
 
 		checkDictsPresence := func(appname string, presence bool) interface{} {
-			d, ok := s.dicts.Cache.Lookup(appname)
+			d, ok := s.dicts.Lookup(appname)
 			if presence {
 				Expect(ok).To(BeTrue())
 			} else {
@@ -135,20 +135,20 @@ var _ = Describe("storage package", func() {
 				/*  S a n i t y   C h e c k s  */
 				/*******************************/
 				// Dimensions
-				Expect(s.dimensions.Cache.Size()).To(Equal(uint64(1)))
+				Expect(s.dimensions.Size()).To(Equal(uint64(1)))
 				checkDimensionsPresence(appname, true)
 
 				// Trees
-				Expect(s.trees.Cache.Size()).To(Equal(uint64(1)))
+				Expect(s.trees.Size()).To(Equal(uint64(1)))
 				checkTreesPresence(appname, st, 0, true)
 
 				// Segments
-				Expect(s.segments.Cache.Size()).To(Equal(uint64(1)))
+				Expect(s.segments.Size()).To(Equal(uint64(1)))
 				checkSegmentsPresence(appname, true)
 
 				// Dicts
 				// I manually inserted a dictionary so it should be fine?
-				Expect(s.dicts.Cache.Size()).To(Equal(uint64(1)))
+				Expect(s.dicts.Size()).To(Equal(uint64(1)))
 				checkDictsPresence(appname, true)
 
 				// Labels
@@ -162,19 +162,19 @@ var _ = Describe("storage package", func() {
 
 				// Trees
 				// should've been deleted from CACHE
-				Expect(s.trees.Cache.Size()).To(Equal(uint64(0)))
+				Expect(s.trees.Size()).To(Equal(uint64(0)))
 				checkTreesPresence(appname, st, 0, false)
 
 				// Dimensions
-				Expect(s.dimensions.Cache.Size()).To(Equal(uint64(0)))
+				Expect(s.dimensions.Size()).To(Equal(uint64(0)))
 				checkDimensionsPresence(appname, false)
 
 				// Dicts
-				Expect(s.dicts.Cache.Size()).To(Equal(uint64(0)))
+				Expect(s.dicts.Size()).To(Equal(uint64(0)))
 				checkDictsPresence(appname, false)
 
 				// Segments
-				Expect(s.segments.Cache.Size()).To(Equal(uint64(0)))
+				Expect(s.segments.Size()).To(Equal(uint64(0)))
 				checkSegmentsPresence(appname, false)
 
 				// Labels
@@ -223,21 +223,21 @@ var _ = Describe("storage package", func() {
 				/*******************************/
 
 				By("checking dimensions were created")
-				Expect(s.dimensions.Cache.Size()).To(Equal(uint64(4)))
+				Expect(s.dimensions.Size()).To(Equal(uint64(4)))
 				checkDimensionsPresence(appname, true)
 
 				By("checking trees were created")
-				Expect(s.trees.Cache.Size()).To(Equal(uint64(3)))
+				Expect(s.trees.Size()).To(Equal(uint64(3)))
 				checkTreesPresence(appname, st, 0, true)
 
 				By("checking segments were created")
-				Expect(s.segments.Cache.Size()).To(Equal(uint64(3)))
+				Expect(s.segments.Size()).To(Equal(uint64(3)))
 				checkSegmentsPresence(appname, true)
 
 				By("checking dicts were created")
 				// Dicts
 				// I manually inserted a dictionary so it should be fine?
-				Expect(s.dicts.Cache.Size()).To(Equal(uint64(1)))
+				Expect(s.dicts.Size()).To(Equal(uint64(1)))
 				checkDictsPresence(appname, true)
 
 				// Labels
@@ -253,22 +253,22 @@ var _ = Describe("storage package", func() {
 				By("checking trees were deleted")
 				// Trees
 				// should've been deleted from CACHE
-				Expect(s.trees.Cache.Size()).To(Equal(uint64(0)))
+				Expect(s.trees.Size()).To(Equal(uint64(0)))
 				checkTreesPresence(appname, st, 0, false)
 
 				// Dimensions
 				By("checking dimensions were deleted")
-				Expect(s.dimensions.Cache.Size()).To(Equal(uint64(0)))
+				Expect(s.dimensions.Size()).To(Equal(uint64(0)))
 				checkDimensionsPresence(appname, false)
 
 				// Dicts
 				By("checking dicts were deleted")
-				Expect(s.dicts.Cache.Size()).To(Equal(uint64(0)))
+				Expect(s.dicts.Size()).To(Equal(uint64(0)))
 				checkDictsPresence(appname, false)
 
 				// Segments
 				By("checking segments were deleted")
-				Expect(s.segments.Cache.Size()).To(Equal(uint64(0)))
+				Expect(s.segments.Size()).To(Equal(uint64(0)))
 				checkSegmentsPresence(appname, false)
 
 				// Labels
@@ -325,22 +325,22 @@ var _ = Describe("storage package", func() {
 				/*  S a n i t y   C h e c k s  */
 				/*******************************/
 				By("checking dimensions were created")
-				Expect(s.dimensions.Cache.Size()).To(Equal(uint64(5)))
+				Expect(s.dimensions.Size()).To(Equal(uint64(5)))
 				checkDimensionsPresence(app1name, true)
 				checkDimensionsPresence(app2name, true)
 
 				By("checking trees were created")
-				Expect(s.trees.Cache.Size()).To(Equal(uint64(6)))
+				Expect(s.trees.Size()).To(Equal(uint64(6)))
 				checkTreesPresence(app1name, st, 0, true)
 				checkTreesPresence(app2name, st, 0, true)
 
 				By("checking segments were created")
-				Expect(s.segments.Cache.Size()).To(Equal(uint64(6)))
+				Expect(s.segments.Size()).To(Equal(uint64(6)))
 				checkSegmentsPresence(app1name, true)
 				checkSegmentsPresence(app2name, true)
 
 				By("checking dicts were created")
-				Expect(s.dicts.Cache.Size()).To(Equal(uint64(2)))
+				Expect(s.dicts.Size()).To(Equal(uint64(2)))
 				checkDictsPresence(app1name, true)
 				checkDictsPresence(app2name, true)
 
@@ -356,13 +356,13 @@ var _ = Describe("storage package", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("checking trees were deleted")
-				Expect(s.trees.Cache.Size()).To(Equal(uint64(3)))
+				Expect(s.trees.Size()).To(Equal(uint64(3)))
 				checkTreesPresence(app1name, st, 0, false)
 				checkTreesPresence(app2name, st, 0, true)
 
 				// Dimensions
 				By("checking dimensions were deleted")
-				Expect(s.dimensions.Cache.Size()).To(Equal(uint64(4)))
+				Expect(s.dimensions.Size()).To(Equal(uint64(4)))
 
 				// Dimensions that refer to app2 are still intact
 				v, ok := s.dimensions.Lookup("__name__:myapp2.cpu")
@@ -393,12 +393,12 @@ var _ = Describe("storage package", func() {
 				}))
 
 				By("checking dicts were deleted")
-				Expect(s.dicts.Cache.Size()).To(Equal(uint64(1)))
+				Expect(s.dicts.Size()).To(Equal(uint64(1)))
 				checkDictsPresence(app1name, false)
 				checkDictsPresence(app2name, true)
 
 				By("checking segments were deleted")
-				Expect(s.segments.Cache.Size()).To(Equal(uint64(3)))
+				Expect(s.segments.Size()).To(Equal(uint64(3)))
 				checkSegmentsPresence(app1name, false)
 				checkSegmentsPresence(app2name, true)
 
@@ -450,19 +450,19 @@ var _ = Describe("storage package", func() {
 			/*******************************/
 			sanityChecks := func() {
 				By("checking dimensions were created")
-				Expect(s.dimensions.Cache.Size()).To(Equal(uint64(4)))
+				Expect(s.dimensions.Size()).To(Equal(uint64(4)))
 				checkDimensionsPresence(appname, true)
 
 				By("checking trees were created")
-				Expect(s.trees.Cache.Size()).To(Equal(uint64(3)))
+				Expect(s.trees.Size()).To(Equal(uint64(3)))
 				checkTreesPresence(appname, st, 0, true)
 
 				By("checking segments were created")
-				Expect(s.segments.Cache.Size()).To(Equal(uint64(3)))
+				Expect(s.segments.Size()).To(Equal(uint64(3)))
 				checkSegmentsPresence(appname, true)
 
 				By("checking dicts were created")
-				Expect(s.dicts.Cache.Size()).To(Equal(uint64(1)))
+				Expect(s.dicts.Size()).To(Equal(uint64(1)))
 				checkDictsPresence(appname, true)
 
 				checkLabelsPresence(appname, true)

--- a/pkg/storage/storage_delete_test.go
+++ b/pkg/storage/storage_delete_test.go
@@ -135,20 +135,20 @@ var _ = Describe("storage package", func() {
 				/*  S a n i t y   C h e c k s  */
 				/*******************************/
 				// Dimensions
-				Expect(s.dimensions.Size()).To(Equal(uint64(1)))
+				Expect(s.dimensions.CacheSize()).To(Equal(uint64(1)))
 				checkDimensionsPresence(appname, true)
 
 				// Trees
-				Expect(s.trees.Size()).To(Equal(uint64(1)))
+				Expect(s.trees.CacheSize()).To(Equal(uint64(1)))
 				checkTreesPresence(appname, st, 0, true)
 
 				// Segments
-				Expect(s.segments.Size()).To(Equal(uint64(1)))
+				Expect(s.segments.CacheSize()).To(Equal(uint64(1)))
 				checkSegmentsPresence(appname, true)
 
 				// Dicts
 				// I manually inserted a dictionary so it should be fine?
-				Expect(s.dicts.Size()).To(Equal(uint64(1)))
+				Expect(s.dicts.CacheSize()).To(Equal(uint64(1)))
 				checkDictsPresence(appname, true)
 
 				// Labels
@@ -162,19 +162,19 @@ var _ = Describe("storage package", func() {
 
 				// Trees
 				// should've been deleted from CACHE
-				Expect(s.trees.Size()).To(Equal(uint64(0)))
+				Expect(s.trees.CacheSize()).To(Equal(uint64(0)))
 				checkTreesPresence(appname, st, 0, false)
 
 				// Dimensions
-				Expect(s.dimensions.Size()).To(Equal(uint64(0)))
+				Expect(s.dimensions.CacheSize()).To(Equal(uint64(0)))
 				checkDimensionsPresence(appname, false)
 
 				// Dicts
-				Expect(s.dicts.Size()).To(Equal(uint64(0)))
+				Expect(s.dicts.CacheSize()).To(Equal(uint64(0)))
 				checkDictsPresence(appname, false)
 
 				// Segments
-				Expect(s.segments.Size()).To(Equal(uint64(0)))
+				Expect(s.segments.CacheSize()).To(Equal(uint64(0)))
 				checkSegmentsPresence(appname, false)
 
 				// Labels
@@ -223,21 +223,21 @@ var _ = Describe("storage package", func() {
 				/*******************************/
 
 				By("checking dimensions were created")
-				Expect(s.dimensions.Size()).To(Equal(uint64(4)))
+				Expect(s.dimensions.CacheSize()).To(Equal(uint64(4)))
 				checkDimensionsPresence(appname, true)
 
 				By("checking trees were created")
-				Expect(s.trees.Size()).To(Equal(uint64(3)))
+				Expect(s.trees.CacheSize()).To(Equal(uint64(3)))
 				checkTreesPresence(appname, st, 0, true)
 
 				By("checking segments were created")
-				Expect(s.segments.Size()).To(Equal(uint64(3)))
+				Expect(s.segments.CacheSize()).To(Equal(uint64(3)))
 				checkSegmentsPresence(appname, true)
 
 				By("checking dicts were created")
 				// Dicts
 				// I manually inserted a dictionary so it should be fine?
-				Expect(s.dicts.Size()).To(Equal(uint64(1)))
+				Expect(s.dicts.CacheSize()).To(Equal(uint64(1)))
 				checkDictsPresence(appname, true)
 
 				// Labels
@@ -253,22 +253,22 @@ var _ = Describe("storage package", func() {
 				By("checking trees were deleted")
 				// Trees
 				// should've been deleted from CACHE
-				Expect(s.trees.Size()).To(Equal(uint64(0)))
+				Expect(s.trees.CacheSize()).To(Equal(uint64(0)))
 				checkTreesPresence(appname, st, 0, false)
 
 				// Dimensions
 				By("checking dimensions were deleted")
-				Expect(s.dimensions.Size()).To(Equal(uint64(0)))
+				Expect(s.dimensions.CacheSize()).To(Equal(uint64(0)))
 				checkDimensionsPresence(appname, false)
 
 				// Dicts
 				By("checking dicts were deleted")
-				Expect(s.dicts.Size()).To(Equal(uint64(0)))
+				Expect(s.dicts.CacheSize()).To(Equal(uint64(0)))
 				checkDictsPresence(appname, false)
 
 				// Segments
 				By("checking segments were deleted")
-				Expect(s.segments.Size()).To(Equal(uint64(0)))
+				Expect(s.segments.CacheSize()).To(Equal(uint64(0)))
 				checkSegmentsPresence(appname, false)
 
 				// Labels
@@ -325,22 +325,22 @@ var _ = Describe("storage package", func() {
 				/*  S a n i t y   C h e c k s  */
 				/*******************************/
 				By("checking dimensions were created")
-				Expect(s.dimensions.Size()).To(Equal(uint64(5)))
+				Expect(s.dimensions.CacheSize()).To(Equal(uint64(5)))
 				checkDimensionsPresence(app1name, true)
 				checkDimensionsPresence(app2name, true)
 
 				By("checking trees were created")
-				Expect(s.trees.Size()).To(Equal(uint64(6)))
+				Expect(s.trees.CacheSize()).To(Equal(uint64(6)))
 				checkTreesPresence(app1name, st, 0, true)
 				checkTreesPresence(app2name, st, 0, true)
 
 				By("checking segments were created")
-				Expect(s.segments.Size()).To(Equal(uint64(6)))
+				Expect(s.segments.CacheSize()).To(Equal(uint64(6)))
 				checkSegmentsPresence(app1name, true)
 				checkSegmentsPresence(app2name, true)
 
 				By("checking dicts were created")
-				Expect(s.dicts.Size()).To(Equal(uint64(2)))
+				Expect(s.dicts.CacheSize()).To(Equal(uint64(2)))
 				checkDictsPresence(app1name, true)
 				checkDictsPresence(app2name, true)
 
@@ -356,13 +356,13 @@ var _ = Describe("storage package", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				By("checking trees were deleted")
-				Expect(s.trees.Size()).To(Equal(uint64(3)))
+				Expect(s.trees.CacheSize()).To(Equal(uint64(3)))
 				checkTreesPresence(app1name, st, 0, false)
 				checkTreesPresence(app2name, st, 0, true)
 
 				// Dimensions
 				By("checking dimensions were deleted")
-				Expect(s.dimensions.Size()).To(Equal(uint64(4)))
+				Expect(s.dimensions.CacheSize()).To(Equal(uint64(4)))
 
 				// Dimensions that refer to app2 are still intact
 				v, ok := s.dimensions.Lookup("__name__:myapp2.cpu")
@@ -393,12 +393,12 @@ var _ = Describe("storage package", func() {
 				}))
 
 				By("checking dicts were deleted")
-				Expect(s.dicts.Size()).To(Equal(uint64(1)))
+				Expect(s.dicts.CacheSize()).To(Equal(uint64(1)))
 				checkDictsPresence(app1name, false)
 				checkDictsPresence(app2name, true)
 
 				By("checking segments were deleted")
-				Expect(s.segments.Size()).To(Equal(uint64(3)))
+				Expect(s.segments.CacheSize()).To(Equal(uint64(3)))
 				checkSegmentsPresence(app1name, false)
 				checkSegmentsPresence(app2name, true)
 
@@ -450,19 +450,19 @@ var _ = Describe("storage package", func() {
 			/*******************************/
 			sanityChecks := func() {
 				By("checking dimensions were created")
-				Expect(s.dimensions.Size()).To(Equal(uint64(4)))
+				Expect(s.dimensions.CacheSize()).To(Equal(uint64(4)))
 				checkDimensionsPresence(appname, true)
 
 				By("checking trees were created")
-				Expect(s.trees.Size()).To(Equal(uint64(3)))
+				Expect(s.trees.CacheSize()).To(Equal(uint64(3)))
 				checkTreesPresence(appname, st, 0, true)
 
 				By("checking segments were created")
-				Expect(s.segments.Size()).To(Equal(uint64(3)))
+				Expect(s.segments.CacheSize()).To(Equal(uint64(3)))
 				checkSegmentsPresence(appname, true)
 
 				By("checking dicts were created")
-				Expect(s.dicts.Size()).To(Equal(uint64(1)))
+				Expect(s.dicts.CacheSize()).To(Equal(uint64(1)))
 				checkDictsPresence(appname, true)
 
 				checkLabelsPresence(appname, true)

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -2,7 +2,13 @@ package storage
 
 //revive:disable:max-public-structs TODO: we will refactor this later
 
-import "context"
+import (
+	"context"
+
+	"github.com/dgraph-io/badger/v2"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/cache"
+	"github.com/pyroscope-io/pyroscope/pkg/util/bytesize"
+)
 
 type Putter interface {
 	Put(ctx context.Context, pi *PutInput) error
@@ -51,3 +57,34 @@ type AppNameGetter interface {
 // 	Delete(ctx context.Context, di *DeleteInput) error
 // 	DeleteApp(ctx context.Context, appname string) error
 // }
+
+type BadgerDB interface {
+	Update(func(txn *badger.Txn) error) error
+	View(func(txn *badger.Txn) error) error
+	NewWriteBatch() *badger.WriteBatch
+	MaxBatchCount() int64
+}
+
+type CacheLayer interface {
+	Put(key string, val interface{})
+	Evict(percent float64)
+	WriteBack()
+	Delete(key string) error
+	Discard(key string)
+	DiscardPrefix(prefix string) error
+	GetOrCreate(key string) (interface{}, error)
+	Lookup(key string) (interface{}, bool)
+}
+
+type BadgerDBWithCache interface {
+	BadgerDB
+	CacheLayer
+
+	Close()
+	Size() bytesize.ByteSize
+	CacheSize() uint64
+
+	DBInstance() *badger.DB
+	CacheInstance() *cache.Cache
+	Name() string
+}


### PR DESCRIPTION
Main changes:
* there's a new `NewBadger` function, allows to initialize badger differently
* `storage.Storage` takes an interface instead of a `*db` wrapper. The interface is too bloated and far from being perfect, fixing that is out of scope for this PR
