### PR TITLE
chore(frontend): cache bust css

### DIFF
--- a/scripts/webpack/webpack.common.ts
+++ b/scripts/webpack/webpack.common.ts
@@ -48,6 +48,10 @@ const pagePlugins = pages.map(
             ? compilation.getStats().toJson().hash
             : LOCAL_HASH;
 
+        // When running locally, the browser will cache the css
+        const cacheBusting =
+          process.env.NODE_ENV === 'production' ? '' : `?${Math.random()}`;
+
         return {
           extra_metadata: process.env.EXTRA_METADATA
             ? fs.readFileSync(process.env.EXTRA_METADATA)
@@ -55,6 +59,7 @@ const pagePlugins = pages.map(
           mode: process.env.NODE_ENV,
           webpack: {
             hash,
+            cacheBusting,
           },
         };
       },

--- a/webapp/templates/index.html
+++ b/webapp/templates/index.html
@@ -10,11 +10,11 @@
     {{- end }}
     <link
       rel="stylesheet"
-      href="{{ .BaseURL }}/assets/styles.<%= webpack.hash %>.css"
+      href="{{ .BaseURL }}/assets/styles.<%= webpack.hash %>.css<%= webpack.cacheBusting %>"
     />
     <link
       rel="stylesheet"
-      href="{{ .BaseURL }}/assets/app.<%= webpack.hash %>.css"
+      href="{{ .BaseURL }}/assets/app.<%= webpack.hash %>.css<%= webpack.cacheBusting %>"
     />
     {{ .ExtraMetadata }} <%= extra_metadata %>
     <link rel="icon" href="{{ .BaseURL }}/assets/images/favicon.ico" />


### PR DESCRIPTION
Since I run with dev tools open and cache disabled by default, I never had this issue. I only came to notice while seeing @pavelpashkovsky's screen.

Basically when running locally we generate files with constant file names, so that we don't calculate a hash, which is slow. The downside is that the browser will cache that file.

I added a random query string at the end of css files (only in local dev), so that it invalidates the browser's cache.