### PR TITLE
chore: remove `prepare` script

### DIFF
--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -63,7 +63,7 @@ jobs:
             ${{ runner.os }}-yarn
 
       - name: Install Webapp dependencies
-        run: yarn bootstrap
+        run: yarn install --frozen-lockfile
 
       # This step will bump the package.json version and NOT push to the repository
       # this is needed since building grafana requires updating the plugin.json file

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "cy:datasource:ci": "cypress run --config-file packages/pyroscope-datasource-plugin/cypress.json",
     "cy:datasource:ss": "./scripts/cypress-screenshots.sh --config-file packages/pyroscope-datasource-plugin/cypress.json",
     "cy:datasource:ss-check": "CYPRESS_updateSnapshots=false ./scripts/cypress-screenshots.sh --config-file packages/pyroscope-datasource-plugin/cypress.json",
-    "prepare": "node ./scripts/ci-skip-husky.js",
     "lint-staged": "lint-staged",
     "size": "size-limit",
     "storybook": "start-storybook -p 6006",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cy:datasource:ci": "cypress run --config-file packages/pyroscope-datasource-plugin/cypress.json",
     "cy:datasource:ss": "./scripts/cypress-screenshots.sh --config-file packages/pyroscope-datasource-plugin/cypress.json",
     "cy:datasource:ss-check": "CYPRESS_updateSnapshots=false ./scripts/cypress-screenshots.sh --config-file packages/pyroscope-datasource-plugin/cypress.json",
-    "prepare": "husky install",
+    "prepare": "node ./scripts/ci-skip-husky.js",
     "lint-staged": "lint-staged",
     "size": "size-limit",
     "storybook": "start-storybook -p 6006",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "start": "lerna-watch @pyroscope/webapp",
-    "bootstrap": "husky install && lerna bootstrap",
+    "bootstrap": "lerna bootstrap && husky install",
     "web-postinstall": "scripts/web-postinstall.js",
     "postinstall": "yarn run web-postinstall",
     "dev": "yarn run dev:webapp",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "start": "lerna-watch @pyroscope/webapp",
-    "bootstrap": "lerna bootstrap",
+    "bootstrap": "husky install && lerna bootstrap",
     "web-postinstall": "scripts/web-postinstall.js",
     "postinstall": "yarn run web-postinstall",
     "dev": "yarn run dev:webapp",

--- a/scripts/ci-skip-husky.js
+++ b/scripts/ci-skip-husky.js
@@ -1,7 +1,0 @@
-const { execSync } = require('child_process');
-
-// https://github.com/yarnpkg/yarn/issues/7212#issuecomment-1136443313
-if (!process.env.CI) {
-  console.log('Executing husky install...');
-  execSync('husky install');
-}

--- a/scripts/ci-skip-husky.js
+++ b/scripts/ci-skip-husky.js
@@ -1,0 +1,7 @@
+const { execSync } = require('child_process');
+
+// https://github.com/yarnpkg/yarn/issues/7212#issuecomment-1136443313
+if (!process.env.CI) {
+  console.log('Executing husky install...');
+  execSync('husky install');
+}


### PR DESCRIPTION
Apparently there's a race condition in `yarn install` when you use a github repo as a dependency (this repo) AND that repo contains a `prepare` script. The race condition makes it pull some dependencies concurrently, corrupting them.  https://github.com/yarnpkg/yarn/issues/7212

Just removed the `prepare` script and moved to `bootstrap`, which people have to run manually anyway.