### PR TITLE
fix: default name when exporting diff

### DIFF
--- a/webapp/javascript/components/ExportData.tsx
+++ b/webapp/javascript/components/ExportData.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable react/destructuring-assignment */
 import React, { useState } from 'react';
+import { format } from 'date-fns';
 
 import Button from '@webapp/ui/Button';
 import { faBars } from '@fortawesome/free-solid-svg-icons/faBars';
 import { buildRenderURL } from '@webapp/util/updateRequests';
-import { dateForExportFilename } from '@webapp/util/formatDate';
+import { convertPresetsToDate } from '@webapp/util/formatDate';
 import { Profile } from '@pyroscope/models';
 import showModalWithInput from './Modals/ModalWithInput';
 
@@ -345,6 +346,22 @@ function ExportData(props: ExportDataProps) {
       </div>
     </div>
   );
+}
+
+const dateFormat = 'yyyy-MM-dd_HHmm';
+
+function dateForExportFilename(from: string, until: string) {
+  let start = new Date(Math.round(parseInt(from, 10) * 1000));
+  let end = new Date(Math.round(parseInt(until, 10) * 1000));
+
+  if (/^now-/.test(from) && until === 'now') {
+    const { _from } = convertPresetsToDate(from);
+
+    start = new Date(Math.round(parseInt(_from.toString(), 10) * 1000));
+    end = new Date();
+  }
+
+  return `${format(start, dateFormat)}-to-${format(end, dateFormat)}`;
 }
 
 export function getFilename(

--- a/webapp/javascript/pages/ContinuousDiffView.tsx
+++ b/webapp/javascript/pages/ContinuousDiffView.tsx
@@ -79,21 +79,12 @@ function ComparisonDiffApp() {
     maxNodes,
   ]);
 
-  const exportFileName = `diff_${(leftQuery === rightQuery
-    ? query
-    : `${leftQuery}_${rightQuery}`
-  ).replace(/{}/g, '')}`;
-
   const exportData = diffView.profile && (
     <ExportData
       flamebearer={{
         ...diffView.profile,
         metadata: {
           ...diffView.profile.metadata,
-          appName: exportFileName,
-          // TODO: refactor metadata types
-          startTime: from as unknown as number,
-          endTime: until as unknown as number,
         },
       }}
       exportJSON

--- a/webapp/javascript/pages/ContinuousDiffView.tsx
+++ b/webapp/javascript/pages/ContinuousDiffView.tsx
@@ -35,8 +35,10 @@ function ComparisonDiffApp() {
     rightFrom,
     leftUntil,
     rightUntil,
+    from,
+    until,
   } = useAppSelector(selectContinuousState);
-  const { leftQuery, rightQuery } = useAppSelector(selectQueries);
+  const { leftQuery, rightQuery, query } = useAppSelector(selectQueries);
 
   usePopulateLeftRightQuery();
   const { leftTags, rightTags } = useTags({ leftQuery, rightQuery });
@@ -76,9 +78,18 @@ function ComparisonDiffApp() {
     maxNodes,
   ]);
 
