### PR TITLE
refactor(webapp): Text Input as standalone component

### DIFF
--- a/webapp/javascript/components/NameSelector.module.scss
+++ b/webapp/javascript/components/NameSelector.module.scss
@@ -2,14 +2,7 @@
 
 .container {
   display: flex;
-
-  // vertical align
   align-items: center;
-
-  input {
-    @include outline;
-    border-radius: 4px;
-  }
 }
 
 .menuButton {

--- a/webapp/javascript/components/NameSelector.tsx
+++ b/webapp/javascript/components/NameSelector.tsx
@@ -17,6 +17,7 @@ import Dropdown, {
   FocusableItem,
   MenuGroup,
 } from '@webapp/ui/Dropdown';
+import Input from '@webapp/ui/Input';
 import { queryFromAppName, queryToAppName, Query } from '@webapp/models/query';
 import styles from './NameSelector.module.scss';
 
@@ -83,7 +84,8 @@ function NameSelector({ onSelectedName }: NameSelectorProps) {
         {noApp}
         <FocusableItem>
           {({ ref }) => (
-            <input
+            <Input
+              name="application seach"
               ref={ref}
               type="text"
               placeholder="Type an app"

--- a/webapp/javascript/components/Settings/APIKeys/APIKeyAddForm.tsx
+++ b/webapp/javascript/components/Settings/APIKeys/APIKeyAddForm.tsx
@@ -118,6 +118,7 @@ function APIKeyAddForm() {
               name="ttlSeconds"
               value={form.ttlSeconds}
               onChange={handleFormChange}
+              type="number"
             />
             <div>
               <Button icon={faCheck} type="submit" kind="secondary">

--- a/webapp/javascript/components/Settings/Security/ChangePasswordForm.tsx
+++ b/webapp/javascript/components/Settings/Security/ChangePasswordForm.tsx
@@ -66,6 +66,7 @@ function ChangePasswordForm(props: ShamefulAny) {
             name="oldPassword"
             required
             onChange={handleChange}
+            value={form.oldPassword}
           />
           <InputField
             label="New password"
@@ -74,6 +75,7 @@ function ChangePasswordForm(props: ShamefulAny) {
             name="password"
             required
             onChange={handleChange}
+            value={form.password}
           />
           <InputField
             label="Confirm new password"
@@ -82,6 +84,7 @@ function ChangePasswordForm(props: ShamefulAny) {
             name="passwordAgain"
             required
             onChange={handleChange}
+            value={form.passwordAgain}
           />
           <Button type="submit" kind="secondary">
             Save

--- a/webapp/javascript/components/Settings/Users/UserAddForm.tsx
+++ b/webapp/javascript/components/Settings/Users/UserAddForm.tsx
@@ -62,6 +62,7 @@ function UserAddForm() {
           name="name"
           value={form.name}
           onChange={handleFormChange}
+          type="text"
         />
         <InputField
           label="Email"
@@ -69,6 +70,7 @@ function UserAddForm() {
           name="email"
           value={form.email}
           onChange={handleFormChange}
+          type="text"
         />
         <InputField
           label="Full name"
@@ -76,6 +78,7 @@ function UserAddForm() {
           name="fullName"
           value={form.fullName}
           onChange={handleFormChange}
+          type="text"
         />
         <InputField
           label="Password"
@@ -83,6 +86,7 @@ function UserAddForm() {
           name="password"
           type="password"
           onChange={handleFormChange}
+          value={form.password}
         />
         <div>
           <Button

--- a/webapp/javascript/components/Settings/Users/Users.module.css
+++ b/webapp/javascript/components/Settings/Users/Users.module.css
@@ -1,10 +1,6 @@
 .searchContainer {
   display: flex;
-}
-
-.searchContainer input {
-  flex: 1;
-  margin-right: 20px;
+  flex-direction: column;
 }
 
 .searchContainer button {

--- a/webapp/javascript/components/Settings/Users/index.tsx
+++ b/webapp/javascript/components/Settings/Users/index.tsx
@@ -15,6 +15,7 @@ import {
 import { selectCurrentUser } from '@webapp/redux/reducers/user';
 import { addNotification } from '@webapp/redux/reducers/notifications';
 import { type User } from '@webapp/models/users';
+import Input from '@webapp/ui/Input';
 import UserTableItem from './UserTableItem';
 
 import userStyles from './Users.module.css';
@@ -97,11 +98,12 @@ function Users() {
         </Button>
       </div>
       <div className={userStyles.searchContainer}>
-        <input
+        <Input
           type="text"
           placeholder="Search user"
           value={search}
           onChange={(v) => setSearchField(v.target.value)}
+          name="Search user input"
         />
       </div>
       <table

--- a/webapp/javascript/components/TagsBar.tsx
+++ b/webapp/javascript/components/TagsBar.tsx
@@ -12,6 +12,7 @@ import Dropdown, {
 import TextareaAutosize from 'react-textarea-autosize';
 import { Prism } from '@webapp/util/prism';
 import { Query, brandQuery } from '@webapp/models/query';
+import Input from '@webapp/ui/Input';
 import styles from './TagsBar.module.css';
 
 interface TagsBarProps {
@@ -227,8 +228,9 @@ function LabelsSubmenu({
     return (
       <FocusableItem>
         {({ ref }) => (
-          <input
+          <Input
             ref={ref}
+            name="Search Tags Input"
             type="text"
             placeholder="Type a tag"
             value={filter[label] || ''}

--- a/webapp/javascript/ui/Input.module.scss
+++ b/webapp/javascript/ui/Input.module.scss
@@ -6,7 +6,7 @@
   position: relative;
   border-radius: 4px;
   padding: 0.25em 0.375em;
-  border: 1px solid transparent;
+  border: 1px solid var(--ps-neutral-10);
 
   &[type='search'] {
     -webkit-appearance: textfield;

--- a/webapp/javascript/ui/Input.tsx
+++ b/webapp/javascript/ui/Input.tsx
@@ -5,9 +5,9 @@ import styles from './Input.module.scss';
 interface InputProps {
   testId?: string;
   className?: string;
-  type: 'search' | 'text' | 'password';
+  type: 'search' | 'text' | 'password' | 'email' | 'number';
   name: string;
-  placeholder: string;
+  placeholder?: string;
   minLength?: number;
   debounceTimeout?: number;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;

--- a/webapp/javascript/ui/Input.tsx
+++ b/webapp/javascript/ui/Input.tsx
@@ -1,41 +1,52 @@
-import React from 'react';
+import React, { Ref, ChangeEvent } from 'react';
 import { DebounceInput } from 'react-debounce-input';
 import styles from './Input.module.scss';
 
 interface InputProps {
   testId?: string;
   className?: string;
-  type: 'search';
+  type: 'search' | 'text' | 'password';
   name: string;
   placeholder: string;
-  minLength: number;
-  debounceTimeout: number;
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  minLength?: number;
+  debounceTimeout?: number;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   value: string | number;
+  htmlId?: string;
 }
 
-export default function Input({
-  testId,
-  className,
-  type,
-  name,
-  placeholder,
-  minLength,
-  debounceTimeout,
-  onChange,
-  value,
-}: InputProps) {
-  return (
-    <DebounceInput
-      data-testid={testId}
-      className={`${styles.input} ${className || ''}`}
-      type={type}
-      name={name}
-      placeholder={placeholder}
-      minLength={minLength}
-      debounceTimeout={debounceTimeout}
-      onChange={onChange}
-      value={value}
-    />
-  );
-}
+const Input = React.forwardRef(
+  (
+    {
+      testId,
+      className,
+      type,
+      name,
+      placeholder,
+      minLength = 0,
+      debounceTimeout = 100,
+      onChange,
+      value,
+      htmlId,
+    }: InputProps,
+    ref?: Ref<HTMLInputElement>
+  ) => {
+    return (
+      <DebounceInput
+        inputRef={ref}
+        data-testid={testId}
+        className={`${styles.input} ${className || ''}`}
+        type={type}
+        name={name}
+        placeholder={placeholder}
+        minLength={minLength}
+        debounceTimeout={debounceTimeout}
+        onChange={onChange}
+        value={value}
+        id={htmlId}
+      />
+    );
+  }
+);
+
+export default Input;

--- a/webapp/javascript/ui/InputField/index.tsx
+++ b/webapp/javascript/ui/InputField/index.tsx
@@ -6,8 +6,8 @@ interface IInputFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
   className?: string;
   name: string;
-  placeholder: string;
-  type: 'text' | 'password';
+  placeholder?: string;
+  type: 'text' | 'password' | 'email' | 'number';
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
   id?: string;

--- a/webapp/javascript/ui/InputField/index.tsx
+++ b/webapp/javascript/ui/InputField/index.tsx
@@ -1,18 +1,39 @@
-import React, { InputHTMLAttributes } from 'react';
-
+import React, { InputHTMLAttributes, ChangeEvent } from 'react';
+import Input from '@webapp/ui/Input';
 import styles from './InputField.module.css';
 
 interface IInputFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
   className?: string;
+  name: string;
+  placeholder: string;
+  type: 'text' | 'password';
+  value: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  id?: string;
 }
 
-/* eslint-disable react/jsx-props-no-spreading */
-function InputField({ label, className, ...rest }: IInputFieldProps) {
+function InputField({
+  label,
+  className,
+  name,
+  onChange,
+  placeholder,
+  type,
+  value,
+  id,
+}: IInputFieldProps) {
   return (
     <div className={`${className || ''} ${styles.inputWrapper}`}>
       <h4>{label}</h4>
-      <input {...rest} />
+      <Input
+        type={type}
+        placeholder={placeholder}
+        name={name}
+        onChange={onChange}
+        value={value}
+        htmlId={id}
+      />
     </div>
   );
 }

--- a/webapp/sass/common.scss
+++ b/webapp/sass/common.scss
@@ -179,10 +179,3 @@ tt {
     }
   }
 }
-
-// TODO(eh-am): use ui/Input
-input {
-  @include outline;
-  border-radius: 4px;
-  border: 1px solid $btn-border-color;
-}

--- a/webapp/sass/login.scss
+++ b/webapp/sass/login.scss
@@ -161,9 +161,6 @@ body.login-page {
     label {
       font-weight: bolder;
     }
-    input {
-      width: 100%;
-    }
   }
 
   button.sign-in-button,
@@ -193,9 +190,6 @@ body.login-page {
     padding-top: 0.5em;
     label {
       font-weight: bolder;
-    }
-    input {
-      width: 100%;
     }
   }
 

--- a/webapp/sass/mixins/outline.scss
+++ b/webapp/sass/mixins/outline.scss
@@ -1,9 +1,10 @@
 @mixin outline {
   outline: none;
+
   &:focus {
-    // outline: 1px auto rgba(59, 153, 252, 0.65);
     outline: none;
   }
+
   &:focus:active {
     outline: none;
   }


### PR DESCRIPTION
REF: https://github.com/pyroscope-io/pyroscope/issues/1126, https://github.com/pyroscope-io/pyroscope/pull/1127

All `<input/>` usages were updated to use `@ui/Input`, including it's styles