### PR TITLE
fix: jfr ingestion issue in 0.17.0

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -93,7 +93,7 @@ func (p *Parser) Put(ctx context.Context, in *PutInput) error {
 		err = convert.ParseIndividualLines(in.Body, cb)
 	// with some formats we write directly to storage, hence the early return
 	case in.Format == "jfr":
-		return jfr.ParseJFR(ctx, in.Body, p.putter, pi)
+		return jfr.ParseJFR(ctx, p.putter, in.Body, pi)
 	case in.Format == "pprof":
 		return writePprofFromBody(ctx, p.putter, in)
 	case strings.Contains(in.ContentType, "multipart/form-data"):


### PR DESCRIPTION
The issue is that jfr parser was built slightly differently compared to other parsers. It reused the same PutInput structure for multiple inserts within one request.

Moreover, pi.Val was set to nil at the after all writes were finished. 

This flaw was exposed after we merged #1104 because PutInput structs were now stored a little bit longer in memory and inserted asynchronously.

I refactored the jfr parser code to create new PutInput structs for each input, I also DRYed the code up a bit.

---

The tests didn't catch this because in tests the controller was initialized without a queue. This was my mistake, for some reason I thought tests were using the queue as well, and that's why I approved #1104. I updated tests to use a queue.

