### PR TITLE
ci: run yarn --frozen-lockfile

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -26,7 +26,7 @@ jobs:
             ${{ runner.os }}-yarn
 
       - name: Install Webapp dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - run: yarn build
       - name: Run Format check
         run: yarn format:check

--- a/.github/workflows/size-limit.yml
+++ b/.github/workflows/size-limit.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Webapp dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: build
         run: yarn build
       - uses: andresz1/size-limit-action@v1

--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -26,7 +26,7 @@ jobs:
             ${{ runner.os }}-yarn
 
       - name: Install Webapp dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Get number of CPU cores
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@v1

--- a/scripts/jest-snapshots/run-snapshots.sh
+++ b/scripts/jest-snapshots/run-snapshots.sh
@@ -26,6 +26,6 @@ fi
 # warning webpack-plugin-serve@1.5.0: Invalid bin field for "webpack-plugin-serve".
 # error eslint-import-resolver-webpack@0.13.1: The engine "node" is incompatible with this module. Expected version "^16 || ^15 || ^14 || ^13 || ^12 || ^11 || ^10 || ^9 || ^8 || ^7 || ^6". Got "17.0.1"
 # error Found incompatible module.
-yarn install --ignore-engines
+yarn install --ignore-engines --frozen-lockfile
 RUN_SNAPSHOTS=true yarn test --testNamePattern='group:snapshot' --verbose "$updateArg" --runInBand
 


### PR DESCRIPTION
As per the docs

```
Don’t generate a yarn.lock lockfile and fail if an update is needed.

If you need reproducible dependencies, which is usually the case with the continuous integration systems, you should pass --frozen-lockfile flag.
```