### PR TITLE
fix: make table value say 0 when it is 0

### DIFF
--- a/packages/pyroscope-flamegraph/src/format/format.spec.ts
+++ b/packages/pyroscope-flamegraph/src/format/format.spec.ts
@@ -29,6 +29,7 @@ describe('format', () => {
       it('correctly formats duration when maxdur = 40', () => {
         const df = getFormatter(80, 2, 'samples');
 
+        expect(df.format(0, 100)).toBe('0.00 seconds');
         expect(df.format(0.001, 100)).toBe('< 0.01 seconds');
         expect(df.format(100, 100)).toBe('1.00 second');
         expect(df.format(2000, 100)).toBe('20.00 seconds');

--- a/packages/pyroscope-flamegraph/src/format/format.spec.ts
+++ b/packages/pyroscope-flamegraph/src/format/format.spec.ts
@@ -29,7 +29,7 @@ describe('format', () => {
       it('correctly formats duration when maxdur = 40', () => {
         const df = getFormatter(80, 2, 'samples');
 
-        expect(df.format(0, 100)).toBe('0.00 seconds');
+        // expect(df.format(0, 100)).toBe('0.00 seconds');
         expect(df.format(0.001, 100)).toBe('< 0.01 seconds');
         expect(df.format(100, 100)).toBe('1.00 second');
         expect(df.format(2000, 100)).toBe('20.00 seconds');

--- a/packages/pyroscope-flamegraph/src/format/format.spec.ts
+++ b/packages/pyroscope-flamegraph/src/format/format.spec.ts
@@ -29,7 +29,7 @@ describe('format', () => {
       it('correctly formats duration when maxdur = 40', () => {
         const df = getFormatter(80, 2, 'samples');
 
-        // expect(df.format(0, 100)).toBe('0.00 seconds');
+        expect(df.format(0, 100)).toBe('0.00 seconds');
         expect(df.format(0.001, 100)).toBe('< 0.01 seconds');
         expect(df.format(100, 100)).toBe('1.00 second');
         expect(df.format(2000, 100)).toBe('20.00 seconds');

--- a/packages/pyroscope-flamegraph/src/format/format.ts
+++ b/packages/pyroscope-flamegraph/src/format/format.ts
@@ -78,7 +78,9 @@ class DurationFormatter {
     const n = samples / sampleRate / this.divider;
     let nStr = n.toFixed(2);
 
-    if (n >= 0 && n < 0.01) {
+    if (n === 0) {
+      nStr = '0.00';
+    } else if (n >= 0 && n < 0.01) {
       nStr = '< 0.01';
     } else if (n <= 0 && n > -0.01) {
       nStr = '< 0.01';


### PR DESCRIPTION
Makes table value say 0 when it is actually 0 instead of `"<0.01 seconds"`