### PR TITLE
chore: @pyroscope/models ship ts files too

### DIFF
--- a/packages/pyroscope-models/package.json
+++ b/packages/pyroscope-models/package.json
@@ -5,7 +5,8 @@
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "files": [
-    "src/index.ts"
+    "dist/**/*",
+    "src/**/*"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",


### PR DESCRIPTION
Long story short, since pyroscope webapp uses `@pyroscope/models/src`, so if you use `@pyroscope/webapp` you also need access to `@pyroscope/models/src`, therefore src needs to be shipped.