### PR TITLE
feat(self-profiling): allow tags to be set

### DIFF
--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -188,7 +188,7 @@ func newServerService(c *config.Server) (*serverService, error) {
 		ingester = ingestion.NewParallelizer(svc.logger, ingesters...)
 	}
 	if !svc.config.NoSelfProfiling {
-		svc.selfProfiling = selfprofiling.NewSession(svc.logger, ingester, "pyroscope.server")
+		svc.selfProfiling = selfprofiling.NewSession(svc.logger, ingester, "pyroscope.server", svc.config.SelfProfilingTags)
 	}
 
 	svc.scrapeManager = scrape.NewManager(

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,7 +155,8 @@ type Server struct {
 
 	ScrapeConfigs []*scrape.Config `yaml:"scrape-configs" mapstructure:"-"`
 
-	NoSelfProfiling bool `def:"false" desc:"disable profiling of pyroscope itself" mapstructure:"no-self-profiling"`
+	NoSelfProfiling   bool              `def:"false" desc:"disable profiling of pyroscope itself" mapstructure:"no-self-profiling"`
+	SelfProfilingTags map[string]string `name:"self-profiling-tag" def:"" desc:"tag in key=value form. The flag may be specified multiple times" mapstructure:"self-profiling-tags" yaml:"self-profiling-tags"`
 
 	RemoteWrite RemoteWrite `yaml:"remote-write" mapstructure:"remote-write"`
 }

--- a/pkg/dbmanager/cli.go
+++ b/pkg/dbmanager/cli.go
@@ -69,7 +69,7 @@ func copyData(dbCfg *config.DbManager, stCfg *storage.Config) error {
 	e, _ := exporter.NewExporter(nil, nil)
 	logger := logrus.StandardLogger()
 	if dbCfg.EnableProfiling {
-		_ = selfprofiling.NewSession(logger, parser.New(logger, s, e), "pyroscope.dbmanager").Start()
+		_ = selfprofiling.NewSession(logger, parser.New(logger, s, e), "pyroscope.dbmanager", map[string]string{}).Start()
 	}
 
 	sk, err := segment.ParseKey(appName)

--- a/pkg/selfprofiling/upstream.go
+++ b/pkg/selfprofiling/upstream.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pyroscope-io/pyroscope/pkg/storage/tree"
 )
 
-func NewSession(logger pyroscope.Logger, ingester ingestion.Ingester, appName string) *pyroscope.Session {
+func NewSession(logger pyroscope.Logger, ingester ingestion.Ingester, appName string, tags map[string]string) *pyroscope.Session {
 	session, _ := pyroscope.NewSession(pyroscope.SessionConfig{
 		Upstream:       NewUpstream(logger, ingester),
 		AppName:        appName,
@@ -22,6 +22,7 @@ func NewSession(logger pyroscope.Logger, ingester ingestion.Ingester, appName st
 		SampleRate:     100,
 		UploadRate:     10 * time.Second,
 		Logger:         logger,
+		Tags:           tags,
 	})
 	return session
 }


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/1137

Usage example:
```yaml
self-profiling-tags:
  foo: bar
```
![image](https://user-images.githubusercontent.com/6951209/173431333-4d9be52e-72a8-4212-93e0-b2d0c6858370.png)



---
I tried to use

```go
SelfProfiling   SelfProfiling `yaml:"self-profiling" desc:"self profiling configurations"`

type SelfProfiling struct {
	Tags map[string]string `name:"tag" desc:"tag in key=value form. The flag may be specified multiple times" mapstructure:"tags"`
}
```

But IIRC our viper setup doesn't play well with nested structs/maps?
Therefore I just inlined the config as `self-profiling-tags` at the root.

The advantage is that it works with cli flags :) eg `--self-profiling-tag=test=123`