### PR TITLE
chore(models): default spyName to 'unknown' when not detected

### DIFF
--- a/packages/pyroscope-models/src/spyName.spec.ts
+++ b/packages/pyroscope-models/src/spyName.spec.ts
@@ -1,12 +1,12 @@
 import { SpyNameSchema, AllSpyNames } from './spyName';
 
 describe('SpyName', () => {
-  it('fails when when passing an unsupported value', () => {
-    expect(SpyNameSchema.safeParse('foo').success).toBe(false);
-  });
-
   it('defaults to "unknown" when absent', () => {
     expect(SpyNameSchema.parse('')).toBe('unknown');
+  });
+
+  it('defaults to "unknown" when value is not in the allowlist', () => {
+    expect(SpyNameSchema.parse('other')).toBe('unknown');
   });
 
   test.each(AllSpyNames.map((a) => [a, a]))(

--- a/packages/pyroscope-models/src/spyName.ts
+++ b/packages/pyroscope-models/src/spyName.ts
@@ -21,7 +21,7 @@ export const SpyNameOther = [
 export const AllSpyNames = [...SpyNameFirstClass, ...SpyNameOther] as const;
 
 export const SpyNameSchema = z.preprocess((val) => {
-  if (!val) {
+  if (!val || !AllSpyNames.includes(val as typeof AllSpyNames[number])) {
     return 'unknown';
   }
   return val;


### PR DESCRIPTION
When a non officially supported `spyName` is passed, default to `unknown`.