### PR TITLE
chore(adhoc): if not spyName is available, use 'unknown'

### DIFF
--- a/pkg/adhoc/server/convert.go
+++ b/pkg/adhoc/server/convert.go
@@ -55,7 +55,7 @@ func PprofToProfileV1(b []byte, name string, maxNodes int) (*flamebearer.Flamebe
 		out := &storage.GetOutput{
 			Tree:       t,
 			Units:      units,
-			SpyName:    name,
+			SpyName:    "unknown",
 			SampleRate: sampleRate,
 		}
 		profile := flamebearer.NewProfile(name, out, maxNodes)
@@ -82,7 +82,7 @@ func CollapsedToProfileV1(b []byte, name string, maxNodes int) (*flamebearer.Fla
 	}
 	out := &storage.GetOutput{
 		Tree:       t,
-		SpyName:    name,
+		SpyName:    "unknown",
 		SampleRate: 100, // We don't have this information, use the default
 	}
 	profile := flamebearer.NewProfile(name, out, maxNodes)


### PR DESCRIPTION
As implemented in https://github.com/pyroscope-io/pyroscope/pull/1300
Only a certain list of spyNames are allowed (https://github.com/pyroscope-io/pyroscope/pull/1300/files#diff-4470a525fa07e3755143aea910fec818e7ad9dc18fd97f5f60203a7f43b73e79R3-R19)

In adhoc we were by default in pprof/collapsed to use the appName as the spyName.
With this PR we use `unknown` instead.

