### PR TITLE
chore: Add javaspy coloring for flamegraphs

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.spec.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.spec.ts
@@ -273,4 +273,35 @@ describe('getPackageNameFromStackTrace', () => {
       });
     });
   });
+
+  describe('java spy', () => {
+    describe.each([
+      [
+        'org/apache/catalina/core/ApplicationFilterChain.doFilter',
+        'org/apache/catalina/core/',
+      ],
+      [
+        'org/apache/catalina/core/ApplicationFilterChain.internalDoFilter',
+        'org/apache/catalina/core/',
+      ],
+      [
+        'org/apache/coyote/AbstractProcessorLight.process',
+        'org/apache/coyote/',
+      ],
+      [
+        'org/springframework/web/servlet/DispatcherServlet.doService',
+        'org/springframework/web/',
+      ],
+      [
+        'org/example/rideshare/RideShareController.orderCar',
+        'org/example/rideshare/',
+      ],
+      ['org/example/rideshare/OrderService.orderCar', 'org/example/rideshare/'],
+      ['total', 'total'],
+    ])(`.getPackageNameFromStackTrace('%s')`, (a, expected) => {
+      it(`returns '${expected}'`, () => {
+        expect(getPackageNameFromStackTrace('javaspy', a)).toBe(expected);
+      });
+    });
+  });
 });

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.spec.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.spec.ts
@@ -290,7 +290,7 @@ describe('getPackageNameFromStackTrace', () => {
       ],
       [
         'org/springframework/web/servlet/DispatcherServlet.doService',
-        'org/springframework/web/',
+        'org/springframework/web/servet/',
       ],
       [
         'org/example/rideshare/RideShareController.orderCar',

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.spec.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.spec.ts
@@ -290,7 +290,7 @@ describe('getPackageNameFromStackTrace', () => {
       ],
       [
         'org/springframework/web/servlet/DispatcherServlet.doService',
-        'org/springframework/web/servet/',
+        'org/springframework/web/servlet/',
       ],
       [
         'org/example/rideshare/RideShareController.orderCar',

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.ts
@@ -94,7 +94,7 @@ function spyToRegex(spyName: string) {
     case 'nodespy':
       return /^(\.\/node_modules\/)?(?<packageName>[^/]*)(?<filename>.*\.?(jsx?|tsx?)?):(?<functionName>.*):(?<line_info>.*)$/;
     case 'javaspy':
-      return /^(?<packageName>.*?\/.*?\.|.*?\.|.+\/)(?<filename>.*\/)(?<functionName>.*)$/;
+      return /^(?<packageName>.*?\/.*?\.|.*?\.|.+\/)(?<filename>.*)\.(?<functionName>.*)$/;
     case 'pyroscope-rs':
       return /^(?<packageName>[^::]+)/;
 

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.ts
@@ -93,6 +93,8 @@ function spyToRegex(spyName: string) {
       return /^(?<packageName>(.*\/)*)(?<filename>.*\.rb+)(?<line_info>.*)$/;
     case 'nodespy':
       return /^(\.\/node_modules\/)?(?<packageName>[^/]*)(?<filename>.*\.?(jsx?|tsx?)?):(?<functionName>.*):(?<line_info>.*)$/;
+    case 'javaspy':
+      return /^(?<packageName>.*?\/.*?\.|.*?\.|.+\/)(?<fileame>.*\/)(?<functionName>.*)$/;
     case 'pyroscope-rs':
       return /^(?<packageName>[^::]+)/;
 

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.ts
@@ -94,7 +94,7 @@ function spyToRegex(spyName: string) {
     case 'nodespy':
       return /^(\.\/node_modules\/)?(?<packageName>[^/]*)(?<filename>.*\.?(jsx?|tsx?)?):(?<functionName>.*):(?<line_info>.*)$/;
     case 'javaspy':
-      return /^(?<packageName>.*?\/.*?\.|.*?\.|.+\/)(?<fileame>.*\/)(?<functionName>.*)$/;
+      return /^(?<packageName>.*?\/.*?\.|.*?\.|.+\/)(?<filename>.*\/)(?<functionName>.*)$/;
     case 'pyroscope-rs':
       return /^(?<packageName>[^::]+)/;
 

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.ts
@@ -94,7 +94,7 @@ function spyToRegex(spyName: string) {
     case 'nodespy':
       return /^(\.\/node_modules\/)?(?<packageName>[^/]*)(?<filename>.*\.?(jsx?|tsx?)?):(?<functionName>.*):(?<line_info>.*)$/;
     case 'javaspy':
-      return /^(?<packageName>.*?\/.*?\.|.*?\.|.+\/)(?<filename>.*)\.(?<functionName>.*)$/;
+      return /^(?<packageName>.+\/)?(?<filneame>.+\.)(?<functionName>.+)$/;
     case 'pyroscope-rs':
       return /^(?<packageName>[^::]+)/;
 


### PR DESCRIPTION
Adds coloring for java:
https://flamegraph.com/share/8022667e-e6d7-11ec-925c-fab0c2c9d0a0

Tested with:
https://regex101.com/r/W5U0uD/2

<img width="1460" alt="image" src="https://user-images.githubusercontent.com/23323466/172936236-44928f2f-076f-4069-af2a-14c20e7c15f0.png">


cc @korniltsev @petethepig  
