### PR TITLE
feat: configurable disk alert threshold

### DIFF
--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -214,7 +214,7 @@ var _ = Describe("flags", func() {
 					BaseURL:                 "",
 					CacheEvictThreshold:     0.25,
 					CacheEvictVolume:        0.33,
-					StorageDiskThreshold:    5,
+					MinFreeSpacePercentage:  5,
 					BadgerNoTruncate:        false,
 					DisablePprofEndpoint:    false,
 					EnableExperimentalAdmin: true,

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -214,7 +214,7 @@ var _ = Describe("flags", func() {
 					BaseURL:                 "",
 					CacheEvictThreshold:     0.25,
 					CacheEvictVolume:        0.33,
-					DiskThreshold:           5,
+					StorageDiskThreshold:    5,
 					BadgerNoTruncate:        false,
 					DisablePprofEndpoint:    false,
 					EnableExperimentalAdmin: true,

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -214,6 +214,7 @@ var _ = Describe("flags", func() {
 					BaseURL:                 "",
 					CacheEvictThreshold:     0.25,
 					CacheEvictVolume:        0.33,
+					DiskThreshold:           5,
 					BadgerNoTruncate:        false,
 					DisablePprofEndpoint:    false,
 					EnableExperimentalAdmin: true,

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -92,7 +92,7 @@ func newServerService(c *config.Server) (*serverService, error) {
 	}
 
 	diskPressure := health.DiskPressure{
-		Threshold: c.StorageDiskThreshold,
+		Threshold: c.MinFreeSpacePercentage,
 		Path:      c.StoragePath,
 	}
 

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -92,7 +92,7 @@ func newServerService(c *config.Server) (*serverService, error) {
 	}
 
 	diskPressure := health.DiskPressure{
-		Threshold: c.DiskThreshold,
+		Threshold: c.StorageDiskThreshold,
 		Path:      c.StoragePath,
 	}
 

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -37,7 +37,6 @@ import (
 	"github.com/pyroscope-io/pyroscope/pkg/service"
 	"github.com/pyroscope-io/pyroscope/pkg/sqlstore"
 	"github.com/pyroscope-io/pyroscope/pkg/storage"
-	"github.com/pyroscope-io/pyroscope/pkg/util/bytesize"
 	"github.com/pyroscope-io/pyroscope/pkg/util/debug"
 )
 
@@ -93,7 +92,7 @@ func newServerService(c *config.Server) (*serverService, error) {
 	}
 
 	diskPressure := health.DiskPressure{
-		Threshold: 512 * bytesize.MB,
+		Threshold: c.DiskThreshold,
 		Path:      c.StoragePath,
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -112,6 +112,8 @@ type Server struct {
 	CacheEvictThreshold float64 `def:"0.25" desc:"percentage of memory at which cache evictions start" mapstructure:"cache-evict-threshold"`
 	CacheEvictVolume    float64 `def:"0.33" desc:"percentage of cache that is evicted per eviction run" mapstructure:"cache-evict-volume"`
 
+	DiskThreshold float64 `def:"5" desc:"percentage of available disk space at which ingestion requests are discarded. Defaults to 5%. Set 0 to disable" mapstructure:"storage-disk-threshold"`
+
 	Database Database `mapstructure:"database"`
 
 	// TODO: I don't think a lot of people will change these values.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -104,15 +104,15 @@ type Server struct {
 	LogLevel       string `def:"info" desc:"log level: debug|info|warn|error" mapstructure:"log-level"`
 	BadgerLogLevel string `def:"error" desc:"log level: debug|info|warn|error" mapstructure:"badger-log-level"`
 
-	StoragePath     string `def:"<installPrefix>/var/lib/pyroscope" desc:"directory where pyroscope stores profiling data" mapstructure:"storage-path"`
+	StoragePath          string  `def:"<installPrefix>/var/lib/pyroscope" desc:"directory where pyroscope stores profiling data" mapstructure:"storage-path"`
+	StorageDiskThreshold float64 `def:"5" desc:"percentage of available disk space at which ingestion requests are discarded. Defaults to 5%. Set 0 to disable" mapstructure:"storage-disk-threshold"`
+
 	APIBindAddr     string `def:":4040" desc:"port for the HTTP(S) server used for data ingestion and web UI" mapstructure:"api-bind-addr"`
 	BaseURL         string `def:"" desc:"base URL for when the server is behind a reverse proxy with a different path" mapstructure:"base-url"`
 	BaseURLBindAddr string `def:"" deprecated:"true" desc:"server for debugging base url" mapstructure:"base-url-bind-addr"`
 
 	CacheEvictThreshold float64 `def:"0.25" desc:"percentage of memory at which cache evictions start" mapstructure:"cache-evict-threshold"`
 	CacheEvictVolume    float64 `def:"0.33" desc:"percentage of cache that is evicted per eviction run" mapstructure:"cache-evict-volume"`
-
-	DiskThreshold float64 `def:"5" desc:"percentage of available disk space at which ingestion requests are discarded. Defaults to 5%. Set 0 to disable" mapstructure:"storage-disk-threshold"`
 
 	Database Database `mapstructure:"database"`
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -104,8 +104,8 @@ type Server struct {
 	LogLevel       string `def:"info" desc:"log level: debug|info|warn|error" mapstructure:"log-level"`
 	BadgerLogLevel string `def:"error" desc:"log level: debug|info|warn|error" mapstructure:"badger-log-level"`
 
-	StoragePath          string  `def:"<installPrefix>/var/lib/pyroscope" desc:"directory where pyroscope stores profiling data" mapstructure:"storage-path"`
-	StorageDiskThreshold float64 `def:"5" desc:"percentage of available disk space at which ingestion requests are discarded. Defaults to 5%. Set 0 to disable" mapstructure:"storage-disk-threshold"`
+	StoragePath            string  `def:"<installPrefix>/var/lib/pyroscope" desc:"directory where pyroscope stores profiling data" mapstructure:"storage-path"`
+	MinFreeSpacePercentage float64 `def:"5" desc:"percentage of available disk space at which ingestion requests are discarded. Defaults to 5% but not less than 1GB. Set 0 to disable" mapstructure:"min-free-space-percentage"`
 
 	APIBindAddr     string `def:":4040" desc:"port for the HTTP(S) server used for data ingestion and web UI" mapstructure:"api-bind-addr"`
 	BaseURL         string `def:"" desc:"base URL for when the server is behind a reverse proxy with a different path" mapstructure:"base-url"`

--- a/pkg/health/disk_pressure.go
+++ b/pkg/health/disk_pressure.go
@@ -1,28 +1,46 @@
 package health
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pyroscope-io/pyroscope/pkg/util/bytesize"
 	"github.com/pyroscope-io/pyroscope/pkg/util/disk"
 )
 
+var (
+	errZeroTotalSize          = errors.New("total disk size is zero")
+	errTotalLessThanAvailable = errors.New("total disk size is less than available space")
+)
+
 type DiskPressure struct {
-	Threshold bytesize.ByteSize
+	Threshold float64
 	Path      string
 }
 
 func (d DiskPressure) Probe() (StatusMessage, error) {
-	var m StatusMessage
-	available, err := disk.FreeSpace(d.Path)
+	if d.Threshold == 0 {
+		return StatusMessage{Status: Healthy}, nil
+	}
+	u, err := disk.Usage(d.Path)
 	if err != nil {
-		return m, err
+		return StatusMessage{}, err
 	}
-	if available < d.Threshold {
+	return d.makeProbe(u)
+}
+
+func (d DiskPressure) makeProbe(u disk.UsageStats) (StatusMessage, error) {
+	var m StatusMessage
+	if u.Total == 0 {
+		return m, errZeroTotalSize
+	}
+	if u.Available > u.Total {
+		return m, errTotalLessThanAvailable
+	}
+	m.Status = Healthy
+	availPercent := 100 * float64(u.Available) / float64(u.Total)
+	if availPercent < d.Threshold {
 		m.Status = Critical
-	} else {
-		m.Status = Healthy
+		m.Message = fmt.Sprintf("Disk space is running low: %v available (%.1f%%)", u.Available, availPercent)
 	}
-	m.Message = fmt.Sprintf("Disk space is running low: %v available", available)
 	return m, nil
 }

--- a/pkg/health/disk_pressure_test.go
+++ b/pkg/health/disk_pressure_test.go
@@ -16,30 +16,43 @@ var _ = Describe("DiskPressure", func() {
 		Expect(m.Message).To(BeEmpty())
 	})
 
-	It("does not fire if available is greater than the configured threshold", func() {
+	It("does not fire if available space is greater than the configured threshold", func() {
 		d := DiskPressure{
-			Threshold: 10,
+			Threshold: 5,
 		}
 		m, err := d.makeProbe(disk.UsageStats{
-			Total:     5 * bytesize.MB,
-			Available: 1 * bytesize.MB,
+			Total:     10 * bytesize.GB,
+			Available: 1 * bytesize.GB,
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(m.Status).To(Equal(Healthy))
 		Expect(m.Message).To(BeEmpty())
 	})
 
-	It("fires if available is less than the configured threshold", func() {
+	It("fires if less than the configured threshold is available", func() {
 		d := DiskPressure{
 			Threshold: 5,
 		}
 		m, err := d.makeProbe(disk.UsageStats{
-			Total:     100 * bytesize.MB,
-			Available: 4 * bytesize.MB,
+			Total:     100 * bytesize.GB,
+			Available: 4 * bytesize.GB,
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(m.Status).To(Equal(Critical))
-		Expect(m.Message).To(Equal("Disk space is running low: 4.00 MB available (4.0%)"))
+		Expect(m.Message).To(Equal("Disk space is running low: 4.00 GB available (4.0%)"))
+	})
+
+	It("fires if less than 1GB is available", func() {
+		d := DiskPressure{
+			Threshold: 5,
+		}
+		m, err := d.makeProbe(disk.UsageStats{
+			Total:     5 * bytesize.GB,
+			Available: bytesize.GB - 1,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m.Status).To(Equal(Critical))
+		Expect(m.Message).To(Equal("Disk space is running low: 1024.00 MB available (20.0%)"))
 	})
 
 	It("fires if available is less than the configured threshold", func() {

--- a/pkg/health/disk_pressure_test.go
+++ b/pkg/health/disk_pressure_test.go
@@ -1,0 +1,88 @@
+package health
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pyroscope-io/pyroscope/pkg/util/bytesize"
+	"github.com/pyroscope-io/pyroscope/pkg/util/disk"
+)
+
+var _ = Describe("DiskPressure", func() {
+	It("does not fire if threshold is zero", func() {
+		var d DiskPressure
+		m, err := d.Probe()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m.Status).To(Equal(Healthy))
+		Expect(m.Message).To(BeEmpty())
+	})
+
+	It("does not fire if available is greater than the configured threshold", func() {
+		d := DiskPressure{
+			Threshold: 10,
+		}
+		m, err := d.makeProbe(disk.UsageStats{
+			Total:     5 * bytesize.MB,
+			Available: 1 * bytesize.MB,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m.Status).To(Equal(Healthy))
+		Expect(m.Message).To(BeEmpty())
+	})
+
+	It("fires if available is less than the configured threshold", func() {
+		d := DiskPressure{
+			Threshold: 5,
+		}
+		m, err := d.makeProbe(disk.UsageStats{
+			Total:     100 * bytesize.MB,
+			Available: 4 * bytesize.MB,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m.Status).To(Equal(Critical))
+		Expect(m.Message).To(Equal("Disk space is running low: 4.00 MB available (4.0%)"))
+	})
+
+	It("fires if available is less than the configured threshold", func() {
+		d := DiskPressure{
+			Threshold: 5,
+		}
+		m, err := d.makeProbe(disk.UsageStats{
+			Total:     1 * bytesize.GB,
+			Available: 1 * bytesize.MB,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m.Status).To(Equal(Critical))
+		Expect(m.Message).To(Equal("Disk space is running low: 1.00 MB available (0.1%)"))
+	})
+
+	It("fires if no space available", func() {
+		d := DiskPressure{
+			Threshold: 5,
+		}
+		m, err := d.makeProbe(disk.UsageStats{
+			Total:     100 * bytesize.MB,
+			Available: 0,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m.Status).To(Equal(Critical))
+		Expect(m.Message).To(Equal("Disk space is running low: 0 bytes available (0.0%)"))
+	})
+
+	It("fails if Available > Total", func() {
+		var d DiskPressure
+		_, err := d.makeProbe(disk.UsageStats{
+			Total:     1 * bytesize.GB,
+			Available: 2 * bytesize.GB,
+		})
+		Expect(err).To(MatchError(errTotalLessThanAvailable))
+	})
+
+	It("fails if Total is zero", func() {
+		var d DiskPressure
+		_, err := d.makeProbe(disk.UsageStats{
+			Total:     0,
+			Available: 2 * bytesize.GB,
+		})
+		Expect(err).To(MatchError(errZeroTotalSize))
+	})
+})

--- a/pkg/util/disk/disk.go
+++ b/pkg/util/disk/disk.go
@@ -1,0 +1,10 @@
+package disk
+
+import (
+	"github.com/pyroscope-io/pyroscope/pkg/util/bytesize"
+)
+
+type UsageStats struct {
+	Total     bytesize.ByteSize
+	Available bytesize.ByteSize
+}

--- a/pkg/util/disk/usage_test.go
+++ b/pkg/util/disk/usage_test.go
@@ -9,15 +9,29 @@ import (
 )
 
 var _ = Describe("disk package", func() {
+	var (
+		u   UsageStats
+		err error
+	)
 	testing.WithConfig(func(cfg **config.Config) {
-		Describe("FreeSpace", func() {
+		BeforeEach(func() {
+			u, err = Usage((*cfg).Server.StoragePath)
+		})
+		Describe("Usage", func() {
 			It("doesn't return an error", func() {
-				_, err := FreeSpace((*cfg).Server.StoragePath)
 				Expect(err).To(Not(HaveOccurred()))
 			})
 
-			It("returns non-zero value for storage space", func() {
-				Expect(FreeSpace((*cfg).Server.StoragePath)).To(BeNumerically(">", 0))
+			It("returns non-zero Total", func() {
+				Expect(u.Total).To(BeNumerically(">", 0))
+			})
+
+			It("returns non-zero Available", func() {
+				Expect(u.Available).To(BeNumerically(">", 0))
+			})
+
+			It("returns Available < Total", func() {
+				Expect(u.Available).To(BeNumerically("<", u.Total))
 			})
 		})
 	})

--- a/pkg/util/disk/usage_unix.go
+++ b/pkg/util/disk/usage_unix.go
@@ -9,12 +9,14 @@ import (
 	"github.com/pyroscope-io/pyroscope/pkg/util/bytesize"
 )
 
-func FreeSpace(storagePath string) (bytesize.ByteSize, error) {
-	fs := syscall.Statfs_t{}
-	err := syscall.Statfs(storagePath, &fs)
-	if err != nil {
-		return 0, err
+func Usage(path string) (UsageStats, error) {
+	var fs syscall.Statfs_t
+	if err := syscall.Statfs(path, &fs); err != nil {
+		return UsageStats{}, err
 	}
-
-	return bytesize.ByteSize(fs.Bavail) * bytesize.ByteSize(fs.Bsize), nil
+	u := UsageStats{
+		Total:     bytesize.ByteSize(fs.Blocks) * bytesize.ByteSize(fs.Bsize),
+		Available: bytesize.ByteSize(fs.Bavail) * bytesize.ByteSize(fs.Bsize),
+	}
+	return u, nil
 }

--- a/pkg/util/disk/usage_windows.go
+++ b/pkg/util/disk/usage_windows.go
@@ -16,10 +16,10 @@ var (
 	getDiskFreeSpaceEx = kernel32.NewProc("GetDiskFreeSpaceExW")
 )
 
-func FreeSpace(path string) (bytesize.ByteSize, error) {
+func Usage(path string) (UsageStats, error) {
 	dirPath, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
-		return 0, err
+		return UsageStats{}, err
 	}
 
 	var (
@@ -34,8 +34,12 @@ func FreeSpace(path string) (bytesize.ByteSize, error) {
 		uintptr(unsafe.Pointer(&totalNumberOfBytes)),
 		uintptr(unsafe.Pointer(&totalNumberOfFreeBytes)))
 	if ret == 0 {
-		return 0, os.NewSyscallError("GetDiskFreeSpaceEx", err)
+		return UsageStats{}, os.NewSyscallError("GetDiskFreeSpaceEx", err)
 	}
 
-	return bytesize.ByteSize(freeBytesAvailableToCaller), nil
+	u := UsageStats{
+		Total:     bytesize.ByteSize(totalNumberOfBytes),
+		Available: bytesize.ByteSize(freeBytesAvailableToCaller),
+	}
+	return u, nil
 }


### PR DESCRIPTION
Currently, we have a hardcoded threshold 512MB for the low free disk space alert. The change makes this value configurable (`storage-disk-threshold` option), and instead of an absolute value it takes a percent of available disk space (disk size), which defaults to 5%.

Essentially, the value also serves as a space quota size, that is reserved and not used by storage: once server hits the threshold, storage writes start being dropped. This should allow us to prevent cases when pyroscope server can't start because of BadgerDB failing to acquire the lock file due to the lack of free space.

Although it is not entirely clear how we get into this situation with a hardcoded value, my best guess is that this might be related to how BadgerDB deletes data: effectively, garbage collection rewrites value log files temorary consuming more disk space.
 