### PR TITLE
ci: improve js tests/lint speed

### DIFF
--- a/.github/lint-js.yml
+++ b/.github/lint-js.yml
@@ -1,4 +1,4 @@
-name: JS Tests
+name: JS Lint
 
 on:
   push:
@@ -27,15 +27,12 @@ jobs:
 
       - name: Install Webapp dependencies
         run: yarn install
-      - name: Get number of CPU cores
-        id: cpu-cores
-        uses: SimenB/github-actions-cpu-cores@v1
-      - name: Run Webapp tests
-        run: yarn run test --coverage --max-workers ${{ steps.cpu-cores.outputs.count }}
-      - name: Upload codecov coverage
-        if: always()
-        uses: codecov/codecov-action@v1
-        with:
-          name: js coverage
-          fail_ci_if_error: false
-          verbose: true
+      - run: build
+      - name: Run Format check
+        run: yarn format:check
+      - name: Run Lint
+        # Use use --quiet so that it only report errors
+        run: yarn lint:quiet
+
+      - name: Run Type check
+        run: yarn type-check

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  js-tests:
+  js-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,7 +27,7 @@ jobs:
 
       - name: Install Webapp dependencies
         run: yarn install
-      - run: build
+      - run: yarn build
       - name: Run Format check
         run: yarn format:check
       - name: Run Lint

--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -27,14 +27,11 @@ jobs:
 
       - name: Install Webapp dependencies
         run: yarn install
-
-      # build the application before testing
-      # otherwise it won't be able to resolve dependencies
-      - name: build
-        run: yarn build
-
+      - name: Get number of CPU cores
+        id: cpu-cores
+        uses: SimenB/github-actions-cpu-cores@v1
       - name: Run Webapp tests
-        run: yarn run test --coverage
+        run: yarn run test --coverage --max-workers ${{ steps.cpu-cores.outputs.count }}
       - name: Upload codecov coverage
         if: always()
         uses: codecov/codecov-action@v1

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:standalone": "webpack --config scripts/webpack/webpack.standalone.ts",
     "build:size-limit": "NODE_ENV=production webpack --config scripts/webpack/webpack.size-limit.ts",
     "build:flamegraph": "lerna run build --scope=@pyroscope/flamegraph",
-    "test": "jest --runInBand",
+    "test": "jest",
     "test:ss": "UPDATE_SNAPSHOTS=true ./scripts/jest-snapshots/run-docker.sh",
     "test:ss-check": "./scripts/jest-snapshots/run-docker.sh",
     "lint": "lerna run lint --parallel --no-bail",

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Tooltip.spec.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Tooltip.spec.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Maybe } from 'true-myth';
-import type { Units } from '@pyroscope/models';
+import type { Units } from '@pyroscope/models/src';
 
 import { diffColorRed, diffColorGreen } from './color';
 import Tooltip, { TooltipProps } from './Tooltip';

--- a/scripts/jest-snapshots/run-snapshots.sh
+++ b/scripts/jest-snapshots/run-snapshots.sh
@@ -27,6 +27,5 @@ fi
 # error eslint-import-resolver-webpack@0.13.1: The engine "node" is incompatible with this module. Expected version "^16 || ^15 || ^14 || ^13 || ^12 || ^11 || ^10 || ^9 || ^8 || ^7 || ^6". Got "17.0.1"
 # error Found incompatible module.
 yarn install --ignore-engines
-yarn build
-RUN_SNAPSHOTS=true yarn test --testNamePattern='group:snapshot' --verbose "$updateArg"
+RUN_SNAPSHOTS=true yarn test --testNamePattern='group:snapshot' --verbose "$updateArg" --runInBand
 


### PR DESCRIPTION
* Set jest `max-workers` to be the number of cores (as per https://jestjs.io/docs/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server)
* Split js lint/tests into different actions (since tests don't require building the dependencies)

For comparison

Before:
![image](https://user-images.githubusercontent.com/6951209/179069071-3ba1056e-ccbc-43b6-9e32-3d2b72ffb9aa.png)
![image](https://user-images.githubusercontent.com/6951209/179069102-3dffae60-7ffd-4943-9b10-702b2ec2e9a6.png)


Now:
![image](https://user-images.githubusercontent.com/6951209/179069036-a67b9e9e-f0cf-48d5-a747-385a441edaf8.png)

Thought slowest tests are still the cypress.
