### PR TITLE
Consolidate colors 

### DIFF
--- a/packages/pyroscope-flamegraph/src/ProfilerTable.module.scss
+++ b/packages/pyroscope-flamegraph/src/ProfilerTable.module.scss
@@ -10,7 +10,7 @@
     &:hover {
       cursor: pointer;
       color: var(--ps-neutral-2);
-      background: var(--ps-neutral-14);
+      background: var(--ps-neutral-10);
     }
   }
 }

--- a/packages/pyroscope-flamegraph/src/ProfilerTable.module.scss
+++ b/packages/pyroscope-flamegraph/src/ProfilerTable.module.scss
@@ -1,6 +1,6 @@
 .rowSelected {
   cursor: pointer;
-  background: var(--ps-accent-2-2) !important;
+  background: var(--ps-accent-2-1) !important;
   color: var(--ps-neutral-1);
 }
 

--- a/webapp/javascript/components/ExportData.module.scss
+++ b/webapp/javascript/components/ExportData.module.scss
@@ -10,7 +10,7 @@
   font-weight: normal;
   font-size: 11px;
   line-height: 20px;
-  color: var(--ps-neutral-7);
+  color: var(--ps-neutral-9);
   text-decoration: none;
   white-space: nowrap;
   cursor: pointer;

--- a/webapp/javascript/components/FileList.module.scss
+++ b/webapp/javascript/components/FileList.module.scss
@@ -10,7 +10,7 @@ $tdHeight: 25px;
 
 .rowSelected {
   cursor: pointer;
-  background: var(--ps-accent-2-2);
+  background: var(--ps-accent-2-1);
   color: var(--ps-neutral-1);
 }
 

--- a/webapp/javascript/components/FileList.module.scss
+++ b/webapp/javascript/components/FileList.module.scss
@@ -31,8 +31,8 @@ $tdHeight: 25px;
     text-align: right;
     padding: 0px 10px;
 
-    border-left: 1px solid var(--ps-neutral-8);
-    border-bottom: 1px solid var(--ps-neutral-8);
+    border-left: 1px solid var(--ps-neutral-10);
+    border-bottom: 1px solid var(--ps-neutral-10);
     width: 400px;
     min-width: 400px;
     max-width: 400px;

