### PR TITLE
feat(frontend): support disabling exporting to flamegraph.com

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -159,6 +159,8 @@ type Server struct {
 	SelfProfilingTags map[string]string `name:"self-profiling-tag" def:"" desc:"tag in key=value form. The flag may be specified multiple times" mapstructure:"self-profiling-tags" yaml:"self-profiling-tags"`
 
 	RemoteWrite RemoteWrite `yaml:"remote-write" mapstructure:"remote-write"`
+
+	DisableExportToFlamegraphDotCom bool `def:"false" desc:"disable exporting to flamegraph.com in the UI" mapstructure:"disable-export-to-flamegraph-dot-com"`
 }
 
 type MetricsExportRules map[string]MetricsExportRule

--- a/pkg/server/index.go
+++ b/pkg/server/index.go
@@ -15,12 +15,13 @@ import (
 )
 
 type Flags struct {
-	EnableAdhocUI       bool `json:"enableAdhocUI"`
-	GoogleEnabled       bool `json:"googleEnabled"`
-	GitlabEnabled       bool `json:"gitlabEnabled"`
-	GithubEnabled       bool `json:"githubEnabled"`
-	InternalAuthEnabled bool `json:"internalAuthEnabled"`
-	SignupEnabled       bool `json:"signupEnabled"`
+	EnableAdhocUI                   bool `json:"enableAdhocUI"`
+	GoogleEnabled                   bool `json:"googleEnabled"`
+	GitlabEnabled                   bool `json:"gitlabEnabled"`
+	GithubEnabled                   bool `json:"githubEnabled"`
+	InternalAuthEnabled             bool `json:"internalAuthEnabled"`
+	SignupEnabled                   bool `json:"signupEnabled"`
+	ExportToFlamegraphDotComEnabled bool `json:"exportToFlamegraphDotComEnabled"`
 }
 
 type IndexHandlerConfig struct {
@@ -43,12 +44,13 @@ type IndexHandler struct {
 func (ctrl *Controller) indexHandler() http.HandlerFunc {
 	cfg := &IndexHandlerConfig{
 		Flags: Flags{
-			EnableAdhocUI:       !ctrl.config.NoAdhocUI,
-			GoogleEnabled:       ctrl.config.Auth.Google.Enabled,
-			GitlabEnabled:       ctrl.config.Auth.Gitlab.Enabled,
-			GithubEnabled:       ctrl.config.Auth.Github.Enabled,
-			InternalAuthEnabled: ctrl.config.Auth.Internal.Enabled,
-			SignupEnabled:       ctrl.config.Auth.Internal.SignupEnabled,
+			EnableAdhocUI:                   !ctrl.config.NoAdhocUI,
+			GoogleEnabled:                   ctrl.config.Auth.Google.Enabled,
+			GitlabEnabled:                   ctrl.config.Auth.Gitlab.Enabled,
+			GithubEnabled:                   ctrl.config.Auth.Github.Enabled,
+			InternalAuthEnabled:             ctrl.config.Auth.Internal.Enabled,
+			SignupEnabled:                   ctrl.config.Auth.Internal.SignupEnabled,
+			ExportToFlamegraphDotComEnabled: !ctrl.config.DisableExportToFlamegraphDotCom,
 		},
 		IsAuthRequired: ctrl.isAuthRequired(),
 		BaseURL:        ctrl.config.BaseURL,

--- a/webapp/javascript/components/ExportData.spec.tsx
+++ b/webapp/javascript/components/ExportData.spec.tsx
@@ -9,7 +9,7 @@ describe('ExportData', () => {
     // ignore console.error since jsdom will complain
     jest.spyOn(global.console, 'error').mockImplementation(() => jest.fn());
 
-    expect(() => render(<ExportData />)).toThrow();
+    expect(() => render(<ExportData flamebearer={{} as any} />)).toThrow();
 
     jest.restoreAllMocks();
   });

--- a/webapp/javascript/components/ExportData.tsx
+++ b/webapp/javascript/components/ExportData.tsx
@@ -13,48 +13,38 @@ import styles from './ExportData.module.scss';
 // These are modeled individually since each condition may have different values
 // For example, a exportPprof: true may accept a custom export function
 // For cases like grafana
-type exportJSON =
-  | {
-      exportJSON: true;
-      flamebearer: Profile;
-    }
-  | { exportJSON?: false };
+type exportJSON = {
+  exportJSON?: boolean;
+  flamebearer: Profile;
+};
 
-type exportPprof =
-  | {
-      exportPprof: true;
-      flamebearer: Profile;
-    }
-  | { exportPprof?: false };
+type exportPprof = {
+  exportPprof?: boolean;
+  flamebearer: Profile;
+};
 
-type exportHTML =
-  | {
-      exportHTML: true;
-      fetchUrlFunc?: () => string;
-      flamebearer: Profile;
-    }
-  | { exportHTML?: false };
+type exportHTML = {
+  exportHTML?: boolean;
+  fetchUrlFunc?: () => string;
+  flamebearer: Profile;
+};
 
-type exportFlamegraphDotCom =
-  | {
-      exportFlamegraphDotCom: true;
-      exportFlamegraphDotComFn: (name?: string) => Promise<string | null>;
-      flamebearer: Profile;
-    }
-  | { exportFlamegraphDotCom?: false };
+type exportFlamegraphDotCom = {
+  exportFlamegraphDotCom?: boolean;
+  exportFlamegraphDotComFn?: (name?: string) => Promise<string | null>;
+  flamebearer: Profile;
+};
 
-type exportPNG =
-  | {
-      exportPNG: true;
-      flamebearer: Profile;
-    }
-  | { exportPNG?: false };
+type exportPNG = {
+  exportPNG?: boolean;
+  flamebearer: Profile;
+};
 
 type ExportDataProps = exportPprof &
-  exportJSON &
   exportHTML &
   exportFlamegraphDotCom &
-  exportPNG;
+  exportPNG &
+  exportJSON;
 
 function ExportData(props: ExportDataProps) {
   const {
@@ -115,7 +105,7 @@ function ExportData(props: ExportDataProps) {
     }
 
     // TODO additional check this won't be needed once we use strictNullChecks
-    if (props.exportFlamegraphDotCom) {
+    if (props.exportFlamegraphDotCom && props.exportFlamegraphDotComFn) {
       const { flamebearer } = props;
 
       const defaultExportName = getFilename(

--- a/webapp/javascript/pages/ContinuousComparisonView.tsx
+++ b/webapp/javascript/pages/ContinuousComparisonView.tsx
@@ -20,12 +20,12 @@ import useExportToFlamegraphDotCom from '@webapp/components/exportToFlamegraphDo
 import TagsBar from '@webapp/components/TagsBar';
 import useTimeZone from '@webapp/hooks/timeZone.hook';
 import useColorMode from '@webapp/hooks/colorMode.hook';
+import { isExportToFlamegraphDotComEnabled } from '@webapp/util/features';
 import styles from './ContinuousComparison.module.css';
 import useTags from '../hooks/tags.hook';
 import useTimelines, { leftColor, rightColor } from '../hooks/timeline.hook';
 import usePopulateLeftRightQuery from '../hooks/populateLeftRightQuery.hook';
 import useFlamegraphSharedQuery from '../hooks/flamegraphSharedQuery.hook';
-import { isExportToFlamegraphDotComEnabled } from '@webapp/util/features';
 
 function ComparisonApp() {
   const dispatch = useAppDispatch();

--- a/webapp/javascript/pages/ContinuousComparisonView.tsx
+++ b/webapp/javascript/pages/ContinuousComparisonView.tsx
@@ -25,6 +25,7 @@ import useTags from '../hooks/tags.hook';
 import useTimelines, { leftColor, rightColor } from '../hooks/timeline.hook';
 import usePopulateLeftRightQuery from '../hooks/populateLeftRightQuery.hook';
 import useFlamegraphSharedQuery from '../hooks/flamegraphSharedQuery.hook';
+import { isExportToFlamegraphDotComEnabled } from '@webapp/util/features';
 
 function ComparisonApp() {
   const dispatch = useAppDispatch();
@@ -126,7 +127,7 @@ function ComparisonApp() {
                     exportJSON
                     exportHTML
                     exportPprof
-                    exportFlamegraphDotCom
+                    exportFlamegraphDotCom={isExportToFlamegraphDotComEnabled}
                     exportFlamegraphDotComFn={exportToFlamegraphDotComLeftFn}
                   />
                 )
@@ -174,7 +175,7 @@ function ComparisonApp() {
                     exportJSON
                     exportHTML
                     exportPprof
-                    exportFlamegraphDotCom
+                    exportFlamegraphDotCom={isExportToFlamegraphDotComEnabled}
                     exportFlamegraphDotComFn={exportToFlamegraphDotComRightFn}
                   />
                 )

--- a/webapp/javascript/pages/ContinuousDiffView.tsx
+++ b/webapp/javascript/pages/ContinuousDiffView.tsx
@@ -23,6 +23,7 @@ import TimelineChartWrapper from '@webapp/components/TimelineChartWrapper';
 import InstructionText from '@webapp/components/InstructionText';
 import useExportToFlamegraphDotCom from '@webapp/components/exportToFlamegraphDotCom.hook';
 import ExportData from '@webapp/components/ExportData';
+import { isExportToFlamegraphDotComEnabled } from '@webapp/util/features';
 
 function ComparisonDiffApp() {
   const dispatch = useAppDispatch();
@@ -83,7 +84,7 @@ function ComparisonDiffApp() {
       exportPNG
       // disable this until we fix it
       //      exportHTML
-      exportFlamegraphDotCom
+      exportFlamegraphDotCom={isExportToFlamegraphDotComEnabled}
       exportFlamegraphDotComFn={exportToFlamegraphDotComFn}
     />
   );

--- a/webapp/javascript/pages/ContinuousSingleView.tsx
+++ b/webapp/javascript/pages/ContinuousSingleView.tsx
@@ -14,6 +14,7 @@ import Toolbar from '@webapp/components/Toolbar';
 import ExportData from '@webapp/components/ExportData';
 import useExportToFlamegraphDotCom from '@webapp/components/exportToFlamegraphDotCom.hook';
 import useTimeZone from '@webapp/hooks/timeZone.hook';
+import { isExportToFlamegraphDotComEnabled } from '@webapp/util/features';
 
 function ContinuousSingleView() {
   const dispatch = useAppDispatch();
@@ -63,7 +64,7 @@ function ContinuousSingleView() {
                 exportJSON
                 exportPprof
                 exportHTML
-                exportFlamegraphDotCom
+                exportFlamegraphDotCom={isExportToFlamegraphDotComEnabled}
                 exportFlamegraphDotComFn={exportToFlamegraphDotComFn}
               />
             }

--- a/webapp/javascript/util/features.ts
+++ b/webapp/javascript/util/features.ts
@@ -8,7 +8,7 @@ interface Features {
   githubEnabled?: boolean;
   internalAuthEnabled?: boolean;
   signupEnabled?: boolean;
-  exportToFlamegraphDotComEnabled?: boolean;
+  exportToFlamegraphDotComEnabled: boolean;
 }
 
 function hasFeatures(

--- a/webapp/javascript/util/features.ts
+++ b/webapp/javascript/util/features.ts
@@ -8,6 +8,7 @@ interface Features {
   githubEnabled?: boolean;
   internalAuthEnabled?: boolean;
   signupEnabled?: boolean;
+  exportToFlamegraphDotComEnabled?: boolean;
 }
 
 function hasFeatures(
@@ -45,4 +46,8 @@ export const isInternalAuthEnabled = hasFeatures(window)
 
 export const isSignupEnabled = hasFeatures(window)
   ? window.features.signupEnabled
+  : true;
+
+export const isExportToFlamegraphDotComEnabled = hasFeatures(window)
+  ? window.features.exportToFlamegraphDotComEnabled
   : true;


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/1186 and https://github.com/pyroscope-io/pyroscope/issues/1119

I kept our standard of using `--disable/--no` for backend flags, and in the frontend to use `enable`.

There's some repetition in the `<FlamegraphRenderer>` (having to pass the same flags multiple times), but it gives us flexibility to change as we want. At some point when we make all the continuous pages have feature parity (eg export to pprof doesn't work with diff) we may clean this up.