### PR TITLE
chore(webapp): import jquery globally

### DIFF
--- a/scripts/webpack/webpack.common.ts
+++ b/scripts/webpack/webpack.common.ts
@@ -152,10 +152,6 @@ export default {
   plugins: [
     // uncomment if you want to see the webpack bundle analysis
     // new BundleAnalyzerPlugin(),
-    new webpack.ProvidePlugin({
-      $: 'jquery',
-      jQuery: 'jquery',
-    }),
     ...pagePlugins,
     new MiniCssExtractPlugin({
       filename: getFilename('css'),

--- a/webapp/javascript/components/TimelineChart/TimelineChart.tsx
+++ b/webapp/javascript/components/TimelineChart/TimelineChart.tsx
@@ -1,13 +1,6 @@
 /* eslint-disable import/first */
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-nocheck
 import 'react-dom';
 import React from 'react';
-import jquery from 'jquery';
-
-// https://github.com/facebook/create-react-app/issues/4281
-window.jQuery = jquery;
-window.$ = jquery;
 
 import ReactFlot from 'react-flot';
 import 'react-flot/flot/jquery.flot.time.min';

--- a/webapp/javascript/globals.tsx
+++ b/webapp/javascript/globals.tsx
@@ -1,0 +1,10 @@
+import jquery from 'jquery';
+
+interface Window {
+  jQuery?: unknown;
+  $?: unknown;
+}
+
+// Used by react-flot/flotjs
+(window as Window).jQuery = jquery;
+(window as Window).$ = jquery;

--- a/webapp/javascript/index.tsx
+++ b/webapp/javascript/index.tsx
@@ -31,6 +31,7 @@ import Forbidden from './pages/IntroPages/Forbidden';
 import NotFound from './pages/IntroPages/NotFound';
 import { PAGES } from './pages/constants';
 import history from './util/history';
+import './globals';
 
 function App() {
   return (

--- a/webapp/javascript/index.tsx
+++ b/webapp/javascript/index.tsx
@@ -1,3 +1,5 @@
+import './globals';
+
 import ReactDOM from 'react-dom';
 import React from 'react';
 
@@ -31,7 +33,6 @@ import Forbidden from './pages/IntroPages/Forbidden';
 import NotFound from './pages/IntroPages/NotFound';
 import { PAGES } from './pages/constants';
 import history from './util/history';
-import './globals';
 
 function App() {
   return (


### PR DESCRIPTION
Let's treat `jQuery` as a global dependency, ie. as if it's always present.

Before it was scopped to the `TimelineChart.tsx` component, but from an architecture POV this is not the only place jQuery is used. And repeating the same import multiple times is cumbersome.