### PR TITLE
fix: flamegraph palette selector checkmark styles

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/DiffLegendPaletteDropdown.module.css
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/DiffLegendPaletteDropdown.module.css
@@ -31,7 +31,7 @@
 
 .dropdownItem svg {
   margin-left: 1em;
-  fill: white;
+  fill: var(--ps-c-white-2);
 }
 
 .row {

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/DiffLegendPaletteDropdown.module.css
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/DiffLegendPaletteDropdown.module.css
@@ -31,6 +31,7 @@
 
 .dropdownItem svg {
   margin-left: 1em;
+  fill: white;
 }
 
 .row {

--- a/webapp/sass/variables.css
+++ b/webapp/sass/variables.css
@@ -30,4 +30,5 @@
   --ps-c-orange-dark-1: #e53825;
   --ps-c-intro-bg-1: #3dc1d3cc;
   --ps-c-intro-bg-2: #d1283980;
+  --ps-c-white-2: #ffffff;
 }


### PR DESCRIPTION
Edited by Eduardo:

before it was like this
<img width="505" alt="image (43)" src="https://user-images.githubusercontent.com/6951209/170531435-76c421be-036e-43e0-88ff-8d1ae1962e77.png">
