### PR TITLE
chore(models): default flamebearer names to 'unknown' when it's empty

### DIFF
--- a/packages/pyroscope-models/src/profile.spec.ts
+++ b/packages/pyroscope-models/src/profile.spec.ts
@@ -1,6 +1,35 @@
-import { MetadataSchema } from './profile';
+import { MetadataSchema, FlamebearerSchema } from './profile';
 
 describe('Profile', () => {
+  describe('FlamebearerSchema', () => {
+    describe('Names', () => {
+      it('defaults to "unknown" when name is empty', () => {
+        const fb = {
+          names: ['', ''],
+          levels: [],
+          numTicks: 100,
+          maxSelf: 100,
+        };
+        expect(FlamebearerSchema.parse(fb)).toStrictEqual({
+          names: ['unknown', 'unknown'],
+          levels: [],
+          numTicks: 100,
+          maxSelf: 100,
+        });
+      });
+
+      it('uses correct name when not empty', () => {
+        const fb = {
+          names: ['myname', 'myname2'],
+          levels: [],
+          numTicks: 100,
+          maxSelf: 100,
+        };
+        expect(FlamebearerSchema.parse(fb)).toStrictEqual(fb);
+      });
+    });
+  });
+
   describe('MetadataSchem', () => {
     describe('Units', () => {
       const expected = {

--- a/packages/pyroscope-models/src/profile.ts
+++ b/packages/pyroscope-models/src/profile.ts
@@ -2,7 +2,15 @@ import { z } from 'zod';
 import { SpyNameSchema } from './spyName';
 
 export const FlamebearerSchema = z.object({
-  names: z.array(z.string()),
+  names: z.array(
+    z.preprocess((n) => {
+      if (!n) {
+        return 'unknown';
+      }
+
+      return n;
+    }, z.string().min(1))
+  ),
   levels: z.array(z.array(z.number())),
   numTicks: z.number(),
   maxSelf: z.number(),


### PR DESCRIPTION
Follow up from https://github.com/pyroscope-io/pyroscope/pull/1321

Previous to this PR we would just render nodes with empy names.
![image](https://user-images.githubusercontent.com/6951209/185636611-19c19bf7-bbff-430e-b6f3-31c3f8965f40.png)

However down the road code assumes it's non empty, eg:
<img width="712" alt="Screen Shot 2022-08-19 at 11 07 51" src="https://user-images.githubusercontent.com/6951209/185636952-df05e186-d731-4b8c-8622-8fb0eb5b87db.png">

So to maintain the invariant and simplify all this, decided to default to `unknown` instead.


Keep in mind values on the table still don't make full sense though.
![image](https://user-images.githubusercontent.com/6951209/185636078-cc21da86-65e9-437d-926c-7a20782ee353.png)




