### PR TITLE
chore: don't run web-boostrap unnecessarily

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ web-bootstrap: install-web-dependencies
 	yarn build:webapp > /dev/null
 
 .PHONY: dev
-dev: web-bootstrap ## Start webpack and pyroscope server. Use this one for working on pyroscope
+dev: install-web-dependencies ## Start webpack and pyroscope server. Use this one for working on pyroscope
 	goreman -exit-on-error -f scripts/dev-procfile start
 
 .PHONY: godoc


### PR DESCRIPTION
Follow up from https://github.com/pyroscope-io/pyroscope/pull/1161

Dont' run `web-bootstrap` unnecessarily when running `make dev`.