### PR TITLE
fix(webapp): fix border of <input> element

### DIFF
--- a/webapp/sass/common.scss
+++ b/webapp/sass/common.scss
@@ -1,3 +1,6 @@
+@use './mixins/outline' as *;
+@import './variables.scss';
+
 pre,
 code,
 tt {
@@ -175,4 +178,11 @@ tt {
       border-radius: 0 4px 4px 0;
     }
   }
+}
+
+// TODO(eh-am): use ui/Input
+input {
+  @include outline;
+  border-radius: 4px;
+  border: 1px solid $btn-border-color;
 }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/6951209/172233711-12aa512e-ba4b-4c07-ab40-5dee271bb1f9.png)

After:
![image](https://user-images.githubusercontent.com/6951209/172233683-f2d85163-723a-4a9e-8464-552d6993401d.png)

Related to https://github.com/pyroscope-io/pyroscope/issues/1126

Ideally we would update all `<input>` usages to use the ui/Input component instead, hence why I am leaving that issue open

