### PR TITLE
fix: infinite loop when no apps are available

### DIFF
--- a/webapp/javascript/components/Continuous.tsx
+++ b/webapp/javascript/components/Continuous.tsx
@@ -18,24 +18,15 @@ export default function Continuous({
   const selectedAppName = useAppSelector(selectApplicationName);
 
   useEffect(() => {
-    async function loadAppNames() {
-      if (appNames.length <= 0) {
-        try {
-          // Load application names
-          const names = await dispatch(reloadAppNames()).unwrap();
+    dispatch(reloadAppNames());
+  }, [dispatch]);
 
-          // Pick the first one if there's nothing selected
-          if (!selectedAppName && names.length > 0) {
-            dispatch(setQuery(queryFromAppName(names[0])));
-          }
-        } catch (e) {
-          console.error(e);
-        }
-      }
+  // Pick the first one if there's nothing selected
+  useEffect(() => {
+    if (!selectedAppName && appNames.length > 0) {
+      dispatch(setQuery(queryFromAppName(appNames[0])));
     }
-
-    loadAppNames();
-  }, []);
+  }, [appNames, selectedAppName]);
 
   return children;
 }

--- a/webapp/javascript/components/Continuous.tsx
+++ b/webapp/javascript/components/Continuous.tsx
@@ -35,7 +35,7 @@ export default function Continuous({
     }
 
     loadAppNames();
-  }, [dispatch, appNames, selectedAppName]);
+  }, []);
 
   return children;
 }


### PR DESCRIPTION
This fixes an issue where if you don't have any apps it will have an infinite loop trying to get app names.

To reproduce, run  something like:
```
rm -rf tmp/pyroscope-storage
PYROSCOPE_NO_SELF_PROFILING=true make dev
```

I think this PR fixes it.  @eh-am I'm not sure if this is the right fix, please review.