### PR TITLE
fix(webapp): hide timeline tooltip if there's no data

### DIFF
--- a/webapp/javascript/components/TimelineChart/TooltipWrapper/styles.module.scss
+++ b/webapp/javascript/components/TimelineChart/TooltipWrapper/styles.module.scss
@@ -9,6 +9,12 @@
   border-radius: 4px;
   padding: 8px 12px;
   color: var(--ps-tooltip-text);
+
+  // Don't show anything when there's no body
+  // Otherwise an empty box will be shown
+  &:empty {
+    display: none;
+  }
 }
 
 .hidden {


### PR DESCRIPTION
Initially raised https://github.com/pyroscope-io/pyroscope/pull/1469#discussion_r964867470

We always render a tooltip, even if there's no body:
![image](https://user-images.githubusercontent.com/6951209/188913955-d6c7ff57-63b4-4bd1-95bb-0c0b668d95f7.png)

It's a bit tricky to solve this, since it would require the parent to know whether the children is empty. Instead of manually rendering I decided to just use CSS to hide the tooltip if it's empty (ie its children is null).

