### PR TITLE
chore: add SerializeTruncateNoDict

### DIFF
--- a/pkg/storage/tree/serialize.go
+++ b/pkg/storage/tree/serialize.go
@@ -306,3 +306,48 @@ func (t *Tree) SerializeNoDictNoLimit(w io.Writer) error {
 	}
 	return nil
 }
+
+func (t *Tree) SerializeTruncateNoDict(maxNodes int, w io.Writer) error {
+	t.Lock()
+	defer t.Unlock()
+	vw := varint.NewWriter()
+	var err error
+	minVal := t.minValue(maxNodes)
+	nodes := make([]*treeNode, 1, 1024)
+	nodes[0] = t.root
+	for len(nodes) > 0 {
+		tn := nodes[0]
+		nodes = nodes[1:]
+		if _, err = vw.Write(w, uint64(len(tn.Name))); err != nil {
+			return err
+		}
+		if _, err = w.Write(tn.Name); err != nil {
+			return err
+		}
+
+		val := tn.Self
+		cNodes := tn.ChildrenNodes
+		tn.ChildrenNodes = tn.ChildrenNodes[:0]
+		for _, cn := range cNodes {
+			if cn.Total >= minVal {
+				tn.ChildrenNodes = append(tn.ChildrenNodes, cn)
+			} else {
+				// Truncated children accounted as parent self.
+				val += cn.Total
+			}
+		}
+		if _, err = vw.Write(w, val); err != nil {
+			return err
+		}
+
+		if len(tn.ChildrenNodes) > 0 {
+			nodes = append(tn.ChildrenNodes, nodes...)
+		} else {
+			tn.ChildrenNodes = nil // Just to make it eligible for GC.
+		}
+		if _, err = vw.Write(w, uint64(len(tn.ChildrenNodes))); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
In contrast to the existing functions this one preserves `total` value.