### PR TITLE
fix: improved nodes coloring by fixing murmur math

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/murmur3.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/murmur3.ts
@@ -58,13 +58,11 @@ export default function murmurhash3_32_gc(key: string, seed = 0) {
   switch (remainder) {
     case 3:
       k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
-      break;
     case 2:
       k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
-      break;
-    default:
+    case 1:
       k1 ^= key.charCodeAt(i) & 0xff;
-
+    default:
       k1 =
         ((k1 & 0xffff) * c1 + ((((k1 >>> 16) * c1) & 0xffff) << 16)) &
         0xffffffff;

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/murmur3.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/murmur3.ts
@@ -58,10 +58,13 @@ export default function murmurhash3_32_gc(key: string, seed = 0) {
   switch (remainder) {
     case 3:
       k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
+    // fall through
     case 2:
       k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
+    // fall through
     case 1:
       k1 ^= key.charCodeAt(i) & 0xff;
+    // fall through
     default:
       k1 =
         ((k1 & 0xffff) * c1 + ((((k1 >>> 16) * c1) & 0xffff) << 16)) &


### PR DESCRIPTION
I don't know how this happened but we introduced this bug at some point. I changed it to proper math. E.g see code [here](https://github.com/jsdelfino/murmurhash-32/blob/master/murmurhash3_gc.js#L44-L47)