### PR TITLE
chore: set package tsconfig as their root

### DIFF
--- a/packages/pyroscope-flamegraph/.eslintrc.js
+++ b/packages/pyroscope-flamegraph/.eslintrc.js
@@ -22,4 +22,7 @@ module.exports = {
       },
     ],
   },
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
 };

--- a/packages/pyroscope-panel-plugin/.eslintrc.js
+++ b/packages/pyroscope-panel-plugin/.eslintrc.js
@@ -3,4 +3,7 @@ const path = require('path');
 module.exports = {
   extends: [path.join(__dirname, '../../.eslintrc.js')],
   ignorePatterns: ['.eslintrc.js'],
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+  },
 };


### PR DESCRIPTION
Solves the following issue (in nvim using `coc-eslint`). Didn't check other editors but they should have the same issue.
<img width="972" alt="Screen Shot 2022-07-08 at 14 22 19" src="https://user-images.githubusercontent.com/6951209/178041730-48af4f58-c242-464c-924b-ae5daa5adba1.png">
