### PR TITLE
chore(frontend): make error message more user friendly

### DIFF
--- a/webapp/javascript/services/base.spec.ts
+++ b/webapp/javascript/services/base.spec.ts
@@ -116,9 +116,7 @@ describe('Base HTTP', () => {
       const res = await request('/test');
 
       expect(res.error).toBeInstanceOf(RequestNotOkWithErrorsList);
-      expect(res.error.message).toBe(
-        'Server returned with multiple errors: error1, error2'
-      );
+      expect(res.error.message).toBe('Error(s) were found: "error1", "error2"');
     });
 
     it(`Returns an error message if available`, async () => {

--- a/webapp/javascript/services/base.ts
+++ b/webapp/javascript/services/base.ts
@@ -33,7 +33,7 @@ export class RequestIncompleteError extends CustomError {
 // When the server returns a list of errors
 export class RequestNotOkWithErrorsList extends CustomError {
   public constructor(public code: number, public errors: string[]) {
-    super(`Server returned with multiple errors: ${errors.join(', ')}`);
+    super(`Error(s) were found: ${errors.map((e) => `"${e}"`).join(', ')}`);
   }
 }
 


### PR DESCRIPTION
Since people may display the error message to users. Let's make it more friendly:
![image](https://user-images.githubusercontent.com/6951209/180283148-f44ead4e-ad31-42b7-a259-6dfee9a56cc6.png)

Becomes
```
Error(s) were found: "empty organization name"
```