### PR TITLE
chore(frontend): add title on hover for select app button

### DIFF
--- a/webapp/javascript/components/AppSelector/SelectButton.tsx
+++ b/webapp/javascript/components/AppSelector/SelectButton.tsx
@@ -67,6 +67,7 @@ const SelectButton = ({
       type="button"
       onClick={onClick}
       className={cx({ button: true, isSelected })}
+      title={name}
     >
       <div>
         <Icon isFolder={isFolder} isSelected={isSelected} />


### PR DESCRIPTION
Adds a `title` parameter to the `app selector button` component. This is so that at least it's >possible< to read the entire app name.

https://user-images.githubusercontent.com/6951209/180785398-be5ffd70-1334-4d4e-a3f5-f56951ad1838.mp4

Related https://github.com/pyroscope-io/pyroscope/issues/1265
