### PR TITLE
fix(flamegraph): do a deep comparison for whether the flamegraph is the same

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -232,8 +232,9 @@ class FlameGraphRenderer extends React.Component<
   };
 
   isSameFlamebearer = (prevFlame: Flamebearer, currFlame: Flamebearer) => {
-    // This is a poor heuristic, but it should work most of the times
-    return prevFlame.numTicks === currFlame.numTicks;
+    // TODO: come up with a less resource intensive operation
+    // keep in mind naive heuristics may provide bad behaviours like (https://github.com/pyroscope-io/pyroscope/issues/1192)
+    return JSON.stringify(prevFlame) === JSON.stringify(currFlame);
   };
 
   onReset = () => {


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/1192

Changed the naive `numTicks` for a deep comparison. Although JSON serialization is slow, which is a not big deal (since our flamegraphs are small), but they could be in the future, hence why I left a comment as a hint.