### PR TITLE
ci(panel): improvements

### DIFF
--- a/.github/workflows/cypress-panel.yml
+++ b/.github/workflows/cypress-panel.yml
@@ -26,11 +26,7 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn
-      - run: yarn
-        # when building hide the logo
-        env:
-          PYROSCOPE_HIDE_LOGO: true
-
+      - run: yarn --frozen-lockfile
       - run: yarn build:panel
         env:
           PYROSCOPE_PANEL_VERSION: test
@@ -39,24 +35,12 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         with:
-          config-file: packages/pyroscope-panel-plugin/cypress.json
+          command: yarn cy:panel:ci
           wait-on: http://localhost:3000
-          start: make server
         env:
-          CYPRESS_VIDEO: true
           CYPRESS_COMPARE_SNAPSHOTS: true
       - uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: cypress-screenshots
-          path: cypress/screenshots
-      - uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: cypress-videos
-          path: cypress/videos
-      - uses: actions/upload-artifact@v2
-        if: always()
+        if: failure()
         with:
           name: cypress-snapshots
           path: cypress/snapshots

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "cy:webapp-base-url:ci": "cypress run --config-file cypress/base-url/cypress.json",
     "cy:webapp-base-url:ss-check": "CYPRESS_updateSnapshots=false ./scripts/cypress-screenshots.sh --config-file cypress/base-url/cypress.json",
     "cy:panel:open": "cypress open --config-file grafana-plugin/panel/cypress.json",
-    "cy:panel:ci": "cypress run --config-file grafana-plugin/panel/cypress.json",
+    "cy:panel:ci": "cypress run --config-file packages/pyroscope-panel-plugin/cypress.json",
     "cy:panel:ss": "./scripts/cypress-screenshots.sh --config-file packages/pyroscope-panel-plugin/cypress.json",
     "cy:panel:ss-check": "CYPRESS_updateSnapshots=false ./scripts/cypress-screenshots.sh --config-file packages/pyroscope-panel-plugin/cypress.json",
     "cy:datasource:open": "cypress open --config-file packages/pyroscope-datasource-plugin/cypress.json",

--- a/packages/pyroscope-panel-plugin/cypress.json
+++ b/packages/pyroscope-panel-plugin/cypress.json
@@ -1,6 +1,7 @@
 {
   "baseUrl": "http://localhost:3000",
   "integrationFolder": "cypress/integration/panel",
+  "reporter": "cypress-image-snapshot/reporter",
   "retries": {
     "runMode": 5
   }


### PR DESCRIPTION
For panel plugin cypress tests:
* Disable cypress videos (to make it faster)
* Remove wrong `make server` call, since in this case we don't run the server
* Setup `cypress-image-snapshot/reporter`, which should create a diff file when screenshot does not match.
* Make the action run `cy:panel:ci`, just to keep it consistent and somewhat reproducible when running locally.