### PR TITLE
fix(frontend): latest version do semantic checks

### DIFF
--- a/webapp/javascript/components/Footer.spec.tsx
+++ b/webapp/javascript/components/Footer.spec.tsx
@@ -1,13 +1,39 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import * as buildInfo from '../util/buildInfo';
 import Footer from './Footer';
 
 const mockDate = new Date('2021-12-21T12:44:01.741Z');
 
+jest.mock('../util/buildInfo.ts');
+
+const basicBuildInfo = {
+  goos: '',
+  goarch: '',
+  goVersion: '',
+  version: '',
+  time: '',
+  gitDirty: '',
+  gitSHA: '',
+  jsVersion: '',
+  useEmbeddedAssets: '',
+};
+
 describe('Footer', function () {
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(mockDate.getTime());
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe('trademark', function () {
     beforeEach(() => {
-      jest.useFakeTimers().setSystemTime(mockDate.getTime());
+      const buildInfoMock = jest.spyOn(buildInfo, 'buildInfo');
+      const latestVersionMock = jest.spyOn(buildInfo, 'latestVersionInfo');
+
+      buildInfoMock.mockImplementation(() => ({ ...basicBuildInfo }));
+      latestVersionMock.mockImplementation(() => ({ latest_version: '' }));
     });
 
     it('shows current year correctly', function () {
@@ -15,5 +41,42 @@ describe('Footer', function () {
 
       expect(queryByText(/Pyroscope 2020 – 2021/i)).toBeInTheDocument();
     });
+  });
+
+  describe('latest version', function () {
+    test.each([
+      // smaller
+      ['0.0.1', '1.0.0', true],
+      ['v0.0.1', 'v1.0.0', true],
+      // same version
+      ['1.0.0', '1.0.0', false],
+      ['v1.0.0', 'v1.0.0', false],
+      // current is bigger (bug with the server most likely)
+      ['1.0.0', '0.0.1', false],
+      ['v1.0.0', 'v0.0.1', false],
+    ])(
+      `currVer (%s), latestVer(%s) should show update available? '%s'`,
+      (v1, v2, display) => {
+        const buildInfoMock = jest.spyOn(buildInfo, 'buildInfo');
+        const latestVersionMock = jest.spyOn(buildInfo, 'latestVersionInfo');
+
+        buildInfoMock.mockImplementation(() => ({
+          ...basicBuildInfo,
+          version: v1,
+        }));
+
+        latestVersionMock.mockImplementation(() => ({ latest_version: v2 }));
+
+        const { queryByText } = render(<Footer />);
+
+        if (display) {
+          expect(queryByText(/Newer Version Available/i)).toBeInTheDocument();
+        } else {
+          expect(
+            queryByText(/Newer Version Available/i)
+          ).not.toBeInTheDocument();
+        }
+      }
+    );
   });
 });

--- a/webapp/javascript/components/Footer.spec.tsx
+++ b/webapp/javascript/components/Footer.spec.tsx
@@ -50,12 +50,15 @@ describe('Footer', function () {
       // smaller
       ['0.0.1', '1.0.0', true],
       ['v0.0.1', 'v1.0.0', true],
+      ['v9.0.1', 'v10.0.0', true],
+
       // same version
       ['1.0.0', '1.0.0', false],
       ['v1.0.0', 'v1.0.0', false],
       // current is bigger (bug with the server most likely)
       ['1.0.0', '0.0.1', false],
       ['v1.0.0', 'v0.0.1', false],
+      ['v10.0.1', 'v1.0.0', false],
     ])(
       `currVer (%s), latestVer(%s) should show update available? '%s'`,
       (v1, v2, display) => {

--- a/webapp/javascript/components/Footer.spec.tsx
+++ b/webapp/javascript/components/Footer.spec.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { Maybe } from 'true-myth';
 import * as buildInfo from '../util/buildInfo';
 import Footer from './Footer';
 
 const mockDate = new Date('2021-12-21T12:44:01.741Z');
 
 jest.mock('../util/buildInfo.ts');
+const actual = jest.requireActual('../util/buildInfo.ts');
 
 const basicBuildInfo = {
   goos: '',
@@ -33,7 +35,7 @@ describe('Footer', function () {
       const latestVersionMock = jest.spyOn(buildInfo, 'latestVersionInfo');
 
       buildInfoMock.mockImplementation(() => ({ ...basicBuildInfo }));
-      latestVersionMock.mockImplementation(() => ({ latest_version: '' }));
+      latestVersionMock.mockImplementation(() => actual.latestVersionInfo());
     });
 
     it('shows current year correctly', function () {
@@ -65,7 +67,9 @@ describe('Footer', function () {
           version: v1,
         }));
 
-        latestVersionMock.mockImplementation(() => ({ latest_version: v2 }));
+        latestVersionMock.mockImplementation(() =>
+          Maybe.of({ latest_version: v2 })
+        );
 
         const { queryByText } = render(<Footer />);
 
@@ -78,5 +82,16 @@ describe('Footer', function () {
         }
       }
     );
+
+    it('does not crash when version is not available', () => {
+      const buildInfoMock = jest.spyOn(buildInfo, 'buildInfo');
+      const latestVersionMock = jest.spyOn(buildInfo, 'latestVersionInfo');
+
+      buildInfoMock.mockImplementation(() => ({ ...basicBuildInfo }));
+      latestVersionMock.mockImplementation(() => Maybe.nothing());
+
+      const { queryByRole } = render(<Footer />);
+      expect(queryByRole('contentinfo')).toBeInTheDocument();
+    });
   });
 });

--- a/webapp/javascript/components/Footer.spec.tsx
+++ b/webapp/javascript/components/Footer.spec.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Footer from './Footer';
+
+const mockDate = new Date('2021-12-21T12:44:01.741Z');
+
+describe('Footer', function () {
+  describe('trademark', function () {
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(mockDate.getTime());
+    });
+
+    it('shows current year correctly', function () {
+      const { queryByText } = render(<Footer />);
+
+      expect(queryByText(/Pyroscope 2020 – 2021/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/webapp/javascript/components/Footer.tsx
+++ b/webapp/javascript/components/Footer.tsx
@@ -15,7 +15,6 @@ function copyrightYears(start: string, end: string) {
 const win = window as unknown as { buildInfo: BuildInfo };
 
 export interface BuildInfo {
-  id: string;
   goos: string;
   goarch: string;
   goVersion: string;
@@ -29,26 +28,46 @@ function buildInfo() {
   return `
     BUILD INFO:
     js_version: v${PYROSCOPE_VERSION}
-    goos: ${win.buildInfo.goos}
-    goarch: ${win.buildInfo.goarch}
-    go_version: ${win.buildInfo.goVersion}
-    version: ${win.buildInfo.version}
-    id: ${win.buildInfo.id}
-    time: ${win.buildInfo.time}
-    gitSHA: ${win.buildInfo.gitSHA}
-    gitDirty: ${win.buildInfo.gitDirty}
-    embeddedAssets: ${win.buildInfo.useEmbeddedAssets}
+    goos: ${win?.buildInfo?.goos}
+    goarch: ${win.buildInfo?.goarch}
+    go_version: ${win.buildInfo?.goVersion}
+    version: ${win.buildInfo?.version}
+    time: ${win.buildInfo?.time}
+    gitSHA: ${win.buildInfo?.gitSHA}
+    gitDirty: ${win.buildInfo?.gitDirty}
+    embeddedAssets: ${win.buildInfo?.useEmbeddedAssets}
 `.replace(/^\s+/gm, '');
 }
 
-function Footer() {
-  const latestVersion = (win as ShamefulAny).latestVersionInfo
-    .latest_version as string;
-  const newVersionAvailable =
-    latestVersion && win.buildInfo.version !== latestVersion;
+//function NewerVersionCheck() {
+//  const latestVersion = (win as ShamefulAny).latestVersionInfo
+//    .latest_version as string;
+//  const newVersionAvailable =
+//    latestVersion && win.buildInfo.version !== latestVersion;
+//
+//  if (!newVersionAvailable) {
+//    return null;
+//  }
+//
+//  return (
+//    <span>
+//      &nbsp;&nbsp;|&nbsp;&nbsp;
+//      <a
+//        href="https://pyroscope.io/downloads?utm_source=pyroscope_footer"
+//        rel="noreferrer"
+//        target="_blank"
+//      >
+//        <FontAwesomeIcon icon={faDownload} />
+//        &nbsp;
+//        <span>{`Newer Version Available (${latestVersion})`}</span>
+//      </a>
+//    </span>
+//  );
+//}
 
+function Footer() {
   return (
-    <div className="footer" title={buildInfo()}>
+    <footer className="footer" title={buildInfo()}>
       <span>
         {`© Pyroscope ${copyrightYears(
           START_YEAR,
@@ -56,22 +75,8 @@ function Footer() {
         )}`}
       </span>
       &nbsp;&nbsp;|&nbsp;&nbsp;
-      <span>{win.buildInfo.version}</span>
-      {newVersionAvailable && (
-        <span>
-          &nbsp;&nbsp;|&nbsp;&nbsp;
-          <a
-            href="https://pyroscope.io/downloads?utm_source=pyroscope_footer"
-            rel="noreferrer"
-            target="_blank"
-          >
-            <FontAwesomeIcon icon={faDownload} />
-            &nbsp;
-            <span>{`Newer Version Available (${latestVersion})`}</span>
-          </a>
-        </span>
-      )}
-    </div>
+      <span>{win.buildInfo?.version}</span>
+    </footer>
   );
 }
 

--- a/webapp/javascript/components/Footer.tsx
+++ b/webapp/javascript/components/Footer.tsx
@@ -37,9 +37,9 @@ function NewerVersionCheck() {
   const latestVersion = maybeLatestVersionInfo.value.latest_version;
 
   interface Version {
-    major: string;
-    minor: string;
-    patch: string;
+    major: number;
+    minor: number;
+    patch: number;
   }
 
   const splitVersion = function (s: string): Maybe<Version> {
@@ -51,9 +51,9 @@ function NewerVersionCheck() {
 
     return Maybe.of({
       // handle cases like v1.0.0
-      major: split[0].replace('v', ''),
-      minor: split[1],
-      patch: split[2],
+      major: parseInt(split[0].replace('v', ''), 10),
+      minor: parseInt(split[1], 10),
+      patch: parseInt(split[2], 10),
     });
   };
 

--- a/webapp/javascript/components/Footer.tsx
+++ b/webapp/javascript/components/Footer.tsx
@@ -28,7 +28,13 @@ function buildInfoStr(buildInfo: BuildInfo) {
 
 function NewerVersionCheck() {
   const { version } = buildInfo();
-  const { latest_version: latestVersion } = latestVersionInfo();
+  const maybeLatestVersionInfo = latestVersionInfo();
+
+  if (maybeLatestVersionInfo.isNothing) {
+    return null;
+  }
+
+  const latestVersion = maybeLatestVersionInfo.value.latest_version;
 
   interface Version {
     major: string;

--- a/webapp/javascript/components/Footer.tsx
+++ b/webapp/javascript/components/Footer.tsx
@@ -2,48 +2,34 @@ import React from 'react';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faDownload } from '@fortawesome/free-solid-svg-icons/faDownload';
-// eslint-disable-next-line import/no-relative-packages
-import { version } from '../../../package.json';
+import { BuildInfo, buildInfo, latestVersionInfo } from '../util/buildInfo';
 
 const START_YEAR = '2020';
-const PYROSCOPE_VERSION = version;
 
 function copyrightYears(start: string, end: string) {
   return start === end ? start : `${start} – ${end}`;
 }
 
-const win = window as unknown as { buildInfo: BuildInfo };
-
-export interface BuildInfo {
-  goos: string;
-  goarch: string;
-  goVersion: string;
-  version: string;
-  time: string;
-  gitSHA: string;
-  gitDirty: string;
-  useEmbeddedAssets: string;
-}
-function buildInfo() {
+function buildInfoStr(buildInfo: BuildInfo) {
   return `
     BUILD INFO:
-    js_version: v${PYROSCOPE_VERSION}
-    goos: ${win?.buildInfo?.goos}
-    goarch: ${win.buildInfo?.goarch}
-    go_version: ${win.buildInfo?.goVersion}
-    version: ${win.buildInfo?.version}
-    time: ${win.buildInfo?.time}
-    gitSHA: ${win.buildInfo?.gitSHA}
-    gitDirty: ${win.buildInfo?.gitDirty}
-    embeddedAssets: ${win.buildInfo?.useEmbeddedAssets}
+    js_version: v${buildInfo.jsVersion}
+    goos: ${buildInfo?.goos}
+    goarch: ${buildInfo?.goarch}
+    go_version: ${buildInfo?.goVersion}
+    version: ${buildInfo?.version}
+    time: ${buildInfo?.time}
+    gitSHA: ${buildInfo?.gitSHA}
+    gitDirty: ${buildInfo?.gitDirty}
+    embeddedAssets: ${buildInfo?.useEmbeddedAssets}
 `.replace(/^\s+/gm, '');
 }
 
 //function NewerVersionCheck() {
 //  const latestVersion = (win as ShamefulAny).latestVersionInfo
-//    .latest_version as string;
+//    ?.latest_version as string;
 //  const newVersionAvailable =
-//    latestVersion && win.buildInfo.version !== latestVersion;
+//    latestVersion && win?.buildInfo?.version !== latestVersion;
 //
 //  if (!newVersionAvailable) {
 //    return null;
@@ -64,10 +50,12 @@ function buildInfo() {
 //    </span>
 //  );
 //}
-
+//
 function Footer() {
+  const info = buildInfo();
+
   return (
-    <footer className="footer" title={buildInfo()}>
+    <footer className="footer" title={buildInfoStr(info)}>
       <span>
         {`© Pyroscope ${copyrightYears(
           START_YEAR,
@@ -75,7 +63,7 @@ function Footer() {
         )}`}
       </span>
       &nbsp;&nbsp;|&nbsp;&nbsp;
-      <span>{win.buildInfo?.version}</span>
+      <span>{info.version}</span>
     </footer>
   );
 }

--- a/webapp/javascript/standalone.module.scss
+++ b/webapp/javascript/standalone.module.scss
@@ -1,8 +1,0 @@
-.container {
-  width: 100%;
-}
-
-.footer {
-  text-align: center;
-  padding: 30px 0;
-}

--- a/webapp/javascript/standalone.tsx
+++ b/webapp/javascript/standalone.tsx
@@ -6,10 +6,6 @@ import { decodeFlamebearer } from '@webapp/models/flamebearer';
 import { FlamegraphRenderer } from '@pyroscope/flamegraph';
 import Footer from './components/Footer';
 import '@pyroscope/flamegraph/dist/index.css';
-import styles from './standalone.module.scss';
-
-// Enable this if you are developing and don't want to run a server
-// (window as any).flamegraph = defaultFlamegraph;
 
 if (!(window as ShamefulAny).flamegraph) {
   alert(`'flamegraph' is required`);
@@ -24,7 +20,7 @@ function StandaloneApp() {
 
   return (
     <div>
-      <Box className={styles.container}>
+      <Box>
         <FlamegraphRenderer
           flamebearer={flamebearer as ShamefulAny}
           showCredit={false}

--- a/webapp/javascript/standalone.tsx
+++ b/webapp/javascript/standalone.tsx
@@ -23,7 +23,6 @@ function StandaloneApp() {
       <Box>
         <FlamegraphRenderer
           flamebearer={flamebearer as ShamefulAny}
-          showCredit={false}
           ExportData={null}
         />
       </Box>

--- a/webapp/javascript/standalone.tsx
+++ b/webapp/javascript/standalone.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Box from '@webapp/ui/Box';
 import { decodeFlamebearer } from '@webapp/models/flamebearer';
 import { FlamegraphRenderer } from '@pyroscope/flamegraph';
-import { BuildInfo } from './components/Footer';
+import Footer from './components/Footer';
 import '@pyroscope/flamegraph/dist/index.css';
 import styles from './standalone.module.scss';
 
@@ -19,22 +19,6 @@ if (!(window as ShamefulAny).flamegraph) {
 // TODO parse window.flamegraph
 const { flamegraph } = window as ShamefulAny;
 
-// TODO: unify with the one in Footer component
-function buildInfo() {
-  const w = (window as ShamefulAny).buildInfo as BuildInfo;
-  return `
-    BUILD INFO:
-    goos: ${w.goos}
-    goarch: ${w.goarch}
-    go_version: ${w.goVersion}
-    version: ${w.version}
-    time: ${w.time}
-    gitSHA: ${w.gitSHA}
-    gitDirty: ${w.gitDirty}
-    embeddedAssets: ${w.useEmbeddedAssets}
-`.replace(/^\s+/gm, '');
-}
-
 function StandaloneApp() {
   const flamebearer = decodeFlamebearer(flamegraph);
 
@@ -47,9 +31,7 @@ function StandaloneApp() {
           ExportData={null}
         />
       </Box>
-      <div className={styles.footer} title={buildInfo()}>
-        {`Copyright © 2020 – ${new Date().getFullYear()} Pyroscope, Inc`}
-      </div>
+      <Footer />
     </div>
   );
 }

--- a/webapp/javascript/util/buildInfo.ts
+++ b/webapp/javascript/util/buildInfo.ts
@@ -1,0 +1,44 @@
+// eslint-disable-next-line import/no-relative-packages
+import { version as jsVersion } from '../../../package.json';
+
+export interface BuildInfo {
+  goos: string;
+  goarch: string;
+  goVersion: string;
+  version: string;
+  time: string;
+  gitSHA: string;
+  gitDirty: string;
+  useEmbeddedAssets: string;
+  jsVersion: string;
+}
+
+export const buildInfo = function (): BuildInfo {
+  // TODO: it may be possible that these fields are not populated
+  const win = window as unknown as { buildInfo: BuildInfo };
+
+  return {
+    jsVersion,
+    goos: win.buildInfo?.goos,
+    goarch: win.buildInfo?.goarch,
+    goVersion: win.buildInfo?.goVersion,
+    version: win.buildInfo?.version,
+    time: win.buildInfo?.time,
+    gitSHA: win.buildInfo?.gitSHA,
+    gitDirty: win.buildInfo?.gitDirty,
+    useEmbeddedAssets: win.buildInfo?.useEmbeddedAssets,
+  };
+};
+
+interface LatestVersionInfo {
+  latest_version: string;
+}
+
+export const latestVersionInfo = function (): LatestVersionInfo {
+  // TODO: it may be possible that these fields are not populated
+  const win = window as unknown as { latestVersionInfo: LatestVersionInfo };
+
+  return {
+    latest_version: win.latestVersionInfo.latest_version,
+  };
+};

--- a/webapp/javascript/util/buildInfo.ts
+++ b/webapp/javascript/util/buildInfo.ts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line import/no-relative-packages
+import { Maybe } from 'true-myth';
 import { version as jsVersion } from '../../../package.json';
 
 export interface BuildInfo {
@@ -15,6 +16,7 @@ export interface BuildInfo {
 
 export const buildInfo = function (): BuildInfo {
   // TODO: it may be possible that these fields are not populated
+  // but as for now assume it is always present
   const win = window as unknown as { buildInfo: BuildInfo };
 
   return {
@@ -34,11 +36,16 @@ interface LatestVersionInfo {
   latest_version: string;
 }
 
-export const latestVersionInfo = function (): LatestVersionInfo {
-  // TODO: it may be possible that these fields are not populated
+// Make it explicit that this field may not be populated
+// for cases like standalone
+export const latestVersionInfo = function (): Maybe<LatestVersionInfo> {
   const win = window as unknown as { latestVersionInfo: LatestVersionInfo };
 
-  return {
+  if (!win.latestVersionInfo) {
+    return Maybe.nothing();
+  }
+
+  return Maybe.of({
     latest_version: win.latestVersionInfo.latest_version,
-  };
+  });
 };


### PR DESCRIPTION
Now the frontend checks if latest version is indeed NEWER (ie semantic version check).
Instead of pulling a library or writing a more robust parser, I decided to just support our specific case (exact matches), since we don't do anything fancy (`>^~`).

Also adds tests and make standalone footer be the same as the webapp's footer.

Hopefully closes https://github.com/pyroscope-io/pyroscope/issues/835 and https://github.com/pyroscope-io/pyroscope/issues/494