### PR TITLE
fix(frontend): don't crash when flamegraph changes

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -190,12 +190,6 @@ class FlameGraphRenderer extends React.Component<
     // This is a simple heuristic based on the name
     // It does not account for eg recursive calls
     const isSameNode = (f: Flamebearer, f2: Flamebearer, s: Maybe<Node>) => {
-      // if flamebearers are different, we can't access the same bar
-      // since it may not exist
-      if (!this.isSameFlamebearer(f, f2)) {
-        return false;
-      }
-
       // TODO: don't use createFF directly
       const getBarName = (f: Flamebearer, i: number, j: number) => {
         return f.names[createFF(f.format).getBarName(f.levels[i], j)];
@@ -206,10 +200,14 @@ class FlameGraphRenderer extends React.Component<
         return true;
       }
 
-      return (
-        getBarName(f, s.value.i, s.value.j) ===
-        getBarName(f2, s.value.i, s.value.j)
-      );
+      // if the bar doesn't exist, it will throw an error
+      try {
+        const barName1 = getBarName(f, s.value.i, s.value.j);
+        const barName2 = getBarName(f2, s.value.i, s.value.j);
+        return barName1 === barName2;
+      } catch {
+        return false;
+      }
     };
 
     // Reset zoom

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -159,8 +159,7 @@ class FlameGraphRenderer extends React.Component<
     const prevFlame = mountFlamebearer(prevProps);
     const currFlame = mountFlamebearer(this.props);
 
-    // This is a poor heuristic, but it should work most of the times
-    if (prevFlame.numTicks !== currFlame.numTicks) {
+    if (!this.isSameFlamebearer(prevFlame, currFlame)) {
       const newConfigs = this.calcNewConfigs(prevFlame, currFlame);
 
       // Batch these updates to not do unnecessary work
@@ -191,6 +190,12 @@ class FlameGraphRenderer extends React.Component<
     // This is a simple heuristic based on the name
     // It does not account for eg recursive calls
     const isSameNode = (f: Flamebearer, f2: Flamebearer, s: Maybe<Node>) => {
+      // if flamebearers are different, we can't access the same bar
+      // since it may not exist
+      if (!this.isSameFlamebearer(f, f2)) {
+        return false;
+      }
+
       // TODO: don't use createFF directly
       const getBarName = (f: Flamebearer, i: number, j: number) => {
         return f.names[createFF(f.format).getBarName(f.levels[i], j)];
@@ -226,6 +231,11 @@ class FlameGraphRenderer extends React.Component<
     this.setState({
       highlightQuery: e,
     });
+  };
+
+  isSameFlamebearer = (prevFlame: Flamebearer, currFlame: Flamebearer) => {
+    // This is a poor heuristic, but it should work most of the times
+    return prevFlame.numTicks === currFlame.numTicks;
   };
 
   onReset = () => {


### PR DESCRIPTION
This was raised by @kolesnikovae  

We introduced a bug in https://github.com/pyroscope-io/pyroscope/pull/1184
Basically when flamegraphs change, we may not always be able to calculate the bar contents, since the flamegraphs may have different sizes.