### PR TITLE
fix(webapp): hotfix CollapseBox overflow

### DIFF
--- a/webapp/javascript/ui/Box.module.scss
+++ b/webapp/javascript/ui/Box.module.scss
@@ -20,7 +20,6 @@
     border: none;
     border-radius: 0;
     padding-bottom: 0;
-    overflow: hidden;
     height: auto;
 
     &.collapsedContent {

--- a/webapp/javascript/ui/Box.module.scss
+++ b/webapp/javascript/ui/Box.module.scss
@@ -26,6 +26,7 @@
       height: 0;
       margin: 0;
       padding: 0;
+      overflow: hidden;
     }
   }
 }


### PR DESCRIPTION
## Brief
- remove `overflow:hidden` for CollapseBox content
![image](https://user-images.githubusercontent.com/7372044/189885910-01b3f530-2f9f-4da3-8235-8562e1d6b80f.png)

## Changes
- removed oveflow:hidden
![image](https://user-images.githubusercontent.com/7372044/189887014-2d3fb96f-2f82-4c41-91bb-d2e4d42ac1f4.png)
