### PR TITLE
docs: remove extra logging from exemplars

### DIFF
--- a/examples/tracing/jaeger/ride/ride.go
+++ b/examples/tracing/jaeger/ride/ride.go
@@ -33,10 +33,9 @@ func checkBikeAvailability(ctx context.Context, n int64) {
 
 	region := os.Getenv("REGION")
 	logger := log.Logger(ctx).WithField("region", region)
-	logger.Info("checking for bike availability")
+	// logger.Info("checking for bike availability")
 
 	burnCPU(n * 3)
-	logger.Info("bike found")
 }
 
 func checkDriverAvailability(ctx context.Context, n int64) {
@@ -45,7 +44,7 @@ func checkDriverAvailability(ctx context.Context, n int64) {
 
 	region := os.Getenv("REGION")
 	logger := log.Logger(ctx).WithField("region", region)
-	logger.Info("checking for driver availability")
+	// logger.Info("checking for driver availability")
 
 	burnCPU(n / 2)
 	// Every 4 minutes this will artificially make requests in us-west-1 region slow
@@ -55,7 +54,7 @@ func checkDriverAvailability(ctx context.Context, n int64) {
 		burnCPU(n * 2)
 	}
 
-	logger.Info("vehicle found")
+	// logger.Info("vehicle found")
 }
 
 func burnCPU(n int64) {


### PR DESCRIPTION
Removes (comments out) extra logging for POC of derived fields in loki