### PR TITLE
chore: Update light mode for tooltip

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Tooltip.module.scss
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Tooltip.module.scss
@@ -1,10 +1,10 @@
 .flamegraphTooltip {
   width: 420px;
   position: fixed;
-  background: var(--ps-neutral-2);
+  background: var(--ps-tooltip-bg);
   box-shadow: 1px 2px 4px 0px rgba(0, 0, 0, 0.3);
   border-radius: 4px;
-  color: var(--ps-neutral-1);
+  color: var(--ps-tooltip-text);
   font-size: 12px;
   visibility: hidden;
   z-index: 2;
@@ -14,7 +14,7 @@
   }
 
   .flamegraphTooltipName {
-    color: var(--ps-neutral-1);
+    color: var(--ps-tooltip-text);
     background-color: var(--ps-tooltip-header-bg);
     border-top-right-radius: 4px;
     border-top-left-radius: 4px;

--- a/webapp/sass/variables.css
+++ b/webapp/sass/variables.css
@@ -24,6 +24,12 @@
   --ps-dropdown-background: #2c2c30; /* dropdown background */
   --ps-sidebar-separator: #d8d8d833; /* sidebar separation lines color */
 
+  --ps-tooltip-bg: #ffffff; /* tooltip header background */
+  --ps-tooltip-text: #000000; /* tooltip header text */
+  --ps-tooltip-header-bg: #d8d8d8; /* flamegraph tooltip heeader */
+
+  --ps-right-click-info: #9a9aa0; /* flamegraph tooltip right click info */
+
   --ps-dropdown-arrow: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' fill='white' height='4'%3E%3Cpath d='M4 0h6L7 4'/%3E%3C/svg%3E");
   --ps-dropdown-shadow: #000000; /* dropdown shadow */
 
@@ -63,9 +69,6 @@
   --ps-immutable-linked-border: #eb7b18; /* linked border color */
   --ps-immutable-white: #ffffff; /* white: Use only when it should be white regardless of color mode */
   --ps-immutable-placeholder-text: #333333; /* placeholder text color */
-
-  --ps-tooltip-header-bg: #d8d8d8; /* flamegraph tooltip heeader */
-  --ps-right-click-info: #9a9aa0; /* flamegraph tooltip right click info */
 }
 
 [data-theme='light'],
@@ -85,6 +88,11 @@
   --ps-dropdown-background: #f8f8f8; /* dropdown background */
   --ps-sidebar-separator: #0000004d; /* sidebar separation lines color */
 
+  --ps-tooltip-bg: #ffffff; /* tooltip header background */
+  --ps-tooltip-text: #000000; /* tooltip header text */
+  --ps-tooltip-header-bg: #d8d8d8; /* flamegraph tooltip heeader */
+  --ps-right-click-info: #9a9aa0; /* flamegraph tooltip right click info */
+
   --ps-dropdown-arrow: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' fill='black' height='4'%3E%3Cpath d='M4 0h6L7 4'/%3E%3C/svg%3E");
   --ps-dropdown-shadow: #00000052; /* dropdown shadow */
 
@@ -97,7 +105,4 @@
   --ps-green-primary: #0bdb79; /* standard green */
   --ps-green-highlight: #5bdc9e; /* highlight (hover) green */
   --ps-green-disabled: #00a757; /* disabled green */
-
-  --ps-tooltip-header-bg: #d8d8d8; /* flamegraph tooltip heeader */
-  --ps-right-click-info: #9a9aa0; /* flamegraph tooltip right click info */
 }


### PR DESCRIPTION
Updated light mode colors for tooltip... Created an issue  (#1274) for biggest remaining "light mode" color change needed before merging (mostly the non-css stuff) 

Before:
<img width="783" alt="image" src="https://user-images.githubusercontent.com/23323466/179285838-0022ece3-6109-4d9b-bbd7-6a256e1dde7d.png">


After: 
<img width="771" alt="Screen Shot 2022-07-15 at 11 13 18 AM" src="https://user-images.githubusercontent.com/23323466/179285878-edbb650a-6eed-4085-a7df-4fb160362f87.png">

