### PR TITLE
fix: Fix missed style in tags submenu

### DIFF
--- a/webapp/javascript/components/TagsBar.tsx
+++ b/webapp/javascript/components/TagsBar.tsx
@@ -231,8 +231,9 @@ function LabelsSubmenu({
           <Input
             ref={ref}
             name="Search Tags Input"
+            className="search"
             type="text"
-            placeholder="Type a tag"
+            placeholder="Type a tag..."
             value={filter[label] || ''}
             onChange={(e) =>
               setFilter({

--- a/webapp/javascript/ui/Dropdown.module.scss
+++ b/webapp/javascript/ui/Dropdown.module.scss
@@ -10,6 +10,7 @@
 
   & ul[class*='rc-menu'] {
     color: var(--ps-neutral-2) !important;
+    background-color: var(--ps-dropdown-background) !important;
   }
 
   & li[class*='hover'],

--- a/webapp/sass/components/tagsbar.scss
+++ b/webapp/sass/components/tagsbar.scss
@@ -103,3 +103,18 @@
     margin: 0;
   }
 }
+
+// TODO: DRY This from SharedQueryInput.module.scss
+.search {
+  background: var(--ps-immutable-1);
+  transition: background-color ease-out 0.1s;
+  font: inherit;
+  margin-right: 8px;
+  border: 1px solid var(--ps-neutral-6);
+  width: 300px;
+
+  &,
+  &::placeholder {
+    color: var(--ps-immutable-4) !important;
+  }
+}


### PR DESCRIPTION
Missed a style in #1152... This will be easier to automatically check for in tests when we add tags to self profiling in #1137 . 

<img width="870" alt="image" src="https://user-images.githubusercontent.com/23323466/173247497-644c760e-e8ae-430a-8245-19566b01446b.png">


also worth noting that in #1136 we started to unify all of the inputs so there is a part of this that may be worth making part of the input component as I had to duplicate it in this pr.

before:
<img width="990" alt="Screen Shot 2022-06-12 at 1 41 16 PM" src="https://user-images.githubusercontent.com/23323466/173246899-265ef035-7776-4deb-ac9b-87b3b743d916.png">

After:
<img width="729" alt="Screen Shot 2022-06-12 at 1 54 38 PM" src="https://user-images.githubusercontent.com/23323466/173246910-6f816c79-4c61-426c-bb7e-3796e3945fb5.png">

