### PR TITLE
fix: exemplars metadata and timestamps

### DIFF
--- a/pkg/server/merge.go
+++ b/pkg/server/merge.go
@@ -118,7 +118,10 @@ func mergeExemplarsInputFromMergeRequest(req mergeRequest) storage.MergeExemplar
 
 func pickTime(primary, fallback string) time.Time {
 	if primary == "" {
-		primary = fallback
+		return attime.Parse(primary)
 	}
-	return attime.Parse(primary)
+	if fallback != "" {
+		return attime.Parse(fallback)
+	}
+	return time.Time{}
 }

--- a/pkg/server/merge.go
+++ b/pkg/server/merge.go
@@ -117,7 +117,7 @@ func mergeExemplarsInputFromMergeRequest(req mergeRequest) storage.MergeExemplar
 }
 
 func pickTime(primary, fallback string) time.Time {
-	if primary == "" {
+	if primary != "" {
 		return attime.Parse(primary)
 	}
 	if fallback != "" {

--- a/pkg/storage/exemplars_test.go
+++ b/pkg/storage/exemplars_test.go
@@ -55,11 +55,6 @@ var _ = Describe("exemplars", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			put(s, map[string]string{
-				"__name__":  "app.cpu",
-				"span_name": "foo",
-				// w/o profile_id, just to create the segment.
-			})
-			put(s, map[string]string{
 				"__name__":   "app.cpu",
 				"span_name":  "foo",
 				"profile_id": "a",
@@ -201,14 +196,6 @@ var _ = Describe("Exemplars retention policy", func() {
 					Val:       tree.Clone(big.NewRat(1, 1)),
 				})).ToNot(HaveOccurred())
 
-				// Just to create the segment.
-				k3, _ := segment.ParseKey("app.cpu{}")
-				Expect(s.Put(context.TODO(), &PutInput{
-					StartTime: t3,
-					EndTime:   t4,
-					Key:       k3,
-					Val:       tree.Clone(big.NewRat(1, 1)),
-				})).ToNot(HaveOccurred())
 				s.exemplars.Sync()
 				rp := &segment.RetentionPolicy{ExemplarsRetentionTime: t3}
 				s.exemplars.enforceRetentionPolicy(context.Background(), rp)

--- a/pkg/storage/exemplars_test.go
+++ b/pkg/storage/exemplars_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pyroscope-io/pyroscope/pkg/testing"
 )
 
-var _ = Describe("exemplars", func() {
+var _ = Describe("Exemplars retrieval", func() {
 	st := time.Now()
 	et := st.Add(10 * time.Second)
 
@@ -219,12 +219,6 @@ var _ = Describe("Exemplars retention policy", func() {
 	})
 })
 
-func randomBytesHex(n int) string {
-	b := make([]byte, n)
-	rand.Read(b)
-	return hex.EncodeToString(b)
-}
-
 var _ = Describe("Concurrent exemplars insertion", func() {
 	testing.WithConfig(func(cfg **config.Config) {
 		JustBeforeEach(func() {
@@ -342,3 +336,67 @@ var _ = Describe("Exemplar serialization", func() {
 		})
 	})
 })
+
+var _ = Describe("Exemplar timestamps", func() {
+	Context("exemplars query", func() {
+		It("selects all entries if no time range is provided or timestamps are not present", func() {
+			for i := 0; i < 0xF; i++ {
+				e := exemplarEntry{
+					StartTime: bitAt(i, 3),
+					EndTime:   bitAt(i, 2),
+				}
+				startTime := bitAt(i, 1)
+				endTime := bitAt(i, 0)
+
+				Expect(exemplarMatchesTimeRange(e, startTime, endTime)).To(BeTrue())
+			}
+		})
+
+		It("selects matched entries", func() {
+			startTime := time.Now().UnixNano()
+			endTime := startTime + 3
+			e := exemplarEntry{
+				StartTime: startTime,
+				EndTime:   endTime,
+			}
+
+			for _, r := range [][2]int64{
+				{0, 0},
+				{1, -1},
+				{-1, 1},
+
+				{0, 1},
+				{1, 0},
+				{1, 1},
+
+				{0, -1},
+				{-1, 0},
+				{-1, -1},
+			} {
+				Expect(exemplarMatchesTimeRange(e, startTime+r[0], endTime+r[1])).To(BeTrue())
+			}
+
+			for _, r := range [][2]int64{
+				{endTime, endTime},
+				{endTime, endTime + 1},
+				{startTime, startTime},
+				{startTime - 1, startTime},
+			} {
+				Expect(exemplarMatchesTimeRange(e, r[0], r[1])).To(BeFalse())
+			}
+		})
+	})
+})
+
+func randomBytesHex(n int) string {
+	b := make([]byte, n)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+func bitAt(n, b int) int64 {
+	if n&(1<<b) > 0 {
+		return 1
+	}
+	return 0
+}

--- a/pkg/storage/segment/key.go
+++ b/pkg/storage/segment/key.go
@@ -121,6 +121,8 @@ func (k *Key) ProfileID() (string, bool) {
 	return id, ok
 }
 
+func AppSegmentKey(appName string) string { return appName + "{}" }
+
 func TreeKey(k string, depth int, unixTime int64) string {
 	return k + ":" + strconv.Itoa(depth) + ":" + strconv.FormatInt(unixTime, 10)
 }

--- a/pkg/storage/storage_merge_exemplars.go
+++ b/pkg/storage/storage_merge_exemplars.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 	"time"
 
@@ -61,10 +62,14 @@ type exemplarsMerge struct {
 
 func (s *Storage) mergeExemplars(ctx context.Context, mi MergeExemplarsInput) (out exemplarsMerge, err error) {
 	out.tree = tree.New()
+	startTime := unixNano(mi.StartTime)
+	endTime := unixNano(mi.EndTime)
 	err = s.exemplars.fetch(ctx, mi.AppName, mi.ProfileIDs, func(e exemplarEntry) error {
-		out.tree.Merge(e.Tree)
-		out.count++
-		out.lastEntry = &e
+		if exemplarMatchesTimeRange(e, startTime, endTime) {
+			out.tree.Merge(e.Tree)
+			out.count++
+			out.lastEntry = &e
+		}
 		return nil
 	})
 	if err != nil || out.lastEntry == nil {
@@ -80,4 +85,63 @@ func (s *Storage) mergeExemplars(ctx context.Context, mi MergeExemplarsInput) (o
 	}
 	out.segment = r.(*segment.Segment)
 	return out, nil
+}
+
+func unixNano(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixNano()
+}
+
+// exemplarMatchesTimeRange reports whether the exemplar is eligible for the
+// given time range. Potentially, we could take exact fraction and scale the
+// exemplar proportionally, in the way we do it in aggregate queries. However,
+// with exemplars down-sampling does not seem to be a good idea as it may be
+// confusing.
+//
+// For backward compatibility, an exemplar is considered eligible if the time
+// range is not specified, or if the exemplar does not have timestamps.
+func exemplarMatchesTimeRange(e exemplarEntry, startTime, endTime int64) bool {
+	if startTime == 0 || endTime == 0 || e.StartTime == 0 || e.EndTime == 0 {
+		return true
+	}
+	return !math.IsNaN(overlap(startTime, endTime, e.StartTime, e.EndTime))
+}
+
+// overlap returns the overlap of the ranges
+// indicating the exemplar time range fraction.
+//
+//   query:    from  – until
+//   exemplar: start – end
+//
+// Special cases:
+//   +Inf - query matches or includes exemplar
+//    NaN - ranges don't overlap
+//
+func overlap(from, until, start, end int64) float64 {
+	span := end - start
+	o := min(until, end) - max(from, start)
+	switch {
+	case o <= 0:
+		return math.NaN()
+	case o == span:
+		return math.Inf(0)
+	default:
+		return float64(o) / float64(span)
+	}
+}
+
+func min(a, b int64) int64 {
+	if b < a {
+		return b
+	}
+	return a
+}
+
+func max(a, b int64) int64 {
+	if b > a {
+		return b
+	}
+	return a
 }

--- a/pkg/storage/storage_merge_exemplars.go
+++ b/pkg/storage/storage_merge_exemplars.go
@@ -67,11 +67,11 @@ func (s *Storage) mergeExemplars(ctx context.Context, mi MergeExemplarsInput) (o
 		out.lastEntry = &e
 		return nil
 	})
-	if err != nil {
+	if err != nil || out.lastEntry == nil {
 		return out, err
 	}
 	// Note that exemplar entry labels don't contain the app name and profile ID.
-	if out.lastEntry != nil && out.lastEntry.Labels == nil {
+	if out.lastEntry.Labels == nil {
 		out.lastEntry.Labels = make(map[string]string)
 	}
 	r, ok := s.segments.Lookup(segment.AppSegmentKey(mi.AppName))

--- a/pkg/storage/storage_put.go
+++ b/pkg/storage/storage_put.go
@@ -38,6 +38,9 @@ func (s *Storage) Put(ctx context.Context, pi *PutInput) error {
 
 	s.putTotal.Inc()
 	if pi.Key.HasProfileID() {
+		if err := s.ensureAppSegmentExists(pi); err != nil {
+			return err
+		}
 		return s.exemplars.insert(ctx, pi)
 	}
 


### PR DESCRIPTION
If an exemplar is written separately from its baseline profile, we don't have access to its metadata. The fix introduces a stub segment for the whole application, which would be present regardless of whether we have a regular baseline profile for the exemplar or not.

In addition, now exemplar timestamps are honoured on querying. For backward compatibility a query w/o time range selects exemplars regardless of its timestamps.
