### PR TITLE
chore(remotewrite): use snake case for target_{name,address}

### DIFF
--- a/pkg/remotewrite/queue_metrics.go
+++ b/pkg/remotewrite/queue_metrics.go
@@ -17,8 +17,8 @@ type queueMetrics struct {
 
 func newQueueMetrics(reg prometheus.Registerer, targetName, targetAddress string) *queueMetrics {
 	labels := prometheus.Labels{
-		"targetName":    targetName,
-		"targetAddress": targetAddress,
+		"target_name":    targetName,
+		"target_address": targetAddress,
 	}
 
 	q := &queueMetrics{reg: reg}


### PR DESCRIPTION
As mentioned by @kolesnikovae in the docs repo https://github.com/pyroscope-io/docs/pull/83/files/ed96e73a7bea232ccd7c37f6bf2c70655f650bd8#diff-b21ab40374e4bc443cf120a99fa819ba24abc66b82886ca59124c6d9841dde3a

We already use snake_case, so we should keep it for consistency.