### PR TITLE
chore: allows empty names in names array

### DIFF
--- a/packages/pyroscope-models/src/profile.ts
+++ b/packages/pyroscope-models/src/profile.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const FlamebearerSchema = z.object({
-  names: z.array(z.string().nonempty()),
+  names: z.array(z.string()),
   levels: z.array(z.array(z.number())),
   numTicks: z.number(),
   maxSelf: z.number(),


### PR DESCRIPTION
I do see empty names in our profiles every once in a while. While those might be caused by bugs, I could also see people uploading stacktraces with empty names, and in that case that wouldn't be a bug and we should probably still render them.

Therefore I'm relaxing this rule. @eh-am what do you think?