### PR TITLE
feat: multiple remote write targets

### DIFF
--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -294,6 +294,15 @@ var _ = Describe("flags", func() {
 					},
 					AdminSocketPath: "/tmp/pyroscope.sock",
 
+					RemoteWrite: config.RemoteWrite{
+						Enabled: true,
+						Targets: []config.RemoteWriteTarget{
+							{
+								Address: "https://pyroscope.io",
+							},
+						},
+					},
+
 					ScrapeConfigs: []*scrape.Config{
 						{
 							JobName:          "testing",

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -296,11 +296,6 @@ var _ = Describe("flags", func() {
 
 					RemoteWrite: config.RemoteWrite{
 						Enabled: true,
-						Targets: []config.RemoteWriteTarget{
-							{
-								Address: "https://pyroscope.io",
-							},
-						},
 					},
 
 					ScrapeConfigs: []*scrape.Config{

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -164,7 +164,8 @@ func newServerService(c *config.Server) (*serverService, error) {
 		}
 
 		remoteClients := make([]ingestion.Ingester, len(svc.config.RemoteWrite.Targets))
-		for i, t := range svc.config.RemoteWrite.Targets {
+		i := 0
+		for _, t := range svc.config.RemoteWrite.Targets {
 			logrus.Debugf("Instantiating remote write client for target %s", t.Address)
 			cfg := config.RemoteWriteTarget{
 				Address:   t.Address,
@@ -172,6 +173,7 @@ func newServerService(c *config.Server) (*serverService, error) {
 				Timeout:   t.Timeout,
 			}
 			remoteClients[i] = remotewrite.NewClient(logger, cfg)
+			i++
 		}
 
 		ingester = remotewrite.NewParallelizer(svc.logger, remoteClients...)
@@ -383,7 +385,7 @@ func loadRemoteWriteTargetConfigsFromFile(c *config.Server) error {
 
 	type cfg struct {
 		RemoteWrite struct {
-			Targets []config.RemoteWriteTarget `yaml:"targets" mapstructure:"-"`
+			Targets map[string]config.RemoteWriteTarget `yaml:"targets" mapstructure:"-"`
 		} `yaml:"remote-write"`
 	}
 

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -14,6 +14,7 @@ import (
 
 	// revive:disable:blank-imports register discoverer
 	"github.com/pyroscope-io/pyroscope/pkg/baseurl"
+	"github.com/pyroscope-io/pyroscope/pkg/remotewrite"
 	_ "github.com/pyroscope-io/pyroscope/pkg/scrape/discovery/file"
 	_ "github.com/pyroscope-io/pyroscope/pkg/scrape/discovery/http"
 	_ "github.com/pyroscope-io/pyroscope/pkg/scrape/discovery/kubernetes"
@@ -26,7 +27,6 @@ import (
 	"github.com/pyroscope-io/pyroscope/pkg/health"
 	"github.com/pyroscope-io/pyroscope/pkg/ingestion"
 	"github.com/pyroscope-io/pyroscope/pkg/parser"
-	"github.com/pyroscope-io/pyroscope/pkg/remotewrite"
 	"github.com/pyroscope-io/pyroscope/pkg/scrape"
 	sc "github.com/pyroscope-io/pyroscope/pkg/scrape/config"
 	"github.com/pyroscope-io/pyroscope/pkg/scrape/discovery"
@@ -154,6 +154,11 @@ func newServerService(c *config.Server) (*serverService, error) {
 
 	// If remote write is available, let's write to both local storage and to the remote server
 	if svc.config.RemoteWrite.Enabled {
+		err = loadRemoteWriteTargetConfigsFromFile(svc.config)
+		if err != nil {
+			return nil, err
+		}
+
 		if len(svc.config.RemoteWrite.Targets) <= 0 {
 			return nil, fmt.Errorf("remote write is enabled but no targets are set up")
 		}
@@ -161,7 +166,12 @@ func newServerService(c *config.Server) (*serverService, error) {
 		remoteClients := make([]ingestion.Ingester, len(svc.config.RemoteWrite.Targets))
 		for i, t := range svc.config.RemoteWrite.Targets {
 			logrus.Debugf("Instantiating remote write client for target %s", t.Address)
-			remoteClients[i] = remotewrite.NewClient(logger, t)
+			cfg := config.RemoteWriteTarget{
+				Address:   t.Address,
+				AuthToken: t.AuthToken,
+				Timeout:   t.Timeout,
+			}
+			remoteClients[i] = remotewrite.NewClient(logger, cfg)
 		}
 
 		ingester = remotewrite.NewParallelizer(svc.logger, remoteClients...)
@@ -358,5 +368,30 @@ func loadScrapeConfigsFromFile(c *config.Server) error {
 	}
 	// Populate scrape configs.
 	c.ScrapeConfigs = s.ScrapeConfigs
+	return nil
+}
+
+func loadRemoteWriteTargetConfigsFromFile(c *config.Server) error {
+	b, err := os.ReadFile(c.Config)
+	switch {
+	case err == nil:
+	case os.IsNotExist(err):
+		return nil
+	default:
+		return err
+	}
+
+	type cfg struct {
+		RemoteWrite struct {
+			Targets []config.RemoteWriteTarget `yaml:"targets" mapstructure:"-"`
+		} `yaml:"remote-write"`
+	}
+
+	var s cfg
+	if err = yaml.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	c.RemoteWrite.Targets = s.RemoteWrite.Targets
 	return nil
 }

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -155,7 +155,7 @@ func newServerService(c *config.Server) (*serverService, error) {
 	// If remote write is available, let's write to both local storage and to the remote server
 	if svc.config.RemoteWrite.Enabled {
 		if len(svc.config.RemoteWrite.Targets) <= 0 {
-			return nil, fmt.Errorf("remote write is enabled but no targets are set up.")
+			return nil, fmt.Errorf("remote write is enabled but no targets are set up")
 		}
 
 		remoteClients := make([]ingestion.Ingester, len(svc.config.RemoteWrite.Targets))

--- a/pkg/cli/testdata/server.yml
+++ b/pkg/cli/testdata/server.yml
@@ -22,8 +22,6 @@ scrape-configs:
 
 remote-write:
   enabled: true
-  targets:
-    - address: https://pyroscope.io
 
 auth:
   signup-default-role: admin

--- a/pkg/cli/testdata/server.yml
+++ b/pkg/cli/testdata/server.yml
@@ -20,6 +20,11 @@ scrape-configs:
         labels:
           foo: bar
 
+remote-write:
+  enabled: true
+  targets:
+    - address: https://pyroscope.io
+
 auth:
   signup-default-role: admin
   cookie-same-site: strict

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -359,7 +359,15 @@ type Database struct {
 type RemoteWrite struct {
 	Enabled bool `def:"false" desc:"EXPERIMENTAL! the API will change, use at your own risk. whether to enable remote write or not"`
 
+	Targets []RemoteWriteTarget `yaml:"targets" desc:"list of remote targets" mapstructure:"targets"`
+
 	Address   string            `def:"" desc:"server that implements the pyroscope /ingest endpoint" mapstructure:"address"`
+	AuthToken string            `def:"" desc:"authorization token used to upload profiling data" mapstructure:"auth-token"`
+	Tags      map[string]string `name:"" def:"" desc:"tag in key=value form. The flag may be specified multiple times" mapstructure:"tags"`
+}
+
+type RemoteWriteTarget struct {
+	Address   string            `def:"address" desc:"server that implements the pyroscope /ingest endpoint" mapstructure:"address"`
 	AuthToken string            `def:"" desc:"authorization token used to upload profiling data" mapstructure:"auth-token"`
 	Tags      map[string]string `name:"tag" def:"" desc:"tag in key=value form. The flag may be specified multiple times" mapstructure:"tags"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -370,4 +370,5 @@ type RemoteWriteTarget struct {
 	Address   string            `def:"address" desc:"server that implements the pyroscope /ingest endpoint" mapstructure:"address"`
 	AuthToken string            `def:"" desc:"authorization token used to upload profiling data" mapstructure:"auth-token"`
 	Tags      map[string]string `name:"tag" def:"" desc:"tag in key=value form. The flag may be specified multiple times" mapstructure:"tags"`
+	Timeout   time.Duration     `def:"30s" desc:"profile upload timeout" mapstructure:"timeout"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -360,15 +360,11 @@ type RemoteWrite struct {
 	Enabled bool `def:"false" desc:"EXPERIMENTAL! the API will change, use at your own risk. whether to enable remote write or not"`
 
 	Targets []RemoteWriteTarget `yaml:"targets" desc:"list of remote targets" mapstructure:"targets"`
-
-	Address   string            `def:"" desc:"server that implements the pyroscope /ingest endpoint" mapstructure:"address"`
-	AuthToken string            `def:"" desc:"authorization token used to upload profiling data" mapstructure:"auth-token"`
-	Tags      map[string]string `name:"" def:"" desc:"tag in key=value form. The flag may be specified multiple times" mapstructure:"tags"`
 }
 
 type RemoteWriteTarget struct {
-	Address   string            `def:"address" desc:"server that implements the pyroscope /ingest endpoint" mapstructure:"address"`
-	AuthToken string            `def:"" desc:"authorization token used to upload profiling data" mapstructure:"auth-token"`
-	Tags      map[string]string `name:"tag" def:"" desc:"tag in key=value form. The flag may be specified multiple times" mapstructure:"tags"`
+	Address   string            `desc:"server that implements the pyroscope /ingest endpoint" mapstructure:"address"`
+	AuthToken string            `desc:"authorization token used to upload profiling data" mapstructure:"auth-token"`
+	Tags      map[string]string `name:"tag" desc:"tag in key=value form. The flag may be specified multiple times" mapstructure:"tags"`
 	Timeout   time.Duration     `def:"30s" desc:"profile upload timeout" mapstructure:"timeout"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -359,7 +359,8 @@ type Database struct {
 type RemoteWrite struct {
 	Enabled bool `def:"false" desc:"EXPERIMENTAL! the API will change, use at your own risk. whether to enable remote write or not"`
 
-	Targets []RemoteWriteTarget `yaml:"targets" desc:"list of remote targets" mapstructure:"targets"`
+	// see loadRemoteWriteTargetConfigsFromFile in server.go
+	Targets []RemoteWriteTarget `yaml:"scrape-configs" mapstructure:"-"`
 }
 
 type RemoteWriteTarget struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -360,7 +360,7 @@ type RemoteWrite struct {
 	Enabled bool `def:"false" desc:"EXPERIMENTAL! the API will change, use at your own risk. whether to enable remote write or not"`
 
 	// see loadRemoteWriteTargetConfigsFromFile in server.go
-	Targets []RemoteWriteTarget `yaml:"scrape-configs" mapstructure:"-"`
+	Targets map[string]RemoteWriteTarget `yaml:"scrape-configs" mapstructure:"-"`
 }
 
 type RemoteWriteTarget struct {

--- a/pkg/remotewrite/client.go
+++ b/pkg/remotewrite/client.go
@@ -26,11 +26,11 @@ var (
 
 type Client struct {
 	log    *logrus.Logger
-	config config.RemoteWrite
+	config config.RemoteWriteTarget
 	client *http.Client
 }
 
-func NewClient(logger *logrus.Logger, cfg config.RemoteWrite) *Client {
+func NewClient(logger *logrus.Logger, cfg config.RemoteWriteTarget) *Client {
 	client := &http.Client{
 		// TODO(eh-am): make timeout configurable
 		Timeout: time.Second * 15,

--- a/pkg/remotewrite/client.go
+++ b/pkg/remotewrite/client.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strconv"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/sirupsen/logrus"
@@ -32,8 +31,7 @@ type Client struct {
 
 func NewClient(logger *logrus.Logger, cfg config.RemoteWriteTarget) *Client {
 	client := &http.Client{
-		// TODO(eh-am): make timeout configurable
-		Timeout: time.Second * 15,
+		Timeout: cfg.Timeout,
 	}
 
 	return &Client{

--- a/pkg/remotewrite/client_test.go
+++ b/pkg/remotewrite/client_test.go
@@ -33,7 +33,7 @@ var _ = Describe("TrafficShadower", func() {
 	Context("happy path", func() {
 		var remoteHandler http.HandlerFunc
 		var wg sync.WaitGroup
-		var cfg config.RemoteWrite
+		var cfg config.RemoteWriteTarget
 		var in ingestion.IngestInput
 
 		BeforeEach(func() {
@@ -180,7 +180,7 @@ var _ = Describe("TrafficShadower", func() {
 	Context("sad path", func() {
 		When("it can't convert PutInput into a http.Request", func() {
 			It("fails with ErrConvertPutInputToRequest", func() {
-				client := remotewrite.NewClient(logger, config.RemoteWrite{
+				client := remotewrite.NewClient(logger, config.RemoteWriteTarget{
 					Address: "%%",
 				})
 				in := ingestion.IngestInput{
@@ -199,7 +199,7 @@ var _ = Describe("TrafficShadower", func() {
 
 		When("it can't send to remote", func() {
 			It("fails with ErrMakingRequest", func() {
-				client := remotewrite.NewClient(logger, config.RemoteWrite{
+				client := remotewrite.NewClient(logger, config.RemoteWriteTarget{
 					Address: "//inexistent-url",
 				})
 				in := ingestion.IngestInput{
@@ -233,7 +233,7 @@ var _ = Describe("TrafficShadower", func() {
 					}),
 				)
 
-				client := remotewrite.NewClient(logger, config.RemoteWrite{
+				client := remotewrite.NewClient(logger, config.RemoteWriteTarget{
 					Address: remoteServer.URL,
 				})
 				in := ingestion.IngestInput{
@@ -259,37 +259,4 @@ var _ = Describe("TrafficShadower", func() {
 			})
 		})
 	})
-
-	//	Context("formats", func() {
-	//		When("format is not supported", func() {
-	//			//			BeforeEach(func() {
-	//			//				pi.Format = "unsupported"
-	//			//			})
-	//
-	//			It("fails with ErrConvertPutInputToRequest and ErrUnsupportedFormat", func() {
-	//				client := remotewrite.NewClient(logger, config.RemoteWrite{
-	//					Address: "https://www.example.com",
-	//				})
-	//				pi := parser.PutInput{
-	//					Key: segment.NewKey(map[string]string{
-	//						"__name__": "myapp",
-	//					}),
-	//
-	//					Format:          "unsupported",
-	//					StartTime:       attime.Parse("1654110240"),
-	//					EndTime:         attime.Parse("1654110250"),
-	//					SampleRate:      100,
-	//					SpyName:         "gospy",
-	//					Units:           metadata.SamplesUnits,
-	//					AggregationType: metadata.SumAggregationType,
-	//					Profile:         strings.NewReader(""),
-	//				}
-	//
-	//				err := client.Put(context.TODO(), &pi)
-	//				Expect(err).To(MatchError(remotewrite.ErrUnsupportedFormat))
-	//				Expect(err).To(MatchError(remotewrite.ErrConvertPutInputToRequest))
-	//			})
-	//		})
-	//	})
-
 })


### PR DESCRIPTION
Allow writing to multiple targets.

Config example:
```yaml
remote-write:
  enabled: true

  targets:
    bar:
      address: http://localhost:4050
      auth-token: "mytoken"
      tags:
        foo: bar
    baz:
      address: http://localhost:4060
      auth-token: "mytoken"
      tags:
        foo: baz
```

There's a somewhat relevant point here: we are using maps instead of arrays due to how maps are easier to merge.