### PR TITLE
fix(flamegraph): fixed tooltip display with color blind palette

### DIFF
--- a/packages/pyroscope-flamegraph/src/Tooltip/FlamegraphTooltip.tsx
+++ b/packages/pyroscope-flamegraph/src/Tooltip/FlamegraphTooltip.tsx
@@ -152,7 +152,7 @@ export default function FlamegraphTooltip(props: FlamegraphTooltipProps) {
           throw new Error(`Unsupported format:'`);
       }
     },
-    [numTicks, sampleRate, units, leftTicks, rightTicks]
+    [numTicks, sampleRate, units, leftTicks, rightTicks, palette]
   );
 
   return (


### PR DESCRIPTION
## Brief
 - https://github.com/pyroscope-io/pyroscope/issues/1398
## Changes
 - now tooltip works correct with color blind palette 
## Concerns
 -

https://user-images.githubusercontent.com/23450818/186697652-d2e3e608-9bed-464c-8743-b09ad1a3f0ea.mov

 