### PR TITLE
fix: segment stub deserialization

### DIFF
--- a/pkg/storage/segment/serialization.go
+++ b/pkg/storage/segment/serialization.go
@@ -106,8 +106,12 @@ func Deserialize(r io.Reader) (*Segment, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	s.populateFromMetadata(mdata)
+
+	// In some cases, there can be no nodes.
+	if br.Buffered() == 0 {
+		return s, nil
+	}
 
 	parents := []*streeNode{nil}
 	for len(parents) > 0 {


### PR DESCRIPTION
Recently introduced stub segment for exemplars (a segment for the whole app) may fail to deserialize since it may not have nodes.