+  const exportFileName = `diff_${query.replace(/..$/, '')}`;
+
   const exportData = diffView.profile && (
     <ExportData
-      flamebearer={diffView.profile}
+      flamebearer={{
+        ...diffView.profile,
+        metadata: {
+          appName: exportFileName,
+          startTime: from,
+          endTime: until,
+        },
+      }}
       exportJSON
       exportPNG
       // disable this until we fix it

--- a/webapp/javascript/pages/ContinuousDiffView.tsx
+++ b/webapp/javascript/pages/ContinuousDiffView.tsx
@@ -23,6 +23,7 @@ import TimelineChartWrapper from '@webapp/components/TimelineChartWrapper';
 import InstructionText from '@webapp/components/InstructionText';
 import useExportToFlamegraphDotCom from '@webapp/components/exportToFlamegraphDotCom.hook';
 import ExportData from '@webapp/components/ExportData';
+import type { Profile } from '@pyroscope/models';
 
 function ComparisonDiffApp() {
   const dispatch = useAppDispatch();
@@ -85,9 +86,11 @@ function ComparisonDiffApp() {
       flamebearer={{
         ...diffView.profile,
         metadata: {
+          ...diffView.profile.metadata,
           appName: exportFileName,
-          startTime: from,
-          endTime: until,
+          // TODO: refactor metadata types
+          startTime: from as unknown as number,
+          endTime: until as unknown as number,
         },
       }}
       exportJSON

--- a/webapp/javascript/pages/ContinuousDiffView.tsx
+++ b/webapp/javascript/pages/ContinuousDiffView.tsx
@@ -23,7 +23,6 @@ import TimelineChartWrapper from '@webapp/components/TimelineChartWrapper';
 import InstructionText from '@webapp/components/InstructionText';
 import useExportToFlamegraphDotCom from '@webapp/components/exportToFlamegraphDotCom.hook';
 import ExportData from '@webapp/components/ExportData';
-import type { Profile } from '@pyroscope/models';
 
 function ComparisonDiffApp() {
   const dispatch = useAppDispatch();

--- a/webapp/javascript/pages/ContinuousDiffView.tsx
+++ b/webapp/javascript/pages/ContinuousDiffView.tsx
@@ -78,7 +78,10 @@ function ComparisonDiffApp() {
     maxNodes,
   ]);
 
-  const exportFileName = `diff_${query.replace(/..$/, '')}`;
+  const exportFileName = `diff_${(leftQuery === rightQuery
+    ? query
+    : `${leftQuery}_${rightQuery}`
+  ).replace(/{}/g, '')}`;
 
   const exportData = diffView.profile && (
     <ExportData

--- a/webapp/javascript/util/formatDate.ts
+++ b/webapp/javascript/util/formatDate.ts
@@ -64,17 +64,6 @@ export function readableRange(
   return `${format(d1, dateFormat)} - ${format(d2, dateFormat)}`;
 }
 
-export function dateForExportFilename(from: string, until: string) {
-  const dateFormat = 'yyyy-MM-dd_HHmm';
-  if (/^now-/.test(from) && until === 'now') {
-    const { number, _multiplier } = convertPresetsToDate(from);
-    return `last_${number}_${_multiplier}`;
-  }
-
-  const d1 = new Date(Math.round(parseInt(from, 10) * 1000));
-  const d2 = new Date(Math.round(parseInt(until, 10) * 1000));
-  return `${format(d1, dateFormat)}-to-${format(d2, dateFormat)}`;
-}
 /**
  * formateAsOBject() returns a Date object
  * based on the passed-in parameter value

--- a/webapp/javascript/util/formatDate.ts
+++ b/webapp/javascript/util/formatDate.ts
@@ -68,7 +68,7 @@ export function dateForExportFilename(from: string, until: string) {
   const dateFormat = 'yyyy-MM-dd_HHmm';
   if (/^now-/.test(from) && until === 'now') {
     const { number, _multiplier } = convertPresetsToDate(from);
-    return `Last ${number} ${_multiplier}`;
+    return `last_${number}_${_multiplier}`;
   }
 
   const d1 = new Date(Math.round(parseInt(from, 10) * 1000));


### PR DESCRIPTION
examples:
diff_pyroscope.server.inuse_objects_last_3_hours
diff_pyroscope.server.inuse_objects_last_12_hours
diff_pyroscope.server.inuse_objects_2022-06-30_0209-to-2022-06-30_1034
diff_pyroscope.server.mutex_duration_last_3_hours
diff_pyroscope.server.mutex_duration_2022-06-30_1014-to-2022-06-30_1120

<img width="419" alt="Снимок экрана 2022-06-30 в 12 29 02" src="https://user-images.githubusercontent.com/47758224/176655959-4b06b981-23eb-479d-a663-c903dfa9d74e.png"> 
<img width="430" alt="Снимок экрана 2022-06-30 в 12 28 48" src="https://user-images.githubusercontent.com/47758224/176656037-030a59ef-2cad-4cb6-8a3a-bbbe091e26a5.png">

if we leave spaces and capitalized L 

<img width="422" alt="Снимок экрана 2022-06-30 в 12 29 26" src="https://user-images.githubusercontent.com/47758224/176656532-65ab035f-161a-4ee5-95a2-ba77101095f2.png">

 


