### PR TITLE
Сomparison dropdown styles

### DIFF
--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
@@ -12,6 +12,7 @@
   margin: 0;
   text-align: left;
   min-height: 150px;
+  max-height: 440px;
 
   li {
     &.selected {

--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
@@ -23,6 +23,10 @@
       padding: 10px 30px;
       width: 100%;
       text-align: left;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      max-width: 100%;
     }
   }
 }

--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
@@ -27,7 +27,6 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      max-width: 100%;
     }
   }
 }

--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.spec.tsx
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.spec.tsx
@@ -70,7 +70,13 @@ describe('Component: ViewTagsSelectLinkModal', () => {
     modalWithToggleEl.querySelectorAll('.tags').forEach((tagList) => {
       tagList.querySelectorAll('input').forEach((tag, i) => {
         expect(tag).toHaveAttribute('value', whereDropdownItems[i]);
+        tag.click();
+        expect(tag.parentElement).toHaveClass('selected');
       });
     });
+
+    //second click
+    screen.getByTestId('toggler').click();
+    expect(modalWithToggleEl).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1445
## Changes
- added comparison tag selector scroll
- added comparison tag selector text-overflow
- added tests for 'selected' state and dropdown close 
## Concerns
-


https://user-images.githubusercontent.com/23450818/187423387-edfb1704-4550-473d-9a97-80bfb586a5ef.mov

