### PR TITLE
chore: Table ui component tests warn

### DIFF
--- a/webapp/javascript/ui/Table.spec.tsx
+++ b/webapp/javascript/ui/Table.spec.tsx
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
 
 import { useTableSort } from './Table';
 
@@ -30,7 +30,9 @@ describe('Hook: useTableSort', () => {
     const hook = render();
 
     expect(hook.current.sortByDirection).toBe('desc');
-    hook.current.updateSortParams('self');
+    act(() => {
+      hook.current.updateSortParams('self');
+    });
     expect(hook.current.sortByDirection).toBe('asc');
   });
 
@@ -42,13 +44,17 @@ describe('Hook: useTableSort', () => {
       sortByDirection: 'desc',
     });
 
-    hook.current.updateSortParams('name');
+    act(() => {
+      hook.current.updateSortParams('name');
+    });
     expect(hook.current).toMatchObject({
       sortBy: 'name',
       sortByDirection: 'desc',
     });
 
-    hook.current.updateSortParams('name');
+    act(() => {
+      hook.current.updateSortParams('name');
+    });
     expect(hook.current).toMatchObject({
       sortBy: 'name',
       sortByDirection: 'asc',


### PR DESCRIPTION
## Brief
- fix Test ui component tests warnings
- ensure that test render and real one are as close to each other as possible
## Changes
- wrap hook export function call in `act`
- to make your test run closer to how React works in the browser, every component update function call should be wrapped in `act` (https://reactjs.org/docs/test-utils.html#act)
## Concerns
-