### PR TITLE
fix(webapp): Don't show tooltip when there's no data

### DIFF
--- a/webapp/javascript/components/TimelineChart/Tooltip.plugin.tsx
+++ b/webapp/javascript/components/TimelineChart/Tooltip.plugin.tsx
@@ -115,6 +115,10 @@ const TOOLTIP_WRAPPER_ID = 'explore_tooltip_parent';
           }
         );
 
+        if (!values?.length) {
+          return;
+        }
+
         const Tooltip: React.ReactElement<
           ExploreTooltipProps,
           string | React.JSXElementConstructor<ExploreTooltipProps>


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1467
## Changes
- Hide Explore tooltip if there is no profiling data
![image](https://user-images.githubusercontent.com/7372044/188847616-8f8060d1-a4d1-434e-8bc7-6de00624d8c9.png)
## Concerns
- I hid the tooltip, but we still have this red line which follows the cursor. If you want to hide it as well I have to extract `react-flot/flot/jquery.flot.crosshair.min` into the project and make up it there. `{hoverable: boolean}` doesn't influence on this red line.
