### PR TITLE
fix: don't write to local db when `disable-local-writes` is set

### DIFF
--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -156,6 +156,8 @@ func newServerService(c *config.Server) (*serverService, error) {
 	var ingester ingestion.Ingester
 	if !svc.config.RemoteWrite.Enabled || !svc.config.RemoteWrite.DisableLocalWrites {
 		ingester = parser.New(svc.logger, svc.storageQueue, metricsExporter)
+	} else {
+		ingester = ingestion.NewNoopIngester()
 	}
 
 	// If remote write is available, let's write to both local storage and to the remote server

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -363,7 +363,7 @@ type Database struct {
 
 type RemoteWrite struct {
 	Enabled            bool `def:"false" desc:"EXPERIMENTAL! the API will change, use at your own risk. whether to enable remote write or not"`
-	DisableLocalWrites bool `def:"false" desc:"EXPERIMENTAL! the API will change, use at your own risk. whether to enable remote write or not"`
+	DisableLocalWrites bool `def:"false" desc:"EXPERIMENTAL! the API will change, use at your own risk. whether to enable remote write or not" mapstructure:"disable-local-writes"`
 
 	// see loadRemoteWriteTargetConfigsFromFile in server.go
 	Targets map[string]RemoteWriteTarget `yaml:"scrape-configs" mapstructure:"-"`

--- a/pkg/ingestion/noop.go
+++ b/pkg/ingestion/noop.go
@@ -7,6 +7,6 @@ type NoopIngester struct{}
 func NewNoopIngester() *NoopIngester {
 	return &NoopIngester{}
 }
-func (*NoopIngester) Ingest(ctx context.Context, in *IngestInput) error {
+func (*NoopIngester) Ingest(_ context.Context, _ *IngestInput) error {
 	return nil
 }

--- a/pkg/ingestion/noop.go
+++ b/pkg/ingestion/noop.go
@@ -1,0 +1,12 @@
+package ingestion
+
+import "context"
+
+type NoopIngester struct{}
+
+func NewNoopIngester() *NoopIngester {
+	return &NoopIngester{}
+}
+func (*NoopIngester) Ingest(ctx context.Context, in *IngestInput) error {
+	return nil
+}


### PR DESCRIPTION
One of our users reported that even after [disabling local writes](https://pyroscope.io/docs/remote-write/#disabling-local-writes), data was still being written to the database.

Turns out it's purely a configuration issue.

After that, Parallelizer was panicing due to ingester being null, instead of second guessing myself with if `ingester != null` checks, I used a `NoopIngester`.