### PR TITLE
fix: Fix typo in regexp for javaspy

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.ts
@@ -94,7 +94,7 @@ function spyToRegex(spyName: string) {
     case 'nodespy':
       return /^(\.\/node_modules\/)?(?<packageName>[^/]*)(?<filename>.*\.?(jsx?|tsx?)?):(?<functionName>.*):(?<line_info>.*)$/;
     case 'javaspy':
-      return /^(?<packageName>.+\/)?(?<filneame>.+\.)(?<functionName>.+)$/;
+      return /^(?<packageName>.+\/)?(?<filename>.+\.)(?<functionName>.+)$/;
     case 'pyroscope-rs':
       return /^(?<packageName>[^::]+)/;
 


### PR DESCRIPTION
Fix typo in regexp