### PR TITLE
Fix derived field in exemplar example for Loki

### DIFF
--- a/examples/tracing/jaeger/grafana/provisioning/datasources/datasources.yml
+++ b/examples/tracing/jaeger/grafana/provisioning/datasources/datasources.yml
@@ -28,3 +28,7 @@ datasources:
           matcherRegex: "trace_id=(\\w+)"
           url: '$${__value.raw}'
           datasourceUid: jaeger
+        - name: 'profileExemplar'
+          matcherRegex: "trace_id=(\\w+)"
+          url: 'ride-sharing-app.cpu{profile_id=${__value.raw}}'
+          datasourceUid: pyroscope

--- a/examples/tracing/jaeger/grafana/provisioning/datasources/datasources.yml
+++ b/examples/tracing/jaeger/grafana/provisioning/datasources/datasources.yml
@@ -29,6 +29,6 @@ datasources:
           url: '$${__value.raw}'
           datasourceUid: jaeger
         - name: 'profileExemplar'
-          matcherRegex: "trace_id=(\\w+)"
-          url: 'ride-sharing-app.cpu{profile_id=${__value.raw}}'
+          matcherRegex: "span_id=(\\w+)"
+          url: 'ride-sharing-app.cpu{profile_id="$${__value.raw}"}'
           datasourceUid: pyroscope

--- a/examples/tracing/jaeger/main.go
+++ b/examples/tracing/jaeger/main.go
@@ -12,19 +12,26 @@ import (
 	"rideshare/car"
 	"rideshare/rideshare"
 	"rideshare/scooter"
+	rlog "rideshare/log"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 func bikeRoute(_ http.ResponseWriter, r *http.Request) {
+	logger := rlog.Logger(r.Context())
+	logger.Info("Ordering nearest bike")
 	bike.OrderBike(r.Context(), 1)
 }
 
 func scooterRoute(_ http.ResponseWriter, r *http.Request) {
+	logger := rlog.Logger(r.Context())
+	logger.Info("Ordering nearest scooter")
 	scooter.OrderScooter(r.Context(), 2)
 }
 
 func carRoute(_ http.ResponseWriter, r *http.Request) {
+	logger := rlog.Logger(r.Context())
+	logger.Info("Ordering nearest car")
 	car.OrderCar(r.Context(), 3)
 }
 

--- a/examples/tracing/jaeger/ride/ride.go
+++ b/examples/tracing/jaeger/ride/ride.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	// "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -17,12 +17,6 @@ func FindNearestVehicle(ctx context.Context, searchRadius int64, vehicle string)
 	span.SetAttributes(attribute.String("vehicle", vehicle))
 	defer span.End()
 
-	logger := log.Logger(ctx).WithFields(logrus.Fields{
-		"radius":  searchRadius,
-		"vehicle": vehicle,
-	})
-
-	logger.Info("looking for nearest vehicle")
 	burnCPU(searchRadius)
 	if vehicle == "car" {
 		checkDriverAvailability(ctx, searchRadius)


### PR DESCRIPTION
Fixes derived field for loki integration and logs root span only (since that's where profiles are available) 