### PR TITLE
chore(flamegraph): reduce barrier for usage

### DIFF
--- a/packages/pyroscope-flamegraph/package.json
+++ b/packages/pyroscope-flamegraph/package.json
@@ -23,12 +23,10 @@
   },
   "peerDependencies": {
     "react": ">=16.14.0",
-    "react-dom": ">=16.14.0"
+    "react-dom": ">=16.14.0",
+    "true-myth": "^5.1.2"
   },
   "devDependencies": {
     "@pyroscope/models": "^0.4.0"
-  },
-  "dependencies": {
-    "true-myth": "^5.1.2"
   }
 }

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Flamegraph.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Flamegraph.ts
@@ -8,7 +8,7 @@ import {
   SpyName,
 } from '@pyroscope/models/src';
 import { PX_PER_LEVEL, BAR_HEIGHT, COLLAPSE_THRESHOLD } from './constants';
-import type { FlamegraphPalette } from './colorPalette';
+import { FlamegraphPalette } from './colorPalette';
 // there's a dependency cycle here but it should be fine
 /* eslint-disable-next-line import/no-cycle */
 import RenderCanvas from './Flamegraph_render';

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Flamegraph_render.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/Flamegraph_render.ts
@@ -43,7 +43,7 @@ import {
   colorGreyscale,
   getPackageNameFromStackTrace,
 } from './color';
-import type { FlamegraphPalette } from './colorPalette';
+import { FlamegraphPalette } from './colorPalette';
 import { isMatch } from '../../search';
 // there's a dependency cycle here but it should be fine
 /* eslint-disable-next-line import/no-cycle */

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.ts
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/color.ts
@@ -3,7 +3,7 @@ import Color from 'color';
 import { scaleLinear } from 'd3-scale';
 import type { SpyName } from '@pyroscope/models/src';
 import murmurhash3_32_gc from './murmur3';
-import type { FlamegraphPalette } from './colorPalette';
+import { FlamegraphPalette } from './colorPalette';
 
 export const defaultColor = Color.rgb(148, 142, 142);
 export const diffColorRed = Color.rgb(200, 0, 0);

--- a/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
+++ b/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, RefObject } from 'react';
 import clsx from 'clsx';
 import type Color from 'color';
-import type { Maybe } from 'true-myth';
+import { Maybe } from 'true-myth';
 import { doubleFF, singleFF, Flamebearer } from '@pyroscope/models/src';
 import TableTooltip from './Tooltip/TableTooltip';
 import { getFormatter } from './format/format';
@@ -12,7 +12,7 @@ import {
 } from './FlameGraph/FlameGraphComponent/color';
 import { fitIntoTableCell, FitModes } from './fitMode/fitMode';
 import { isMatch } from './search';
-import type { FlamegraphPalette } from './FlameGraph/FlameGraphComponent/colorPalette';
+import { FlamegraphPalette } from './FlameGraph/FlameGraphComponent/colorPalette';
 import styles from './ProfilerTable.module.scss';
 
 const zero = (v?: number) => v || 0;

--- a/packages/pyroscope-flamegraph/src/convert/convertJaegerTraceToProfile.ts
+++ b/packages/pyroscope-flamegraph/src/convert/convertJaegerTraceToProfile.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export */
 import groupBy from 'lodash.groupby';
 import map from 'lodash.map';
-import type { Profile, Trace, TraceSpan } from '@pyroscope/models/src';
+import { Profile, Trace, TraceSpan } from '@pyroscope/models/src';
 import { deltaDiffWrapperReverse } from '../FlameGraph/decode';
 
 interface Span extends TraceSpan {

--- a/packages/pyroscope-flamegraph/src/convert/diffTwoProfiles.ts
+++ b/packages/pyroscope-flamegraph/src/convert/diffTwoProfiles.ts
@@ -2,7 +2,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 
-import type { Profile } from '@pyroscope/models/src';
+import { Profile } from '@pyroscope/models/src';
 import {
   deltaDiffWrapper,
   deltaDiffWrapperReverse,

--- a/yarn.lock
+++ b/yarn.lock
@@ -21221,11 +21221,6 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
-"true-myth@^5.1.2":
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/true-myth/-/true-myth-5.1.2.tgz#58a425b0aefe57eed279ac2d1b65e567153ea9b0"
-  integrity sha512-4A8CVJiDt35EhS2U4DYoU1Kg8nMdqpC4sIc4ktan/nE3T2u5kLd7fJ1ZSQTn5xO/A41IB7DLF8R8xL6l0MPgsQ==
-
 "true-myth@~5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/true-myth/-/true-myth-5.2.0.tgz#f434d4ca314922568260d742f7bed613b5ae3652"


### PR DESCRIPTION
Edited by Eduardo:

* remove `true-myth` frmo dependencies, since we publish the flamegraph bundled, there should be no need to pull that dependency
* downgrade typescript usage, [`import type` was introduced in typescript 3.8](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html), which prohibits usage from users in older versions