### PR TITLE
fix(flamegraph): table, buttons colors for light mode

### DIFF
--- a/packages/pyroscope-flamegraph/src/Toolbar.module.css
+++ b/packages/pyroscope-flamegraph/src/Toolbar.module.css
@@ -5,6 +5,10 @@
   align-items: center;
 }
 
+.navbar button {
+  color: var(--ps-neutral-2);
+}
+
 /* Give same amount of space between all children */
 .navbar > *:not(:first-child) {
   margin-left: 5px;

--- a/webapp/sass/common.scss
+++ b/webapp/sass/common.scss
@@ -45,8 +45,13 @@ tt {
   font-size: 14px;
   border: 1px solid var(--ps-ui-border);
 
+  thead th {
+    color: var(--ps-neutral-2);
+  }
+
   th,
   td {
+    color: var(--ps-neutral-2);
     text-align: right;
     padding: 0px 10px;
 


### PR DESCRIPTION
## Brief

Fix incorrect colors for UI elements on Flamegraph for light mode.

## Changes

### before:
![before](https://user-images.githubusercontent.com/7372044/188432888-16a46fe2-e670-4de5-80cb-1b5ad76a8f82.png)

### after:
![image](https://user-images.githubusercontent.com/7372044/188432977-ff4df2aa-b745-404c-a17b-ac2355559e8e.png)

## Concerns
- imported `sanitize.css` re-writes assigned styles 