### PR TITLE
chore: add a script to obfuscate json files

### DIFF
--- a/scripts/obfuscate.js
+++ b/scripts/obfuscate.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const args = process.argv.slice(2);
+
+if (args.length != 1) {
+  console.error('Usage ./obfuscate [filepath]');
+  process.exit(1);
+}
+// TODO(eh-am): read from stdin if available
+const filename = args[0];
+const data = JSON.parse(fs.readFileSync(filename));
+
+function randomName() {
+  let r = (Math.random() + 1).toString(36).substring(7);
+  return r;
+}
+
+data.metadata.name = randomName();
+data.flamebearer.names = data.flamebearer.names.map(randomName);
+
+console.log(JSON.stringify(data));


### PR DESCRIPTION
Sometimes we need to post flamegraph json files (for reproducibility, example https://github.com/pyroscope-io/pyroscope/pull/1341#issuecomment-1204048760), but we don't want to expose function names etc. This simple scripts just replaces these somewhat confidential data (app name and node names) for random strings.