### PR TITLE
chore(flamegraph): ship raw files

### DIFF
--- a/packages/pyroscope-flamegraph/package.json
+++ b/packages/pyroscope-flamegraph/package.json
@@ -7,6 +7,7 @@
   "types": "dist/packages/pyroscope-flamegraph/src/index.d.ts",
   "license": "Apache-2.0",
   "files": [
+    "src/FlamegraphRenderer.tsx",
     "dist/**/*",
     "package.json",
     "README.md",
@@ -16,11 +17,9 @@
     "test": "jest",
     "build": "yarn build:types && NODE_ENV=production webpack --config ../../scripts/webpack/webpack.flamegraph.ts",
     "build:types": "tsc -p tsconfig.json --emitDeclarationOnly",
-    "build:types:watch": "tsc -p tsconfig.json --watch --preserveWatchOutput",
+    "build:types:watch": "tsc -p tsconfig.json --emitDeclarationOnly --watch --preserveWatchOutput",
     "type-check": "tsc -p tsconfig.json --noEmit",
-    "lint": "eslint ./ --cache --fix",
-    "dev": "NODE_ENV=production webpack --config ../../scripts/webpack/webpack.flamegraph.ts --watch",
-    "watch": "yarn build:types:watch & yarn dev"
+    "lint": "eslint ./ --cache --fix"
   },
   "peerDependencies": {
     "react": ">=16.14.0",

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Flamegraph.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Flamegraph.ts
@@ -1,6 +1,11 @@
 import { DeepReadonly } from 'ts-essentials';
 import { Maybe } from 'true-myth';
-import { createFF, Flamebearer, singleFF, doubleFF } from '@pyroscope/models';
+import {
+  createFF,
+  Flamebearer,
+  singleFF,
+  doubleFF,
+} from '@pyroscope/models/src';
 import { PX_PER_LEVEL, BAR_HEIGHT, COLLAPSE_THRESHOLD } from './constants';
 import type { FlamegraphPalette } from './colorPalette';
 // there's a dependency cycle here but it should be fine

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Flamegraph_render.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Flamegraph_render.ts
@@ -22,7 +22,7 @@ THIS SOFTWARE.
 */
 
 /* eslint-disable no-continue */
-import { createFF, Flamebearer } from '@pyroscope/models';
+import { createFF, Flamebearer } from '@pyroscope/models/src';
 import {
   formatPercent,
   getFormatter,

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Header.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Flamebearer } from '@pyroscope/models';
+import { Flamebearer } from '@pyroscope/models/src';
 import styles from './Header.module.css';
 import { FlamegraphPalette } from './colorPalette';
 import { DiffLegendPaletteDropdown } from './DiffLegendPaletteDropdown';

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Tooltip.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Tooltip.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Maybe } from 'true-myth';
-import { Units } from '@pyroscope/models';
+import { Units } from '@pyroscope/models/src';
 import type { Unwrapped } from 'true-myth/maybe';
 import {
   getFormatter,

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/index.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/index.tsx
@@ -5,7 +5,7 @@ import { MenuItem } from '@szhsin/react-menu';
 import useResizeObserver from '@react-hook/resize-observer';
 import { Maybe } from 'true-myth';
 import debounce from 'lodash.debounce';
-import { Flamebearer } from '@pyroscope/models';
+import { Flamebearer } from '@pyroscope/models/src';
 import styles from './canvas.module.css';
 import Flamegraph from './Flamegraph';
 import Highlight from './Highlight';

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/utils.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/utils.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/prefer-default-export */
-import { doubleFF } from '@pyroscope/models';
+import { doubleFF } from '@pyroscope/models/src';
 
 // not entirely sure where this should fit
 function getRatios(

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -8,7 +8,7 @@
 import React, { Dispatch, SetStateAction } from 'react';
 import clsx from 'clsx';
 import { Maybe } from 'true-myth';
-import { createFF, Flamebearer, Profile, Trace } from '@pyroscope/models';
+import { createFF, Flamebearer, Profile, Trace } from '@pyroscope/models/src';
 import Graph from './FlameGraphComponent';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: let's move this to typescript some time in the future

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -400,6 +400,7 @@ class FlameGraphRenderer extends React.Component<
   }
 
   render = () => {
+    console.log('hey');
     // This is necessary because the order switches depending on single vs comparison view
     const tablePane = (
       <div

--- a/packages/pyroscope-flamegraph/src/FlameGraph/decode.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/decode.ts
@@ -1,4 +1,4 @@
-import { Profile } from '@pyroscope/models';
+import { Profile } from '@pyroscope/models/src';
 
 function deltaDiffWrapper(
   format: Profile['metadata']['format'],

--- a/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
+++ b/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-import { doubleFF, singleFF, Flamebearer } from '@pyroscope/models';
+import { doubleFF, singleFF, Flamebearer } from '@pyroscope/models/src';
 import Color from 'color';
 import { Maybe } from 'true-myth';
 import { getFormatter } from './format/format';

--- a/packages/pyroscope-flamegraph/src/convert/convert.ts
+++ b/packages/pyroscope-flamegraph/src/convert/convert.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 import groupBy from 'lodash.groupby';
 import map from 'lodash.map';
-import type { Flamebearer, Trace, TraceSpan } from '@pyroscope/models';
+import type { Flamebearer, Trace, TraceSpan } from '@pyroscope/models/src';
 
 interface Span extends TraceSpan {
   children: Span[];

--- a/packages/pyroscope-flamegraph/src/format/format.ts
+++ b/packages/pyroscope-flamegraph/src/format/format.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-classes-per-file */
-import { Units } from '@pyroscope/models';
+import { Units } from '@pyroscope/models/src';
 
 export function numberWithCommas(x: number): string {
   return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');

--- a/packages/pyroscope-models/package.json
+++ b/packages/pyroscope-models/package.json
@@ -4,6 +4,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
+  "files": [
+    "src/index.ts"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "type-check": "tsc -p tsconfig.json --noEmit",

--- a/webapp/javascript/components/ExportData.spec.tsx
+++ b/webapp/javascript/components/ExportData.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 // import { SimpleSingle as TestData } from '@utils/testData';
 import { render, screen } from '@testing-library/react';
-import { Profile } from '@pyroscope/models';
+import { Profile } from '@pyroscope/models/src';
 import ExportData, { getFilename } from './ExportData';
 
 describe('ExportData', () => {

--- a/webapp/javascript/components/ExportData.tsx
+++ b/webapp/javascript/components/ExportData.tsx
@@ -6,7 +6,7 @@ import Button from '@webapp/ui/Button';
 import { faBars } from '@fortawesome/free-solid-svg-icons/faBars';
 import { buildRenderURL } from '@webapp/util/updateRequests';
 import { convertPresetsToDate } from '@webapp/util/formatDate';
-import { Profile } from '@pyroscope/models';
+import { Profile } from '@pyroscope/models/src';
 import showModalWithInput from './Modals/ModalWithInput';
 
 import styles from './ExportData.module.scss';

--- a/webapp/javascript/components/exportToFlamegraphDotCom.hook.ts
+++ b/webapp/javascript/components/exportToFlamegraphDotCom.hook.ts
@@ -1,4 +1,4 @@
-import { Profile } from '@pyroscope/models';
+import { Profile } from '@pyroscope/models/src';
 import { shareWithFlamegraphDotcom } from '@webapp/services/share';
 import { useAppDispatch } from '@webapp/redux/hooks';
 import handleError from '@webapp/util/handleError';

--- a/webapp/javascript/index.jsx
+++ b/webapp/javascript/index.jsx
@@ -23,7 +23,6 @@ import ServiceDiscoveryApp from './pages/ServiceDiscovery';
 import ServerNotifications from './components/ServerNotifications';
 import Protected from './components/Protected';
 // since this style is practically all pages
-import '@pyroscope/flamegraph/dist/index.css';
 
 import SignInPage from './pages/IntroPages/SignIn';
 import SignUpPage from './pages/IntroPages/SignUp';

--- a/webapp/javascript/models/flamebearer.ts
+++ b/webapp/javascript/models/flamebearer.ts
@@ -1,4 +1,4 @@
-import { Units } from '@pyroscope/models';
+import { Units } from '@pyroscope/models/src';
 import { deltaDiffWrapper } from '@webapp/util/flamebearer';
 
 export type Flamebearer = {

--- a/webapp/javascript/pages/AdhocComparison.tsx
+++ b/webapp/javascript/pages/AdhocComparison.tsx
@@ -7,7 +7,7 @@ import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import Spinner from 'react-svg-spinner';
 import { FlamegraphRenderer } from '@pyroscope/flamegraph/src/FlamegraphRenderer';
 import classNames from 'classnames';
-import { Profile } from '@pyroscope/models';
+import { Profile } from '@pyroscope/models/src';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import FileList from '@webapp/components/FileList';

--- a/webapp/javascript/pages/AdhocComparison.tsx
+++ b/webapp/javascript/pages/AdhocComparison.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch, useOldRootSelector } from '@webapp/redux/hooks';
 import Box from '@webapp/ui/Box';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import Spinner from 'react-svg-spinner';
-import { FlamegraphRenderer } from '@pyroscope/flamegraph';
+import { FlamegraphRenderer } from '@pyroscope/flamegraph/src/FlamegraphRenderer';
 import classNames from 'classnames';
 import { Profile } from '@pyroscope/models';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/webapp/javascript/pages/AdhocDiff.tsx
+++ b/webapp/javascript/pages/AdhocDiff.tsx
@@ -6,7 +6,7 @@ import Box from '@webapp/ui/Box';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import Spinner from 'react-svg-spinner';
 import classNames from 'classnames';
-import { FlamegraphRenderer } from '@pyroscope/flamegraph';
+import { FlamegraphRenderer } from '@pyroscope/flamegraph/src/FlamegraphRenderer';
 import { Profile } from '@pyroscope/models';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore

--- a/webapp/javascript/pages/AdhocDiff.tsx
+++ b/webapp/javascript/pages/AdhocDiff.tsx
@@ -7,7 +7,7 @@ import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import Spinner from 'react-svg-spinner';
 import classNames from 'classnames';
 import { FlamegraphRenderer } from '@pyroscope/flamegraph/src/FlamegraphRenderer';
-import { Profile } from '@pyroscope/models';
+import { Profile } from '@pyroscope/models/src';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import FileList from '@webapp/components/FileList';

--- a/webapp/javascript/pages/AdhocSingle.tsx
+++ b/webapp/javascript/pages/AdhocSingle.tsx
@@ -6,7 +6,7 @@ import Box from '@webapp/ui/Box';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import Spinner from 'react-svg-spinner';
 import { FlamegraphRenderer } from '@pyroscope/flamegraph/src/FlamegraphRenderer';
-import { Profile } from '@pyroscope/models';
+import { Profile } from '@pyroscope/models/src';
 import classNames from 'classnames';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore

--- a/webapp/javascript/pages/AdhocSingle.tsx
+++ b/webapp/javascript/pages/AdhocSingle.tsx
@@ -5,7 +5,7 @@ import { useAppDispatch, useOldRootSelector } from '@webapp/redux/hooks';
 import Box from '@webapp/ui/Box';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import Spinner from 'react-svg-spinner';
-import { FlamegraphRenderer } from '@pyroscope/flamegraph';
+import { FlamegraphRenderer } from '@pyroscope/flamegraph/src/FlamegraphRenderer';
 import { Profile } from '@pyroscope/models';
 import classNames from 'classnames';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/webapp/javascript/pages/ContinuousComparisonView.tsx
+++ b/webapp/javascript/pages/ContinuousComparisonView.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import 'react-dom';
 
 import Box from '@webapp/ui/Box';
-import { FlamegraphRenderer } from '@pyroscope/flamegraph';
+import { FlamegraphRenderer } from '@pyroscope/flamegraph/src/FlamegraphRenderer';
 import { useAppDispatch, useAppSelector } from '@webapp/redux/hooks';
 import {
   selectContinuousState,

--- a/webapp/javascript/pages/ContinuousDiffView.tsx
+++ b/webapp/javascript/pages/ContinuousDiffView.tsx
@@ -8,7 +8,7 @@ import {
   fetchTagValues,
   selectQueries,
 } from '@webapp/redux/reducers/continuous';
-import { FlamegraphRenderer } from '@pyroscope/flamegraph';
+import { FlamegraphRenderer } from '@pyroscope/flamegraph/src/FlamegraphRenderer';
 import usePopulateLeftRightQuery from '@webapp/hooks/populateLeftRightQuery.hook';
 import useTimelines, {
   leftColor,

--- a/webapp/javascript/pages/ContinuousSingleView.tsx
+++ b/webapp/javascript/pages/ContinuousSingleView.tsx
@@ -3,7 +3,7 @@ import 'react-dom';
 
 import { useAppDispatch, useAppSelector } from '@webapp/redux/hooks';
 import Box from '@webapp/ui/Box';
-import { FlamegraphRenderer } from '@pyroscope/flamegraph';
+import { FlamegraphRenderer } from '@pyroscope/flamegraph/src/FlamegraphRenderer';
 import {
   fetchSingleView,
   setDateRange,

--- a/webapp/javascript/redux/reducers/continuous.ts
+++ b/webapp/javascript/redux/reducers/continuous.ts
@@ -1,4 +1,4 @@
-import { Profile } from '@pyroscope/models';
+import { Profile } from '@pyroscope/models/src';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { AppNames } from '@webapp/models/appNames';
 import { Query, brandQuery, queryToAppName } from '@webapp/models/query';

--- a/webapp/javascript/services/TestData.ts
+++ b/webapp/javascript/services/TestData.ts
@@ -1,4 +1,4 @@
-import { Profile } from '@pyroscope/models';
+import { Profile } from '@pyroscope/models/src';
 
 const SimpleGoApp: Profile = {
   flamebearer: {

--- a/webapp/javascript/services/render.ts
+++ b/webapp/javascript/services/render.ts
@@ -1,5 +1,5 @@
 import { Result } from '@webapp/util/fp';
-import { Profile, FlamebearerProfileSchema } from '@pyroscope/models';
+import { Profile, FlamebearerProfileSchema } from '@pyroscope/models/src';
 import { z } from 'zod';
 import type { ZodError } from 'zod';
 import { buildRenderURL } from '@webapp/util/updateRequests';

--- a/webapp/javascript/services/share.ts
+++ b/webapp/javascript/services/share.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 import { Result } from '@webapp/util/fp';
 import type { ZodError } from 'zod';
-import { Profile } from '@pyroscope/models';
+import { Profile } from '@pyroscope/models/src';
 import {
   FlamegraphDotComResponse,
   flamegraphDotComResponseScheme,

--- a/webapp/javascript/standalone.tsx
+++ b/webapp/javascript/standalone.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import Box from '@webapp/ui/Box';
 import { decodeFlamebearer } from '@webapp/models/flamebearer';
-import { FlamegraphRenderer } from '@pyroscope/flamegraph';
+import { FlamegraphRenderer } from '@pyroscope/flamegraph/src/FlamegraphRenderer';
 import Footer from './components/Footer';
 import '@pyroscope/flamegraph/dist/index.css';
 

--- a/webapp/javascript/util/testData.ts
+++ b/webapp/javascript/util/testData.ts
@@ -1,4 +1,4 @@
-import { Profile } from '@pyroscope/models';
+import { Profile } from '@pyroscope/models/src';
 
 export const SimpleSingle: Profile = {
   version: 1,


### PR DESCRIPTION
Ship `FlamegraphRenderer.tsx` directly (without bundling/minifying). For clarification, we still ship the flamegraph bundled for the people that want it.

This allows people to use the unminified version if they want, which allows for better tree shaking.
For us, it allows not having to build the flamegraph separately while running locally, which is faster and doesn't contain race conditions (https://github.com/pyroscope-io/pyroscope/pull/1161).

Some other arguments against bundling/minification https://www.briefs.fm/3-minutes-with-kent/221

Did the same thing for `@pyroscope/models`.