### PR TITLE
fix(webapp): fixes crash when hitting back button

### DIFF
--- a/webapp/javascript/util/formatDate.spec.ts
+++ b/webapp/javascript/util/formatDate.spec.ts
@@ -33,6 +33,10 @@ describe('FormatDate', () => {
         '1640090089000000000',
         '2021-06-21 12:34 PM - 2021-12-21 12:34 PM',
       ],
+
+      // Return nothing when mixing absolute/relative
+      ['1624278889000000000', 'now-1h', ''],
+      ['now-1h', '1624278889000000000', ''],
     ];
 
     test.each(cases)(

--- a/webapp/javascript/util/formatDate.ts
+++ b/webapp/javascript/util/formatDate.ts
@@ -55,7 +55,16 @@ export function readableRange(
 
   const d1 = getUTCdate(parseUnixTime(from), offsetInMinutes);
   const d2 = getUTCdate(parseUnixTime(until), offsetInMinutes);
+
+  if (!isValidDate(d1) || !isValidDate(d2)) {
+    return '';
+  }
+
   return `${format(d1, dateFormat)} - ${format(d2, dateFormat)}`;
+}
+
+function isValidDate(d: Date) {
+  return d instanceof Date && !isNaN(d.getTime());
 }
 
 /**


### PR DESCRIPTION
Original issue:

When selecting a time range and hitting the back button
https://user-images.githubusercontent.com/6951209/185229101-47444c01-7644-460e-b194-404750e681c8.mp4


This happens due to `redux-sync`, which syncs the URL with the redux state both ways.
The url changes all at once (both `from` and `until` parameters), while in redux only a single action is dispatched at a time:
<img width="278" alt="Screen Shot 2022-08-17 at 16 37 44" src="https://user-images.githubusercontent.com/6951209/185229360-48bffa41-d6f6-408b-bbb6-fcf508b18c49.png">

Which leads to a somewhat inconsistent state, where we are mixing relative values (like `from`) with absolute values (unix `timestamp`)
<img width="500" alt="Screen Shot 2022-08-17 at 16 37 27" src="https://user-images.githubusercontent.com/6951209/185229327-0127865e-7adf-48c5-9347-be147acaba62.png">

Which then generates a wrong date, crashing `date-fns` (https://github.com/pyroscope-io/pyroscope/blob/e2128b9e7fdde0fc823985c098b1b86ddcf710f9/webapp/javascript/util/formatDate.ts#L56-L58)

So my lazy solution is to just check whether it's a valid date, and if not, to just return an empty string. Since this is used as a label only, it should be somewhat fine.

Ahh how I would love using `Maybe` here :)

BTW the problem also happens when loading data:
<img width="594" alt="Screen Shot 2022-08-17 at 16 44 47" src="https://user-images.githubusercontent.com/6951209/185229950-806a6aed-a616-4fdc-a439-52b56b7ae90f.png">

However since it happens so fast, we end up cancelling the previous request.