### PR TITLE
ci: update to go 1.18 in tests

### DIFF
--- a/.github/workflows/tests-go.yml
+++ b/.github/workflows/tests-go.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.17.0'
+          go-version: '^1.18.0'
       - name: Cache go mod directories
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
uses 1.18 in tests