### PR TITLE
chore: add a web-boostrap command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,8 +213,11 @@ install-dev-tools: ## Install dev tools
 	cat tools/tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI {} go install {}
 
 .PHONY: web-bootstrap
-web-bootstrap:
+web-bootstrap: install-web-dependencies
 	yarn bootstrap
+# build webapp just to get its dependencies built
+# otherwise when first running, the webapp will fail to build since its deps don't exist yet
+	yarn build:webapp > /dev/null
 
 .PHONY: dev
 dev: web-bootstrap ## Start webpack and pyroscope server. Use this one for working on pyroscope


### PR DESCRIPTION
When first building pyroscope (eg when setting up a new local environment), there's a data race (not exactly) when running `make dev`:
* since we run `lerna-watch`, all dependencies + the webapp will be built at the same time
* webapp will fail to built, since its dependencies are still being built
* dependencies are finally built
* webapp is not refreshed

A workaround for this is just running `make dev` again.

Not very happy with this workaround, so I added a new `web-bootstrap` command. 

We can tell people to run it once, the first time they set up a new environment.

---
Will add docs once this PR is merged.