### PR TITLE
feat: adds support for group-by queries on the backend

### DIFF
--- a/cypress/fixtures/cart-service-dotnet-cpu.json
+++ b/cypress/fixtures/cart-service-dotnet-cpu.json
@@ -197,5 +197,6 @@
     "startTime": 1634591500,
     "samples": [361, 1613, 360, 908],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/hotrod-python-driver-cpu.json
+++ b/cypress/fixtures/hotrod-python-driver-cpu.json
@@ -112,5 +112,6 @@
     "startTime": 1634591500,
     "samples": [2405, 2168, 1761, 1829],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/hotrod-ruby-driver-cpu.json
+++ b/cypress/fixtures/hotrod-ruby-driver-cpu.json
@@ -184,5 +184,6 @@
     "startTime": 1634591500,
     "samples": [9, 13, 12, 11],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/pyroscope.server.alloc_objects.json
+++ b/cypress/fixtures/pyroscope.server.alloc_objects.json
@@ -137,5 +137,6 @@
     "startTime": 1632505880,
     "samples": [26580, 48911],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/pyroscope.server.alloc_space.json
+++ b/cypress/fixtures/pyroscope.server.alloc_space.json
@@ -146,5 +146,6 @@
     "startTime": 1632505880,
     "samples": [7116106, 5404818],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/pyroscope.server.cpu.json
+++ b/cypress/fixtures/pyroscope.server.cpu.json
@@ -113,5 +113,6 @@
     "startTime": 1632505880,
     "samples": [14, 14],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/pyroscope.server.inuse_objects.json
+++ b/cypress/fixtures/pyroscope.server.inuse_objects.json
@@ -180,5 +180,6 @@
     "startTime": 1632505880,
     "samples": [57657, 31258],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/pyroscope.server.inuse_space.json
+++ b/cypress/fixtures/pyroscope.server.inuse_space.json
@@ -187,5 +187,6 @@
     "startTime": 1632505880,
     "samples": [450187206, 448452204],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/render.json
+++ b/cypress/fixtures/render.json
@@ -37,5 +37,6 @@
     "startTime": 1631138160,
     "samples": [1, 3, 1, 2, 2, 4, 2, 3, 1, 1, 3, 4],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/render2.json
+++ b/cypress/fixtures/render2.json
@@ -28,5 +28,6 @@
     "startTime": 1631138160,
     "samples": [1, 3, 1, 2, 2, 4, 2, 3, 1, 1, 3, 4],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/shipping-service-go-cpu.json
+++ b/cypress/fixtures/shipping-service-go-cpu.json
@@ -225,5 +225,6 @@
     "startTime": 1634591500,
     "samples": [12, 16, 16, 17],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/simple-dotnet-app-cpu.json
+++ b/cypress/fixtures/simple-dotnet-app-cpu.json
@@ -28,5 +28,6 @@
     "startTime": 1632504460,
     "samples": [0, 46],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/simple-golang-app-cpu-diff.json
+++ b/cypress/fixtures/simple-golang-app-cpu-diff.json
@@ -63,5 +63,6 @@
     "startTime": 1633024290,
     "samples": [992, 988],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/simple-golang-app-cpu.json
+++ b/cypress/fixtures/simple-golang-app-cpu.json
@@ -31,5 +31,6 @@
     "startTime": 1632335270,
     "samples": [989],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/simple-golang-app-cpu2.json
+++ b/cypress/fixtures/simple-golang-app-cpu2.json
@@ -34,5 +34,6 @@
     "startTime": 1633024290,
     "samples": [992],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/simple-java-app-cpu.json
+++ b/cypress/fixtures/simple-java-app-cpu.json
@@ -53,5 +53,10 @@
     "spyName": "javaspy",
     "units": "samples"
   },
-  "timeline": { "startTime": 1632504610, "samples": [991], "durationDelta": 10 }
+  "timeline": {
+    "startTime": 1632504610,
+    "samples": [991],
+    "durationDelta": 10
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/simple-php-app-cpu.json
+++ b/cypress/fixtures/simple-php-app-cpu.json
@@ -22,5 +22,6 @@
     "startTime": 1632504370,
     "samples": [0, 2],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/simple-python-app-cpu.json
+++ b/cypress/fixtures/simple-python-app-cpu.json
@@ -44,5 +44,6 @@
     "startTime": 1632504210,
     "samples": [1001],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/cypress/fixtures/simple-ruby-app-cpu.json
+++ b/cypress/fixtures/simple-ruby-app-cpu.json
@@ -33,5 +33,6 @@
     "startTime": 1632504320,
     "samples": [942, 1001],
     "durationDelta": 10
-  }
+  },
+  "groups": {}
 }

