### PR TITLE
chore: update light-mode colors for flamegraph component

### DIFF
--- a/webapp/javascript/ui/Button.module.scss
+++ b/webapp/javascript/ui/Button.module.scss
@@ -33,7 +33,7 @@ $border-radius: 4px;
   }
 
   &:disabled {
-    color: var(--ps-grey-disabled);
+    color: var(--ps-disabled-button-text);
     pointer-events: none;
   }
 }

--- a/webapp/javascript/ui/Select.module.scss
+++ b/webapp/javascript/ui/Select.module.scss
@@ -12,6 +12,6 @@
   background-color: var(--ps-ui-element-bg-primary);
 
   &:not([multiple]):not([size]) {
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' fill='white' height='4'%3E%3Cpath d='M4 0h6L7 4'/%3E%3C/svg%3E");
+    background-image: var(--dropdown-arrow);
   }
 }

--- a/webapp/sass/variables.css
+++ b/webapp/sass/variables.css
@@ -13,15 +13,17 @@
     4. --ps-ui-element-bg-highlight:  highlight of ui elements, selected app, table highlight, 
   */
 
-  --ps-ui-element-bg-primary: #242428; /* non-selected button background, highlighted button text (when buttons are green) */
+  --ps-ui-element-bg-primary: #2c2c30; /* non-selected button background, highlighted button text (when buttons are green) */
   --ps-ui-element-bg-highlight: #47474e; /* table and dropdown background highlight, disabled button background-color, dark button color, table borders, selected sidebar item highlight background */
 
+  --ps-ui-background: #0e0e13; /* background furthest back color */
   --ps-ui-border: #3b3b44; /* Note: same as --ps-grey-primary */
+  --ps-disabled-button-text: #404047; /* disabled button text */
   --ps-ui-foreground: #212124; /* sidebar background and "panel"/"box" background */
   --ps-ui-foreground-text: #d8d8d8; /* sidebar text and datepicker text */
-  --ps-ui-background: #0e0e13; /* background furthest back color */
   --ps-dropdown-background: #2c2c30; /* dropdown background */
   --ps-sidebar-separator: #d8d8d833; /* sidebar separation lines color */
+  --dropdown-arrow: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' fill='white' height='4'%3E%3Cpath d='M4 0h6L7 4'/%3E%3C/svg%3E");
 
   --ps-blue-primary: #0d8eff; /* Standard blue for button, instructions text (right) */
   --ps-blue-highlight: #40a6ff; /* highlight (hover) blue */
@@ -63,19 +65,21 @@
   --ps-neutral-2: #000000;
   --ps-neutral-9: #00000008; /* lighter background for table */
 
-  --ps-ui-element-bg-primary: #e2e2e2; /* non-selected button background, highlighted button text (when buttons are green) */
+  --ps-ui-element-bg-primary: #f8f8f8; /* non-selected button background, highlighted button text (when buttons are green) */
   --ps-ui-element-bg-highlight: #c4c4c4; /* table and dropdown background highlight, disabled button background-color, dark button color, table borders, selected sidebar item highlight background */
 
-  --ps-ui-border: #b2b2b2; /* Note: same as --ps-grey-primary */
+  --ps-ui-background: #eaeaea; /* original: background furthest back color */
+  --ps-ui-border: #cccccc; /* border color */
+  --ps-disabled-button-text: #cccccc; /* disabled button text */
   --ps-ui-foreground: #f8f8f8; /* sidebar background and "panel"/"box" background */
   --ps-ui-foreground-text: #272727; /* sidebar text and datepicker text */
-  --ps-ui-background: #eaeaea; /* background furthest back color */
-  --ps-dropdown-background: #e2e2e2; /* dropdown background */
+  --ps-dropdown-background: #f8f8f8; /* dropdown background */
   --ps-sidebar-separator: #d8d8d833; /* sidebar separation lines color */
+  --dropdown-arrow: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' fill='black' height='4'%3E%3Cpath d='M4 0h6L7 4'/%3E%3C/svg%3E");
 
-  --ps-selected-app: #0d8eff; /* active selected app color in dropdown */
+  --ps-selected-app: #1b73e7; /* active selected app color in dropdown */
 
-  --ps-green-primary: #7db26d; /* standard green */
-  --ps-green-highlight: #8fcb7c; /* highlight (hover) green */
-  --ps-green-disabled: #67935a; /* disabled green */
+  --ps-green-primary: #0bdb79; /* standard green */
+  --ps-green-highlight: #5bdc9e; /* highlight (hover) green */
+  --ps-green-disabled: #00a757; /* disabled green */
 }


### PR DESCRIPTION
When using the flamegraph component in light mode as we intend to for #1219 the colors are a little weird expecially for the buttons. This fixes them _somewhat_. Still not a huge fan of the green for the selected button, but I think its slightly better than it was before.. on light mode I'm thinking of replacing the green with blue for the selected item

Before:
<img width="1533" alt="image" src="https://user-images.githubusercontent.com/23323466/178086898-859ce47e-75ef-478e-9a1a-3d08d2a20ce9.png">

After:
![image](https://user-images.githubusercontent.com/23323466/178086854-a0562e0a-3957-4e9d-a1ec-16031fb1f424.png)