--- a/webapp/javascript/components/FileList.module.scss
+++ b/webapp/javascript/components/FileList.module.scss
@@ -59,7 +59,7 @@ $tdHeight: 25px;
   }
   tr th,
   tr:nth-child(2n) td {
-    background: var(--ps-neutral-7);
+    background: var(--ps-neutral-9);
   }
 
   td {

--- a/webapp/javascript/components/FileList.module.scss
+++ b/webapp/javascript/components/FileList.module.scss
@@ -39,7 +39,7 @@ $tdHeight: 25px;
 
     span {
       // mix-blend-mode: exclusion;
-      text-shadow: 0 0 2px var(--ps-neutral-3);
+      text-shadow: 0 0 2px var(--ps-neutral-1);
     }
 
     &:first-child {
@@ -59,7 +59,7 @@ $tdHeight: 25px;
   }
   tr th,
   tr:nth-child(2n) td {
-    background: var(--ps-neutral-17);
+    background: var(--ps-neutral-7);
   }
 
   td {

--- a/webapp/javascript/components/FileUploader.module.scss
+++ b/webapp/javascript/components/FileUploader.module.scss
@@ -1,8 +1,8 @@
 .container {
   // same color as canvas-container
-  background-color: var(--ps-neutral-7);
+  background-color: var(--ps-neutral-9);
   // same border as canvas-container
-  border: 1px solid var(--ps-neutral-5);
+  border: 1px solid var(--ps-neutral-9);
 
   padding: 5px;
   margin: 5px;

--- a/webapp/javascript/components/ProfilerHeader.module.css
+++ b/webapp/javascript/components/ProfilerHeader.module.css
@@ -16,7 +16,7 @@
 
 .search {
   background: rgba(255, 255, 255, 0.8);
-  color: var(--ps-neutral-8);
+  color: var(--ps-neutral-10);
   transition: background-color ease-out 0.1s;
   margin-right: 8px;
 }

--- a/webapp/javascript/components/Settings/Settings.module.css
+++ b/webapp/javascript/components/Settings/Settings.module.css
@@ -33,7 +33,7 @@
   height: 4px;
   bottom: 6px;
   border-radius: 2px;
-  background: var(--ps-accent-1-3);
+  background: var(--ps-accent-1-4);
 }
 
 .settingsWrapper h1 {

--- a/webapp/javascript/components/Settings/Settings.module.css
+++ b/webapp/javascript/components/Settings/Settings.module.css
@@ -16,7 +16,7 @@
   padding: 10px 5px;
   text-decoration: none;
   position: relative;
-  color: var(--ps-neutral-19);
+  color: var(--ps-neutral-11);
 }
 
 .navLinkActive {

--- a/webapp/javascript/components/Settings/SettingsTable.module.css
+++ b/webapp/javascript/components/Settings/SettingsTable.module.css
@@ -18,7 +18,7 @@
 }
 
 .settingsTable tbody {
-  color: var(--ps-neutral-19);
+  color: var(--ps-neutral-11);
 }
 
 .settingsTable button {
@@ -26,5 +26,5 @@
 }
 
 .settingsTable tbody tr:nth-child(odd) {
-  background-color: var(--ps-neutral-17);
+  background-color: var(--ps-neutral-7);
 }

--- a/webapp/javascript/components/Settings/SettingsTable.module.css
+++ b/webapp/javascript/components/Settings/SettingsTable.module.css
@@ -26,5 +26,5 @@
 }
 
 .settingsTable tbody tr:nth-child(odd) {
-  background-color: var(--ps-neutral-7);
+  background-color: var(--ps-neutral-9);
 }

--- a/webapp/javascript/components/Settings/Users/Users.module.css
+++ b/webapp/javascript/components/Settings/Users/Users.module.css
@@ -18,7 +18,7 @@
 
 .usersTableEmptyMessage {
   text-align: center;
-  color: var(--ps-neutral-19);
+  color: var(--ps-neutral-11);
 }
 
 .actionContainer {

--- a/webapp/javascript/pages/IntroPages/IntroPages.module.css
+++ b/webapp/javascript/pages/IntroPages/IntroPages.module.css
@@ -20,8 +20,8 @@
   background-size: cover, auto, auto;
   background: radial-gradient(
       farthest-side at 0% 0%,
-      var(--ps-neutral-4) 60%,
-      var(--ps-neutral-3)
+      var(--ps-neutral-1) 60%,
+      var(--ps-neutral-1)
     ),
     url(data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.1%22%20x%3D%220%22%20y%3D%220%22%20width%3D%22160%22%20height%3D%2215%22%20viewBox%3D%220%200%20160%2015%22%20preserveAspectRatio%3D%22xMinYMin%22%3E%3Cpath%20fill%3D%22none%22%20stroke%3D%22%23000000%22%20stroke-opacity%3D%220.13%22%20stroke-miterlimit%3D%2210%22%20d%3D%22M0%200.5c26.7%200%2053.3%2014%2080%2014%2026.7%200%2053.3-14%2080-14M0-4.5c26.7%200%2053.3%2014%2080%2014%2026.7%200%2053.3-14%2080-14M0-9.5c26.7%200%2053.3%2014%2080%2014%2026.7%200%2053.3-14%2080-14M0%205.5c26.7%200%2053.3%2014%2080%2014%2026.7%200%2053.3-14%2080-14M0%2010.5c26.7%200%2053.3%2014%2080%2014%2026.7%200%2053.3-14%2080-14%22%2F%3E%3C%2Fsvg%3E),
     linear-gradient(180deg, var(--ps-accent-1-7) 0, var(--ps-accent-3-10) 100%)
@@ -37,7 +37,7 @@
   bottom: 0;
   background-image: radial-gradient(
     farthest-corner at 0% 0%,
-    var(--ps-neutral-4) 0%,
+    var(--ps-neutral-1) 0%,
     var(--ps-neutral-1)
   );
 
@@ -57,8 +57,8 @@
 .form {
   width: 450px;
   padding: 50px;
-  background-color: var(--ps-neutral-3);
-  box-shadow: 0 3px 30px 0 var(--ps-neutral-4);
+  background-color: var(--ps-neutral-1);
+  box-shadow: 0 3px 30px 0 var(--ps-neutral-1);
   border-radius: 10px;
   text-align: center;
   left: 0;

--- a/webapp/javascript/pages/IntroPages/IntroPages.module.css
+++ b/webapp/javascript/pages/IntroPages/IntroPages.module.css
@@ -96,7 +96,7 @@
   padding: 0.5em;
   border: none;
   border-radius: 4px;
-  background-color: var(--ps-accent-1-3);
+  background-color: var(--ps-accent-1-4);
   color: var(--ps-immutable-1);
   cursor: pointer;
   text-decoration: none;

--- a/webapp/javascript/pages/IntroPages/IntroPages.module.css
+++ b/webapp/javascript/pages/IntroPages/IntroPages.module.css
@@ -104,7 +104,7 @@
 }
 
 .buttonDark {
-  background-color: var(--ps-neutral-8);
+  background-color: var(--ps-neutral-10);
 }
 
 .button:hover {

--- a/webapp/javascript/pages/IntroPages/SignIn/buttons.module.css
+++ b/webapp/javascript/pages/IntroPages/SignIn/buttons.module.css
@@ -15,7 +15,7 @@
 }
 
 .buttonGithub:hover {
-  background-color: var(--ps-neutral-8);
+  background-color: var(--ps-neutral-10);
 }
 
 .buttonGitlab {

--- a/webapp/javascript/ui/Box.module.scss
+++ b/webapp/javascript/ui/Box.module.scss
@@ -1,6 +1,6 @@
 .box {
-  background-color: var(--ps-neutral-7);
-  border: 1px solid var(--ps-neutral-5);
+  background-color: var(--ps-neutral-9);
+  border: 1px solid var(--ps-neutral-9);
   border-radius: 4px;
 
   //  display: inline-block;

--- a/webapp/javascript/ui/Button.module.scss
+++ b/webapp/javascript/ui/Button.module.scss
@@ -33,7 +33,7 @@ $border-radius: 4px;
   }
 
   &:disabled {
-    color: var(--ps-neutral-16);
+    color: var(--ps-neutral-10);
     pointer-events: none;
   }
 }

--- a/webapp/javascript/ui/Button.module.scss
+++ b/webapp/javascript/ui/Button.module.scss
@@ -29,7 +29,7 @@ $border-radius: 4px;
   background: var(--ps-neutral-9);
 
   &:hover:not(:disabled) {
-    background-color: var(--ps-neutral-12);
+    background-color: var(--ps-neutral-10);
   }
 
   &:disabled {

--- a/webapp/javascript/ui/Button.module.scss
+++ b/webapp/javascript/ui/Button.module.scss
@@ -39,7 +39,7 @@ $border-radius: 4px;
 }
 
 .primary {
-  color: var(--ps-neutral-13) !important;
+  color: var(--ps-neutral-9) !important;
   background-color: var(--ps-accent-2-1);
   border-left-color: var(--ps-accent-2-1);
   border-right-color: var(--ps-accent-2-1);

--- a/webapp/javascript/ui/Button.module.scss
+++ b/webapp/javascript/ui/Button.module.scss
@@ -57,19 +57,19 @@ $border-radius: 4px;
 }
 
 .secondary {
-  background-color: var(--ps-accent-1-3);
-  border-left-color: var(--ps-accent-1-3);
-  border-right-color: var(--ps-accent-1-3);
-  border-top-color: var(--ps-accent-1-3);
-  border-bottom-color: var(--ps-accent-1-3);
+  background-color: var(--ps-accent-1-4);
+  border-left-color: var(--ps-accent-1-4);
+  border-right-color: var(--ps-accent-1-4);
+  border-top-color: var(--ps-accent-1-4);
+  border-bottom-color: var(--ps-accent-1-4);
   color: var(--ps-immutable-1);
 
   &:hover {
     background-color: var(--ps-accent-1-4);
   }
   &:disabled {
-    border-color: var(--ps-accent-1-6);
-    background-color: var(--ps-accent-1-6);
+    border-color: var(--ps-accent-1-4);
+    background-color: var(--ps-accent-1-4);
     pointer-events: none;
   }
 }

--- a/webapp/javascript/ui/Button.module.scss
+++ b/webapp/javascript/ui/Button.module.scss
@@ -47,11 +47,11 @@ $border-radius: 4px;
   border-bottom-color: var(--ps-accent-2-1);
 
   &:hover {
-    background-color: var(--ps-accent-2-2);
+    background-color: var(--ps-accent-2-1);
   }
   &:disabled {
-    border-color: var(--ps-accent-2-4);
-    background-color: var(--ps-accent-2-4);
+    border-color: var(--ps-accent-2-1);
+    background-color: var(--ps-accent-2-1);
     pointer-events: none;
   }
 }

--- a/webapp/javascript/ui/Dropdown.module.scss
+++ b/webapp/javascript/ui/Dropdown.module.scss
@@ -1,7 +1,7 @@
 @import '@szhsin/react-menu/dist/index.css';
 
 .dropdownMenu {
-  box-shadow: 0 2px 5px var(--ps-neutral-4);
+  box-shadow: 0 2px 5px var(--ps-neutral-1);
   padding: 0.25rem 0;
   background-color: var(--ps-neutral-9) !important;
   color: var(--ps-neutral-2) !important;

--- a/webapp/javascript/ui/Dropdown.module.scss
+++ b/webapp/javascript/ui/Dropdown.module.scss
@@ -13,7 +13,7 @@
 
   & li[class*='hover'],
   div[class*='hover'] {
-    background-color: var(--ps-neutral-14);
+    background-color: var(--ps-neutral-10);
   }
 
   [class*='rc-menu--open']:empty {
@@ -21,7 +21,7 @@
   }
 
   [class*='rc-menu__item active'] {
-    background-color: var(--ps-neutral-14);
+    background-color: var(--ps-neutral-10);
     color: var(--ps-accent-3-9);
   }
 

--- a/webapp/javascript/ui/Modals/Modal.module.css
+++ b/webapp/javascript/ui/Modals/Modal.module.css
@@ -1,5 +1,5 @@
 .popup {
-  background-color: var(--ps-neutral-7);
+  background-color: var(--ps-neutral-9);
 }
 
 .popup label {

--- a/webapp/javascript/ui/Sidebar.scss
+++ b/webapp/javascript/ui/Sidebar.scss
@@ -1,9 +1,9 @@
 // Unfortunately the lib uses SASS directly
 // So we can't use css modules
-$sidebar-bg-color: var(--ps-neutral-7);
+$sidebar-bg-color: var(--ps-neutral-9);
 $submenu-bg-color: transparent;
 $sidebar-color: var(--ps-neutral-11);
-$submenu-bg-color-collapsed: var(--ps-neutral-7);
+$submenu-bg-color-collapsed: var(--ps-neutral-9);
 $sidebar-width: 250px !default;
 $sidebar-collapsed-width: 54px !default;
 

--- a/webapp/javascript/ui/Sidebar.scss
+++ b/webapp/javascript/ui/Sidebar.scss
@@ -2,7 +2,7 @@
 // So we can't use css modules
 $sidebar-bg-color: var(--ps-neutral-7);
 $submenu-bg-color: transparent;
-$sidebar-color: var(--ps-neutral-19);
+$sidebar-color: var(--ps-neutral-11);
 $submenu-bg-color-collapsed: var(--ps-neutral-7);
 $sidebar-width: 250px !default;
 $sidebar-collapsed-width: 54px !default;

--- a/webapp/javascript/ui/Sidebar.scss
+++ b/webapp/javascript/ui/Sidebar.scss
@@ -36,7 +36,7 @@ $sidebar-collapsed-width: 54px !default;
 // when collapsed, highlight since there's nothing visible
 .pro-sidebar.collapsed .pro-menu-item.active,
 .pro-sidebar.collapsed .pro-sub-menu.pro-menu-item:hover {
-  background: var(--ps-neutral-8);
+  background: var(--ps-neutral-10);
   color: var(--ps-neutral-20);
 }
 
@@ -121,7 +121,7 @@ $sidebar-collapsed-width: 54px !default;
 .pro-sidebar .pro-menu .pro-menu-item.open,
 .pro-sidebar .pro-menu .pro-menu-item > .pro-inner-item:focus,
 .pro-sidebar .pro-menu .pro-menu-item {
-  color: var(--ps-neutral-15);
+  color: var(--ps-neutral-20);
 }
 .pro-sidebar
   .pro-menu

--- a/webapp/sass/common.scss
+++ b/webapp/sass/common.scss
@@ -47,8 +47,8 @@ tt {
     text-align: right;
     padding: 0px 10px;
 
-    border-left: 1px solid var(--ps-neutral-8);
-    border-bottom: 1px solid var(--ps-neutral-8);
+    border-left: 1px solid var(--ps-neutral-10);
+    border-bottom: 1px solid var(--ps-neutral-10);
     width: 150px;
     min-width: 150px;
     max-width: 150px;

--- a/webapp/sass/common.scss
+++ b/webapp/sass/common.scss
@@ -9,7 +9,7 @@ tt {
   border-radius: 3px;
   border: 1px solidver(--ps-gray-light-4);
   padding: 2px 4px;
-  background-color: var(--ps-neutral-18);
+  background-color: var(--ps-neutral-10);
 }
 
 .navbar {
@@ -61,7 +61,7 @@ tt {
     .sort-arrow {
       display: inline-block;
       border: 5px solid transparent;
-      border-top-color: var(--ps-neutral-18);
+      border-top-color: var(--ps-neutral-10);
       top: 3px;
       position: relative;
       margin-left: 7px;
@@ -77,7 +77,7 @@ tt {
     }
 
     span {
-      text-shadow: 0 0 2px var(--ps-neutral-4);
+      text-shadow: 0 0 2px var(--ps-neutral-1);
     }
 
     &:first-child {
@@ -110,7 +110,7 @@ tt {
   }
   tr th,
   tr:nth-child(2n) td {
-    background: var(--ps-neutral-17);
+    background: var(--ps-neutral-7);
   }
 
   td {

--- a/webapp/sass/common.scss
+++ b/webapp/sass/common.scss
@@ -110,7 +110,7 @@ tt {
   }
   tr th,
   tr:nth-child(2n) td {
-    background: var(--ps-neutral-7);
+    background: var(--ps-neutral-9);
   }
 
   td {

--- a/webapp/sass/components/button.scss
+++ b/webapp/sass/components/button.scss
@@ -19,8 +19,8 @@
   }
 
   &:disabled {
-    color: var(--ps-neutral-18);
-    color: 1px solid var(--ps-neutral-17);
+    color: var(--ps-neutral-10);
+    color: 1px solid var(--ps-neutral-7);
     pointer-events: none;
   }
 }

--- a/webapp/sass/components/button.scss
+++ b/webapp/sass/components/button.scss
@@ -20,7 +20,7 @@
 
   &:disabled {
     color: var(--ps-neutral-10);
-    color: 1px solid var(--ps-neutral-7);
+    color: 1px solid var(--ps-neutral-9);
     pointer-events: none;
   }
 }

--- a/webapp/sass/components/daterangepicker.scss
+++ b/webapp/sass/components/daterangepicker.scss
@@ -22,7 +22,7 @@
   }
 
   .drp-dropdown {
-    background-color: var(--ps-neutral-7);
+    background-color: var(--ps-neutral-9);
     display: none;
     position: absolute;
     top: 45px;

--- a/webapp/sass/components/daterangepicker.scss
+++ b/webapp/sass/components/daterangepicker.scss
@@ -76,7 +76,7 @@
     padding: 2px 0;
     // compensates for the negative margin in .drp-presets
     padding-left: 20px;
-    color: var(--ps-neutral-19);
+    color: var(--ps-neutral-11);
 
     // give some room between the text and the icon
     // https://web.dev/learn/css/logical-properties/#solving-the-icon-issue

--- a/webapp/sass/components/daterangepicker.scss
+++ b/webapp/sass/components/daterangepicker.scss
@@ -87,7 +87,7 @@
     &:hover,
     &.active {
       color: var(--ps-neutral-20);
-      background: var(--ps-neutral-14);
+      background: var(--ps-neutral-10);
     }
 
     &:hover {

--- a/webapp/sass/components/daterangepicker.scss
+++ b/webapp/sass/components/daterangepicker.scss
@@ -127,7 +127,7 @@
 
 // range picker custom styles
 .react-datepicker__day--in-range {
-  background-color: var(--ps-accent-1-2) !important;
+  background-color: var(--ps-accent-1-4) !important;
   color: var(--ps-neutral-20) !important;
 }
 .react-datepicker__day--in-selecting-range {
@@ -135,7 +135,7 @@
   color: var(--ps-neutral-1);
 }
 .react-datepicker__day--in-range:hover {
-  background-color: var(--ps-accent-1-2);
+  background-color: var(--ps-accent-1-4);
   color: var(--ps-neutral-20);
 }
 

--- a/webapp/sass/components/tagsbar.scss
+++ b/webapp/sass/components/tagsbar.scss
@@ -53,7 +53,7 @@
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
     caret-color: var(--ps-neutral-20);
-    background-color: var(--ps-accent-1-3);
+    background-color: var(--ps-accent-1-4);
     border-color: darken(#0074d9, 10%);
     letter-spacing: 0;
     font-family: arial;

--- a/webapp/sass/profile.scss
+++ b/webapp/sass/profile.scss
@@ -180,7 +180,7 @@ $pane-width: 6px;
 }
 
 .right-instructions-text {
-  color: var(--ps-accent-1-5);
+  color: var(--ps-accent-1-4);
   font-size: 12px;
 }
 

--- a/webapp/sass/profile.scss
+++ b/webapp/sass/profile.scss
@@ -23,7 +23,7 @@ body {
   font: 400 16px/1.7 -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica,
     Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 
-  background-color: var(--ps-neutral-6);
+  background-color: var(--ps-neutral-9);
   color: var(--ps-neutral-20);
   -webkit-font-smoothing: antialiased;
 }

--- a/webapp/sass/variables.css
+++ b/webapp/sass/variables.css
@@ -8,7 +8,6 @@
   --ps-neutral-9: #272727;
   --ps-neutral-10: #4d4d4d;
   --ps-neutral-11: #aaaaaa;
-  --ps-neutral-12: #414141;
   --ps-neutral-13: #222222;
   --ps-neutral-14: #3b3b3b;
   --ps-neutral-15: #d8d8d8;

--- a/webapp/sass/variables.css
+++ b/webapp/sass/variables.css
@@ -49,24 +49,24 @@
 
 [data-theme='light'],
 [data-flamegraph-color-mode='light'] {
-  --ps-neutral-1: #ffffff;
-  --ps-neutral-2: #000000;
-  --ps-neutral-3: #ffffff99;
-  --ps-neutral-4: #ffffff54;
-  --ps-neutral-5: #ebebeb;
-  --ps-neutral-6: #e4e4e4;
-  --ps-neutral-7: #dededb;
-  --ps-neutral-8: #cccccc;
-  --ps-neutral-9: #d8d8d8;
-  --ps-neutral-10: #b2b2b2;
-  --ps-neutral-11: #555555;
-  --ps-neutral-12: #bebebe;
-  --ps-neutral-13: #dddddd;
-  --ps-neutral-14: #c4c4c4;
-  --ps-neutral-15: #272727;
-  --ps-neutral-16: #0000004c;
-  --ps-neutral-17: #00000008;
-  --ps-neutral-18: #00000054;
-  --ps-neutral-19: #000000a8;
-  --ps-neutral-20: #191919;
+  --ps-light-neutral-1: #ffffff;
+  --ps-light-neutral-2: #000000;
+  --ps-light-neutral-3: #ffffff99;
+  --ps-light-neutral-4: #ffffff54;
+  --ps-light-neutral-5: #ebebeb;
+  --ps-light-neutral-6: #e4e4e4;
+  --ps-light-neutral-7: #dededb;
+  --ps-light-neutral-8: #cccccc;
+  --ps-light-neutral-9: #d8d8d8;
+  --ps-light-neutral-10: #b2b2b2;
+  --ps-light-neutral-11: #555555;
+  --ps-light-neutral-12: #bebebe;
+  --ps-light-neutral-13: #dddddd;
+  --ps-light-neutral-14: #c4c4c4;
+  --ps-light-neutral-15: #272727;
+  --ps-light-neutral-16: #0000004c;
+  --ps-light-neutral-17: #00000008;
+  --ps-light-neutral-18: #00000054;
+  --ps-light-neutral-19: #000000a8;
+  --ps-light-neutral-20: #191919;
 }

--- a/webapp/sass/variables.css
+++ b/webapp/sass/variables.css
@@ -1,9 +1,6 @@
 :root {
   --ps-neutral-1: #000000;
   --ps-neutral-2: #ffffff;
-  --ps-neutral-5: #141414;
-  --ps-neutral-6: #1b1b1b;
-  --ps-neutral-7: #212124;
   --ps-neutral-8: #333333;
   --ps-neutral-9: #272727;
   --ps-neutral-10: #4d4d4d;

--- a/webapp/sass/variables.css
+++ b/webapp/sass/variables.css
@@ -6,12 +6,8 @@
   --ps-neutral-11: #aaaaaa;
   --ps-neutral-20: #e6e6e6;
 
-  --ps-accent-1-1: #1d49a1;
-  --ps-accent-1-2: #216ba5;
-  --ps-accent-1-3: #0074d9;
+  --ps-accent-1-1: #1d49a1; /* hover */
   --ps-accent-1-4: #0d8eff;
-  --ps-accent-1-5: #1398f6;
-  --ps-accent-1-6: #40a6ff;
   --ps-accent-1-7: #3dc1d3cc;
 
   --ps-accent-2-1: #2ecc40;

--- a/webapp/sass/variables.css
+++ b/webapp/sass/variables.css
@@ -1,13 +1,9 @@
 :root {
   --ps-neutral-1: #000000;
   --ps-neutral-2: #ffffff;
-  --ps-neutral-8: #333333;
   --ps-neutral-9: #272727;
   --ps-neutral-10: #4d4d4d;
   --ps-neutral-11: #aaaaaa;
-  --ps-neutral-13: #222222;
-  --ps-neutral-14: #3b3b3b;
-  --ps-neutral-15: #d8d8d8;
   --ps-neutral-20: #e6e6e6;
 
   --ps-accent-1-1: #1d49a1;
@@ -39,24 +35,10 @@
 
 [data-theme='light'],
 [data-flamegraph-color-mode='light'] {
-  --ps-light-neutral-1: #ffffff;
-  --ps-light-neutral-2: #000000;
-  --ps-light-neutral-3: #ffffff99;
-  --ps-light-neutral-4: #ffffff54;
-  --ps-light-neutral-5: #ebebeb;
-  --ps-light-neutral-6: #e4e4e4;
-  --ps-light-neutral-7: #dededb;
-  --ps-light-neutral-8: #cccccc;
-  --ps-light-neutral-9: #d8d8d8;
-  --ps-light-neutral-10: #b2b2b2;
-  --ps-light-neutral-11: #555555;
-  --ps-light-neutral-12: #bebebe;
-  --ps-light-neutral-13: #dddddd;
-  --ps-light-neutral-14: #c4c4c4;
-  --ps-light-neutral-15: #272727;
-  --ps-light-neutral-16: #0000004c;
-  --ps-light-neutral-17: #00000008;
-  --ps-light-neutral-18: #00000054;
-  --ps-light-neutral-19: #000000a8;
-  --ps-light-neutral-20: #191919;
+  --ps-neutral-1: #ffffff;
+  --ps-neutral-2: #000000;
+  --ps-neutral-9: #d8d8d8;
+  --ps-neutral-10: #b2b2b2;
+  --ps-neutral-11: #555555;
+  --ps-neutral-20: #191919;
 }

--- a/webapp/sass/variables.css
+++ b/webapp/sass/variables.css
@@ -11,9 +11,7 @@
   --ps-accent-1-7: #3dc1d3cc;
 
   --ps-accent-2-1: #2ecc40;
-  --ps-accent-2-2: #54d964;
   --ps-accent-2-3: #28a745;
-  --ps-accent-2-4: #7ee289;
 
   --ps-accent-3-1: #8a1722;
   --ps-accent-3-2: #dc3545;

--- a/webapp/sass/variables.css
+++ b/webapp/sass/variables.css
@@ -1,8 +1,6 @@
 :root {
   --ps-neutral-1: #000000;
   --ps-neutral-2: #ffffff;
-  --ps-neutral-3: #00000099;
-  --ps-neutral-4: #00000054;
   --ps-neutral-5: #141414;
   --ps-neutral-6: #1b1b1b;
   --ps-neutral-7: #212124;
@@ -14,10 +12,6 @@
   --ps-neutral-13: #222222;
   --ps-neutral-14: #3b3b3b;
   --ps-neutral-15: #d8d8d8;
-  --ps-neutral-16: #ffffff4c;
-  --ps-neutral-17: #ffffff08;
-  --ps-neutral-18: #ffffff54;
-  --ps-neutral-19: #ffffffa8;
   --ps-neutral-20: #e6e6e6;
 
   --ps-accent-1-1: #1d49a1;


### PR DESCRIPTION
We have a ton of a pretty identical colors and in #1103 we started adding the ability for light mode. This PR is to start consolidating those colors so that we have a reasonable range (i.e. 5-10 colors total) throughout the UI. 

The goal is to make the UI color scheme as minimal as possible. I likely will accidentally get rid of some colors (i.e. hover colors or something) which were meant to be slightly off, but I think we can go back and fix those over time if they are missed in this PR