### PR TITLE
feat(webapp): persist uploaded data via adhoc ui

### DIFF
--- a/pkg/adhoc/cli.go
+++ b/pkg/adhoc/cli.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/pyroscope-io/pyroscope/pkg/adhoc/writer"
 	"github.com/pyroscope-io/pyroscope/pkg/analytics"
 	"github.com/pyroscope-io/pyroscope/pkg/health"
 	"github.com/sirupsen/logrus"
@@ -136,7 +137,7 @@ func Cli(cfg *config.Adhoc, args []string) error {
 		go analytics.AdhocReport(m.String()+"-"+status, &wg)
 	}
 
-	if err := newWriter(cfg, st, logger).write(t0, time.Now()); err != nil {
+	if err := writer.NewWriter(cfg, st, logger).Write(t0, time.Now()); err != nil {
 		logger.WithError(err).Error("writing profiling data")
 	}
 

--- a/pkg/adhoc/server/server.go
+++ b/pkg/adhoc/server/server.go
@@ -10,12 +10,14 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
+	"github.com/pyroscope-io/pyroscope/pkg/adhoc/writer"
 	"github.com/pyroscope-io/pyroscope/pkg/structs/flamebearer"
 )
 
@@ -28,12 +30,13 @@ type profile struct {
 }
 
 type server struct {
-	log      logrus.FieldLogger
-	dataDir  string
-	maxNodes int
-	enabled  bool
-	profiles map[string]profile
-	mtx      sync.RWMutex
+	log                logrus.FieldLogger
+	dataDir            string
+	adhocDataDirWriter *writer.AdhocDataDirWriter
+	maxNodes           int
+	enabled            bool
+	profiles           map[string]profile
+	mtx                sync.RWMutex
 }
 
 type Server interface {
@@ -42,11 +45,12 @@ type Server interface {
 
 func New(log logrus.FieldLogger, dataDir string, maxNodes int, enabled bool) Server {
 	return &server{
-		log:      log,
-		dataDir:  dataDir,
-		maxNodes: maxNodes,
-		enabled:  enabled,
-		profiles: make(map[string]profile),
+		log:                log,
+		adhocDataDirWriter: writer.NewAdhocDataDirWriter(dataDir),
+		dataDir:            dataDir,
+		maxNodes:           maxNodes,
+		enabled:            enabled,
+		profiles:           make(map[string]profile),
 	}
 }
 
@@ -230,12 +234,36 @@ func (s *server) Upload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
+	err = s.adhocDataDirWriter.EnsureExists()
+	if err != nil {
+		msg := "Unable to create adhoc's DataPath"
+		s.log.WithError(err).Error(msg)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	now := time.Now()
+	// Remove extension, since we will store a json file
+	filename := strings.TrimSuffix(m.Filename, filepath.Ext(m.Filename))
+	// TODO(eh-am): maybe we should use whatever the user has sent us?
+	filename = fmt.Sprintf("%s-%s.json", filename, now.Format("2006-01-02-15-04-05"))
+
+	err = s.adhocDataDirWriter.Write(filename, *fb)
+	if err != nil {
+		msg := "Unable to write profile to adhoc's DataPath"
+		s.log.WithError(err).Error(msg)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(fb); err != nil {
 		s.log.WithError(err).Error("Unable to encode the response")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
 }
 
 // Upload two single profiles in native JSON format and convert to a diff profile

--- a/pkg/adhoc/server/server.go
+++ b/pkg/adhoc/server/server.go
@@ -263,7 +263,6 @@ func (s *server) Upload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-
 }
 
 // Upload two single profiles in native JSON format and convert to a diff profile

--- a/pkg/adhoc/server/server.go
+++ b/pkg/adhoc/server/server.go
@@ -249,7 +249,7 @@ func (s *server) Upload(w http.ResponseWriter, r *http.Request) {
 	// TODO(eh-am): maybe we should use whatever the user has sent us?
 	filename = fmt.Sprintf("%s-%s.json", filename, now.Format("2006-01-02-15-04-05"))
 
-	err = s.adhocDataDirWriter.Write(filename, *fb)
+	_, err = s.adhocDataDirWriter.Write(filename, *fb)
 	if err != nil {
 		msg := "Unable to write profile to adhoc's DataPath"
 		s.log.WithError(err).Error(msg)

--- a/pkg/adhoc/writer/datadir_writer.go
+++ b/pkg/adhoc/writer/datadir_writer.go
@@ -33,7 +33,7 @@ func (w *AdhocDataDirWriter) EnsureExists() error {
 // TODO(eh-am): do we even need a name?
 func (w *AdhocDataDirWriter) Write(filename string, flame flamebearer.FlamebearerProfile) error {
 	// Remove extension
-	path := filepath.Join(w.dataDir, filename+".json")
+	path := filepath.Join(w.dataDir, filename)
 	f, err := os.Create(path)
 	if err != nil {
 		return err

--- a/pkg/adhoc/writer/datadir_writer.go
+++ b/pkg/adhoc/writer/datadir_writer.go
@@ -1,0 +1,52 @@
+package writer
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pyroscope-io/pyroscope/pkg/structs/flamebearer"
+)
+
+type AdhocDataDirWriter struct {
+	dataDir string
+}
+
+func NewAdhocDataDirWriter(dataDir string) *AdhocDataDirWriter {
+	return &AdhocDataDirWriter{
+		dataDir,
+	}
+}
+
+// EnsureExist makes sure the ${dataDir} directory exists in the filesystem
+func (w *AdhocDataDirWriter) EnsureExists() error {
+	if err := os.MkdirAll(w.dataDir, os.ModeDir|os.ModePerm); err != nil {
+		return fmt.Errorf("could not create data directory %s: %w", w.dataDir, err)
+	}
+
+	return nil
+}
+
+// Write writes a flamebearer in json format to its dataDir
+// given the app name, a flamebearer and a timestamp
+// TODO(eh-am): do we even need a name?
+func (w *AdhocDataDirWriter) Write(filename string, flame flamebearer.FlamebearerProfile) error {
+	// Remove extension
+	path := filepath.Join(w.dataDir, filename+".json")
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if err := json.NewEncoder(f).Encode(flame); err != nil {
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/adhoc/writer/datadir_writer.go
+++ b/pkg/adhoc/writer/datadir_writer.go
@@ -31,22 +31,22 @@ func (w *AdhocDataDirWriter) EnsureExists() error {
 // Write writes a flamebearer in json format to its dataDir
 // given the app name, a flamebearer and a timestamp
 // TODO(eh-am): do we even need a name?
-func (w *AdhocDataDirWriter) Write(filename string, flame flamebearer.FlamebearerProfile) error {
+func (w *AdhocDataDirWriter) Write(filename string, flame flamebearer.FlamebearerProfile) (string, error) {
 	// Remove extension
 	path := filepath.Join(w.dataDir, filename)
 	f, err := os.Create(path)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer f.Close()
 
 	if err := json.NewEncoder(f).Encode(flame); err != nil {
-		return err
+		return "", err
 	}
 
 	if err := f.Close(); err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return path, nil
 }

--- a/pkg/adhoc/writer/datadir_writer.go
+++ b/pkg/adhoc/writer/datadir_writer.go
@@ -29,10 +29,7 @@ func (w *AdhocDataDirWriter) EnsureExists() error {
 }
 
 // Write writes a flamebearer in json format to its dataDir
-// given the app name, a flamebearer and a timestamp
-// TODO(eh-am): do we even need a name?
 func (w *AdhocDataDirWriter) Write(filename string, flame flamebearer.FlamebearerProfile) (string, error) {
-	// Remove extension
 	path := filepath.Join(w.dataDir, filename)
 	f, err := os.Create(path)
 	if err != nil {

--- a/pkg/adhoc/writer/external_writer.go
+++ b/pkg/adhoc/writer/external_writer.go
@@ -1,4 +1,4 @@
-package adhoc
+package writer
 
 import (
 	"fmt"

--- a/pkg/adhoc/writer/writer.go
+++ b/pkg/adhoc/writer/writer.go
@@ -1,4 +1,4 @@
-package adhoc
+package writer
 
 import (
 	"context"
@@ -7,7 +7,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	adhocWriter "github.com/pyroscope-io/pyroscope/pkg/adhoc/writer"
 	"github.com/pyroscope-io/pyroscope/pkg/config"
 	"github.com/pyroscope-io/pyroscope/pkg/storage"
 	"github.com/pyroscope-io/pyroscope/pkg/storage/segment"
@@ -21,21 +20,21 @@ type writer struct {
 	logger         *logrus.Logger
 	storage        *storage.Storage
 
-	adhocDataDirWriter *adhocWriter.AdhocDataDirWriter
+	adhocDataDirWriter *AdhocDataDirWriter
 }
 
-func newWriter(cfg *config.Adhoc, st *storage.Storage, logger *logrus.Logger) writer {
+func NewWriter(cfg *config.Adhoc, st *storage.Storage, logger *logrus.Logger) writer {
 	return writer{
 		maxNodesRender:     cfg.MaxNodesRender,
 		outputFormat:       cfg.OutputFormat,
 		outputJSON:         !cfg.NoJSONOutput,
 		logger:             logger,
 		storage:            st,
-		adhocDataDirWriter: adhocWriter.NewAdhocDataDirWriter(cfg.DataPath),
+		adhocDataDirWriter: NewAdhocDataDirWriter(cfg.DataPath),
 	}
 }
 
-func (w writer) write(t0, t1 time.Time) error {
+func (w writer) Write(t0, t1 time.Time) error {
 	err := w.adhocDataDirWriter.EnsureExists()
 	if err != nil {
 		return err

--- a/pkg/adhoc/writer/writer.go
+++ b/pkg/adhoc/writer/writer.go
@@ -78,12 +78,13 @@ func (w writer) Write(t0, t1 time.Time) error {
 		if w.outputJSON {
 			flame := flamebearer.NewProfile(name, out, w.maxNodesRender)
 			filename := fmt.Sprintf("%s-%s.json", name, t0.Format("2006-01-02-15-04-05"))
-			err = w.adhocDataDirWriter.Write(filename, flame)
-
+			path, err := w.adhocDataDirWriter.Write(filename, flame)
 			if err != nil {
 				w.logger.WithError(err).Error("saving to AdhocDir")
 				continue
 			}
+
+			w.logger.Infof("profiling data has been saved to %s", path)
 		}
 
 		profiles++

--- a/pkg/adhoc/writer/writer.go
+++ b/pkg/adhoc/writer/writer.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pyroscope-io/pyroscope/pkg/structs/flamebearer"
 )
 
-type writer struct {
+type Writer struct {
 	maxNodesRender int
 	outputFormat   string
 	outputJSON     bool
@@ -23,8 +23,8 @@ type writer struct {
 	adhocDataDirWriter *AdhocDataDirWriter
 }
 
-func NewWriter(cfg *config.Adhoc, st *storage.Storage, logger *logrus.Logger) writer {
-	return writer{
+func NewWriter(cfg *config.Adhoc, st *storage.Storage, logger *logrus.Logger) Writer {
+	return Writer{
 		maxNodesRender:     cfg.MaxNodesRender,
 		outputFormat:       cfg.OutputFormat,
 		outputJSON:         !cfg.NoJSONOutput,
@@ -34,7 +34,7 @@ func NewWriter(cfg *config.Adhoc, st *storage.Storage, logger *logrus.Logger) wr
 	}
 }
 
-func (w writer) Write(t0, t1 time.Time) error {
+func (w Writer) Write(t0, t1 time.Time) error {
 	err := w.adhocDataDirWriter.EnsureExists()
 	if err != nil {
 		return err

--- a/webapp/javascript/redux/reducers/adhoc.ts
+++ b/webapp/javascript/redux/reducers/adhoc.ts
@@ -72,6 +72,9 @@ export const uploadFile = createAsyncThunk(
     const res = await upload(file);
 
     if (res.isOk) {
+      // Since we just uploaded a file, let's reload to see it on the file list
+      thunkAPI.dispatch(fetchAllProfiles());
+
       return Promise.resolve({ profile: res.value, fileName: file.name });
     }
 


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/1317

https://user-images.githubusercontent.com/6951209/182932596-653c8400-74b4-415f-be9e-5dbcedb1c301.mp4


The frontend can be simplified/improved:
* have a single path of loading a profile (from file list)
* auto select profile after uploading
