### PR TITLE
build(flamegraph): only build types

### DIFF
--- a/packages/pyroscope-flamegraph/package.json
+++ b/packages/pyroscope-flamegraph/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "test": "jest",
     "build": "yarn build:types && NODE_ENV=production webpack --config ../../scripts/webpack/webpack.flamegraph.ts",
-    "build:types": "tsc -p tsconfig.json",
+    "build:types": "tsc -p tsconfig.json --emitDeclarationOnly",
     "build:types:watch": "tsc -p tsconfig.json --watch --preserveWatchOutput",
     "type-check": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint ./ --cache --fix",


### PR DESCRIPTION
Before this PR, the flamegraph was shipping with js files. We instead only want to ship a bundled version + types (with souremap).