### PR TITLE
chore(flamegraph): don't show <TBD> for unknown case in tooltip footer

### DIFF
--- a/packages/pyroscope-flamegraph/src/Tooltip/Tooltip.tsx
+++ b/packages/pyroscope-flamegraph/src/Tooltip/Tooltip.tsx
@@ -359,7 +359,7 @@ function TooltipFooter({
       );
       break;
     default:
-      clickInfo = '<TBD ?>';
+      clickInfo = <></>;
   }
 
   return (


### PR DESCRIPTION
Don't know if this is a case that can ever happen in the wild, but nevertheless it's better to not show anything instead of `TBD

https://user-images.githubusercontent.com/6951209/182663231-197c3f9a-86d5-4c66-99b3-301eade7a153.mp4

`