--- a/pkg/server/render.go
+++ b/pkg/server/render.go
@@ -172,6 +172,7 @@ func (rh *RenderHandler) renderParametersFromRequest(r *http.Request, p *renderP
 
 	k := v.Get("name")
 	q := v.Get("query")
+	p.gi.GroupBy = v.Get("groupBy")
 
 	switch {
 	case k == "" && q == "":
@@ -192,6 +193,9 @@ func (rh *RenderHandler) renderParametersFromRequest(r *http.Request, p *renderP
 
 	p.maxNodes = rh.maxNodesDefault
 	if mn, err := strconv.Atoi(v.Get("max-nodes")); err == nil && mn > 0 {
+		p.maxNodes = mn
+	}
+	if mn, err := strconv.Atoi(v.Get("maxNodes")); err == nil && mn > 0 {
 		p.maxNodes = mn
 	}
 

--- a/pkg/structs/flamebearer/flamebearer.go
+++ b/pkg/structs/flamebearer/flamebearer.go
@@ -32,7 +32,8 @@ type FlamebearerProfileV1 struct {
 	// required: true
 	Metadata FlamebearerMetadataV1 `json:"metadata"`
 	// Timeline associated to the profile, used for continuous profiling only.
-	Timeline *FlamebearerTimelineV1 `json:"timeline"`
+	Timeline *FlamebearerTimelineV1            `json:"timeline"`
+	Groups   map[string]*FlamebearerTimelineV1 `json:"groups"`
 	// Number of samples in the left / base profile. Only used in "double" format.
 	LeftTicks uint64 `json:"leftTicks,omitempty"`
 	// Number of samples in the right / diff profile. Only used in "double" format.
@@ -108,9 +109,18 @@ func NewProfile(name string, output *storage.GetOutput, maxNodes int) Flamebeare
 			Flamebearer: newFlambearer(fb),
 			Metadata:    newMetadata(name, fb.Format, output),
 			Timeline:    NewTimeline(output.Timeline),
+			Groups:      convertGroups(output.Groups),
 		},
 		Telemetry: output.Telemetry,
 	}
+}
+
+func convertGroups(v map[string]*segment.Timeline) map[string]*FlamebearerTimelineV1 {
+	res := make(map[string]*FlamebearerTimelineV1)
+	for k, v := range v {
+		res[k] = NewTimeline(v)
+	}
+	return res
 }
 
 func NewCombinedProfile(name string, left, right *storage.GetOutput, maxNodes int) (FlamebearerProfile, error) {

--- a/webapp/javascript/services/render.ts
+++ b/webapp/javascript/services/render.ts
@@ -39,7 +39,7 @@ export async function renderSingle(
     z.object({ timeline: TimelineSchema })
   )
     .merge(z.object({ telemetry: z.object({}).passthrough().optional() }))
-    .merge(z.object({ groups: z.object({}) }))
+    .merge(z.object({ groups: z.object({}).passthrough().optional() }))
     .safeParse(response.value);
 
   if (parsed.success) {

--- a/webapp/javascript/services/render.ts
+++ b/webapp/javascript/services/render.ts
@@ -39,6 +39,7 @@ export async function renderSingle(
     z.object({ timeline: TimelineSchema })
   )
     .merge(z.object({ telemetry: z.object({}).passthrough().optional() }))
+    .merge(z.object({ groups: z.object({}) }))
     .safeParse(response.value);
 
   if (parsed.success) {


### PR DESCRIPTION
To test:
```shell
# to create data
curl -X POST --data 'foo;bar;baz 100' 'http://localhost:4040/ingest?name=0-app%7Bfoo%3D%22bar%22%7D'
curl -X POST --data 'foo;bar;baz 100' 'http://localhost:4040/ingest?name=0-app%7Bfoo%3D%22baz%22%7D'

# then to get the data
curl 'http://localhost:4040/render?from=now-1m&until=now&query=0-app&groupBy=foo&format=json' | jq .groups
```