### PR TITLE
feat: add 'perf script' format upload

### DIFF
--- a/pkg/adhoc/server/server_test.go
+++ b/pkg/adhoc/server/server_test.go
@@ -520,6 +520,65 @@ var _ = Describe("Server", func() {
 			})
 		})
 
+		Context("perf script", func() {
+			When("detect by content", func() {
+				var m Model
+
+				BeforeEach(func() {
+					m = Model{
+						Profile: []byte("java 12688 [002] 6544038.708352: cpu-clock:\n\n"),
+					}
+				})
+
+				It("should return perf_script", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(PerfScriptToProfileV1).Pointer()
+					f, err := m.converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+			When("detect by .txt extension and content", func() {
+				var m Model
+
+				BeforeEach(func() {
+					m = Model{
+						Filename: "foo.txt",
+						Profile:  []byte("java 12688 [002] 6544038.708352: cpu-clock:\n\n"),
+					}
+				})
+
+				It("should return perf_script", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(PerfScriptToProfileV1).Pointer()
+					f, err := m.converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+			When("detect by .perf_script extension", func() {
+				var m Model
+
+				BeforeEach(func() {
+					m = Model{
+						Filename: "foo.perf_script",
+						Profile:  []byte("foo;bar 239"),
+					}
+				})
+
+				It("should return perf_script", func() {
+					// We want to compare functions, which is not ideal.
+					expected := reflect.ValueOf(PerfScriptToProfileV1).Pointer()
+					f, err := m.converter()
+					Expect(err).To(BeNil())
+					Expect(f).ToNot(BeNil())
+					Expect(reflect.ValueOf(f).Pointer()).To(Equal(expected))
+				})
+			})
+		})
+
 		Context("with an empty model", func() {
 			var m Model
 			It("should return an error", func() {

--- a/pkg/convert/perf/script.go
+++ b/pkg/convert/perf/script.go
@@ -1,0 +1,132 @@
+package perf
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+)
+
+var reEventStart = regexp.MustCompile("^(\\S.+?)\\s+(\\d+)/*(\\d+)*\\s+\\S.+")
+var errEventStartRegexMismatch = fmt.Errorf("reEventStart mismatch")
+var reStackFrame = regexp.MustCompile("^\\s*(\\w+)\\s*(.+) \\((\\S*)\\)")
+var errStackFrameRegexMismatch = fmt.Errorf("reStackFrame mismatch")
+var sep = []byte{'\n'}
+
+type ScriptParser struct {
+	lines     [][]byte
+	lineIndex int
+}
+
+func NewScriptParser(buf []byte) *ScriptParser {
+	return &ScriptParser{
+		lines:     bytes.Split(buf, sep),
+		lineIndex: 0,
+	}
+}
+func (p *ScriptParser) nextLine() ([]byte, error) {
+	if p.lineIndex < len(p.lines) {
+		ret := p.lines[p.lineIndex]
+		p.lineIndex += 1
+		return ret, nil
+	}
+	return nil, io.EOF
+}
+
+func (p *ScriptParser) ParseEvents() ([][][]byte, error) {
+	stacks := make([][][]byte, 0, 256)
+	for {
+		stack, err := p.ParseEvent()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		stacks = append(stacks, stack)
+	}
+	return stacks, nil
+}
+
+func (p *ScriptParser) ParseEvent() ([][]byte, error) {
+	line, err := p.nextLine()
+	if err != nil {
+		return nil, err
+	}
+	stack := make([][]byte, 0, 16)
+	comm, _, _, err := parseEventStart(line)
+	if err != nil {
+		if len(line) == 0 && p.lineIndex >= len(p.lines) {
+			return nil, io.EOF
+		}
+		return nil, err
+	}
+	var sym []byte
+	for {
+		line, err = p.nextLine()
+		if err != nil {
+			return nil, err
+		}
+		if parseEventEnd(line) {
+			break
+		}
+		_, sym, _, err = parseStackFrame(line)
+		if err != nil {
+			return nil, err
+		}
+		stack = append(stack, sym)
+	}
+	stack = append(stack, comm)
+	for i, j := 0, len(stack)-1; i < j; i, j = i+1, j-1 {
+		stack[i], stack[j] = stack[j], stack[i]
+	}
+	return stack, nil
+}
+
+func IsPerfScript(buf []byte) bool {
+	ls := bytes.SplitN(buf, sep, 2)
+	if len(ls) < 2 {
+		return false
+	}
+	l := ls[0]
+	_, _, _, err := parseEventStart(l)
+	return err == nil
+}
+
+func parseEventStart(line []byte) (comm []byte, pid int, tid int, err error) {
+	res := reEventStart.FindSubmatch(line)
+	if res == nil {
+		err = errEventStartRegexMismatch
+		return
+	}
+
+	comm = res[1]
+	pid, err = strconv.Atoi(string(res[2]))
+	if err != nil {
+		return
+	}
+	if res[3] != nil {
+		tid, err = strconv.Atoi(string(res[3]))
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+func parseEventEnd(line []byte) bool {
+	return len(line) == 0
+}
+
+func parseStackFrame(line []byte) (adr, sym, mod []byte, err error) {
+	res := reStackFrame.FindSubmatch(line)
+	if res == nil {
+		err = errStackFrameRegexMismatch
+		return
+	}
+	adr = res[1]
+	sym = res[2]
+	mod = res[3]
+	return
+}

--- a/pkg/convert/perf/script.go
+++ b/pkg/convert/perf/script.go
@@ -28,7 +28,7 @@ func NewScriptParser(buf []byte) *ScriptParser {
 func (p *ScriptParser) nextLine() ([]byte, error) {
 	if p.lineIndex < len(p.lines) {
 		ret := p.lines[p.lineIndex]
-		p.lineIndex += 1
+		p.lineIndex++
 		return ret, nil
 	}
 	return nil, io.EOF
@@ -94,39 +94,37 @@ func IsPerfScript(buf []byte) bool {
 	return err == nil
 }
 
-func parseEventStart(line []byte) (comm []byte, pid int, tid int, err error) {
+func parseEventStart(line []byte) ([]byte, int, int, error) {
 	res := reEventStart.FindSubmatch(line)
 	if res == nil {
-		err = errEventStartRegexMismatch
-		return
+		return nil, 0, 0, errEventStartRegexMismatch
 	}
-
-	comm = res[1]
-	pid, err = strconv.Atoi(string(res[2]))
+	comm := res[1]
+	tid := 0
+	pid, err := strconv.Atoi(string(res[2]))
 	if err != nil {
-		return
+		return nil, 0, 0, err
 	}
 	if res[3] != nil {
 		tid, err = strconv.Atoi(string(res[3]))
 		if err != nil {
-			return
+			return nil, 0, 0, err
 		}
 	}
-	return
+	return comm, pid, tid, nil
 }
 
 func parseEventEnd(line []byte) bool {
 	return len(line) == 0
 }
 
-func parseStackFrame(line []byte) (adr, sym, mod []byte, err error) {
+func parseStackFrame(line []byte) ([]byte, []byte, []byte, error) {
 	res := reStackFrame.FindSubmatch(line)
 	if res == nil {
-		err = errStackFrameRegexMismatch
-		return
+		return nil, nil, nil, errStackFrameRegexMismatch
 	}
-	adr = res[1]
-	sym = res[2]
-	mod = res[3]
-	return
+	adr := res[1]
+	sym := res[2]
+	mod := res[3]
+	return adr, sym, mod, nil
 }

--- a/pkg/convert/perf/script_test.go
+++ b/pkg/convert/perf/script_test.go
@@ -1,0 +1,173 @@
+package perf
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestParseEventStart(t *testing.T) {
+	test := func(s string, comm string, pid int, tid int, ok bool) {
+		t.Run(s, func(t *testing.T) {
+			rComm, rPid, rTid, err := parseEventStart([]byte(s))
+			if ok {
+				if err != nil {
+					t.Errorf("expected no error")
+				}
+				if comm != string(rComm) {
+					t.Errorf("comm %v != %v", comm, rComm)
+				}
+				if rPid != pid {
+					t.Errorf("pid %v != %v", rPid, pid)
+				}
+				if rTid != tid {
+					t.Errorf("tid %v != %v", rTid, tid)
+				}
+
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error ")
+			}
+		})
+	}
+
+	test("java 12688 [002] 6544038.708352: cpu-clock:", "java", 12688, 0, true)
+	test("V8 WorkerThread 25607 4794564.109216: cycles:", "V8 WorkerThread", 25607, 0, true)
+	test("java 24636/25607 [000] 4794564.109216: cycles:", "java", 24636, 25607, true)
+	test("java 12688/12764 6544038.708352: cpu-clock:", "java", 12688, 12764, true)
+	test("V8 WorkerThread 24636/25607 [000] 94564.109216: cycles:", "V8 WorkerThread", 24636, 25607, true)
+	test("", "", 0, 0, false)
+	test("\n", "", 0, 0, false)
+	test("swapper;start_kernel;rest_init;cpu_idle;default_idle;native_safe_halt 1\n", "", 0, 0, false)
+}
+
+func TestParseStackFrame(t *testing.T) {
+	test := func(s string, addr, sym, mod string, ok bool) {
+		t.Run(s, func(t *testing.T) {
+			rAddr, rSym, rMod, err := parseStackFrame([]byte(s))
+			if ok {
+				if err != nil {
+					t.Errorf("expected no error")
+				}
+				if string(rAddr) != addr {
+					t.Errorf("addr %v != %v", rAddr, addr)
+				}
+				if string(rSym) != sym {
+					t.Errorf("mod %v != %v", rSym, sym)
+				}
+				if string(rMod) != mod {
+					t.Errorf("mod %v != %v", rMod, mod)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error<")
+			}
+		})
+	}
+	test("        ffffffffb37b3618 __cgroup_account_cputime+0x28 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb37b3618", "__cgroup_account_cputime+0x28", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb37105ed update_curr+0x10d (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb37105ed", "update_curr+0x10d", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb3712293 dequeue_entity+0x23 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb3712293", "dequeue_entity+0x23", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb3712773 dequeue_task_fair+0xb3 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb3712773", "dequeue_task_fair+0xb3", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb36ff7e2 dequeue_task+0x42 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb36ff7e2", "dequeue_task+0x42", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb4408753 __schedule+0x3e3 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb4408753", "__schedule+0x3e3", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb440982c schedule+0x5c (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb440982c", "schedule+0x5c", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb379d3f8 futex_wait_queue+0x78 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb379d3f8", "futex_wait_queue+0x78", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb379daba futex_wait+0x15a (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb379daba", "futex_wait+0x15a", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb379a2f8 do_futex+0x138 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb379a2f8", "do_futex+0x138", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb379a7c8 __x64_sys_futex+0x78 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb379a7c8", "__x64_sys_futex+0x78", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb43f916c do_syscall_64+0x5c (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb43f916c", "do_syscall_64+0x5c", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb460009b entry_SYSCALL_64_after_hwframe+0x63 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb460009b", "entry_SYSCALL_64_after_hwframe+0x63", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("                   91197 __GI___strncasecmp_l_sse2+0x1547 (/usr/lib/x86_64-linux-gnu/libc.so.6)\n", "91197", "__GI___strncasecmp_l_sse2+0x1547", "/usr/lib/x86_64-linux-gnu/libc.so.6", true)
+	test("                  3fa48f [unknown] ([unknown])\n", "3fa48f", "[unknown]", "[unknown]", true)
+	test("java 12688 [002] 6544038.708352: cpu-clock:", "", "", "", false)
+	test("V8 WorkerThread 25607 4794564.109216: cycles:", "", "", "", false)
+	test("java 24636/25607 [000] 4794564.109216: cycles:", "", "", "", false)
+	test("java 12688/12764 6544038.708352: cpu-clock:", "", "", "", false)
+	test("V8 WorkerThread 24636/25607 [000] 94564.109216: cycles:", "", "", "", false)
+	test("", "", "", "", false)
+	test("\n", "", "", "", false)
+}
+
+func TestParseSingleEvent(t *testing.T) {
+	event := "perf 617960 [004] 116825.359144:         16   cycles: \n" +
+		"        ffffffffb377256a exit_to_user_mode_prepare+0x6a (/lib/modules/5.19.0/build/vmlinux)\n" +
+		"        ffffffffb43fe8a6 syscall_exit_to_user_mode+0x26 (/lib/modules/5.19.0/build/vmlinux)\n" +
+		"        ffffffffb43f9179 do_syscall_64+0x69 (/lib/modules/5.19.0/build/vmlinux)\n" +
+		"        ffffffffb460009b entry_SYSCALL_64_after_hwframe+0x63 (/lib/modules/5.19.0/build/vmlinux)\n" +
+		"                  11aaff setsourcefilter+0x18f (/usr/lib/x86_64-linux-gnu/libc.so.6)\n" +
+		"                  3364c7 __evlist__enable.constprop.0+0x97 (/home/korniltsev/github/jammy/tools/perf/perf)\n" +
+		"                  296253 __cmd_record.constprop.0+0x2683 (/home/korniltsev/github/jammy/tools/perf/perf)\n" +
+		"                  297db7 cmd_record+0xbb7 (/home/korniltsev/github/jammy/tools/perf/perf)\n" +
+		"                  31ecd0 run_builtin+0x70 (/home/korniltsev/github/jammy/tools/perf/perf)\n" +
+		"                  27ae79 main+0x6a9 (/home/korniltsev/github/jammy/tools/perf/perf)\n" +
+		"                   29d90 __vstrfmon_l_internal+0x4e0 (/usr/lib/x86_64-linux-gnu/libc.so.6)\n" +
+		"\n"
+	p := NewScriptParser([]byte(event))
+	events, err := p.ParseEvents()
+	if err != nil {
+		t.Fatalf("err %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event")
+	}
+	stack := events[0]
+	expected := [][]byte{
+		[]byte("perf"),
+		[]byte("__vstrfmon_l_internal+0x4e0"),
+		[]byte("main+0x6a9"),
+		[]byte("run_builtin+0x70"),
+		[]byte("cmd_record+0xbb7"),
+		[]byte("__cmd_record.constprop.0+0x2683"),
+		[]byte("__evlist__enable.constprop.0+0x97"),
+		[]byte("setsourcefilter+0x18f"),
+		[]byte("entry_SYSCALL_64_after_hwframe+0x63"),
+		[]byte("do_syscall_64+0x69"),
+		[]byte("syscall_exit_to_user_mode+0x26"),
+		[]byte("exit_to_user_mode_prepare+0x6a"),
+	}
+	for i := 0; i < len(expected); i++ {
+		if !bytes.Equal(expected[i], stack[i]) {
+			t.Fatalf("expected %s got %s", string(expected[i]), string(stack[i]))
+		}
+	}
+
+}
+
+func TestMultipleEvents(t *testing.T) {
+	event := "perf 617960 [004] 116825.359144:         16   cycles: \n" +
+		"        ffffffffb460009b entry_SYSCALL_64_after_hwframe+0x63 (/lib/modules/5.19.0/build/vmlinux)\n" +
+		"                  27ae79 main+0x6a9 (/home/korniltsev/github/jammy/tools/perf/perf)\n" +
+		"\n" +
+		"perf 617960 [004] 116825.359144:         16   cycles: \n" +
+		"        ffffffffb43f9179 do_syscall_64+0x69 (/lib/modules/5.19.0/build/vmlinux)\n" +
+		"                  31ecd0 run_builtin+0x70 (/home/korniltsev/github/jammy/tools/perf/perf)\n" +
+		"\n"
+	p := NewScriptParser([]byte(event))
+	events, err := p.ParseEvents()
+	if err != nil {
+		t.Fatalf("err %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events")
+	}
+
+	expect := func(expected [][]byte, actual [][]byte) {
+		for i := 0; i < len(expected); i++ {
+			if !bytes.Equal(expected[i], actual[i]) {
+				t.Fatalf("expected %s got %s", string(expected[i]), string(actual[i]))
+			}
+		}
+	}
+	expect([][]byte{
+		[]byte("perf"),
+		[]byte("main+0x6a9"),
+		[]byte("entry_SYSCALL_64_after_hwframe+0x63"),
+	}, events[0])
+	expect([][]byte{
+		[]byte("perf"),
+		[]byte("run_builtin+0x70"),
+		[]byte("do_syscall_64+0x69"),
+	}, events[1])
+
+}

--- a/pkg/convert/perf/script_test.go
+++ b/pkg/convert/perf/script_test.go
@@ -22,7 +22,6 @@ func TestParseEventStart(t *testing.T) {
 				if rTid != tid {
 					t.Errorf("tid %v != %v", rTid, tid)
 				}
-
 				return
 			}
 			if err == nil {
@@ -65,20 +64,34 @@ func TestParseStackFrame(t *testing.T) {
 			}
 		})
 	}
-	test("        ffffffffb37b3618 __cgroup_account_cputime+0x28 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb37b3618", "__cgroup_account_cputime+0x28", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("        ffffffffb37105ed update_curr+0x10d (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb37105ed", "update_curr+0x10d", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("        ffffffffb3712293 dequeue_entity+0x23 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb3712293", "dequeue_entity+0x23", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("        ffffffffb3712773 dequeue_task_fair+0xb3 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb3712773", "dequeue_task_fair+0xb3", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("        ffffffffb36ff7e2 dequeue_task+0x42 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb36ff7e2", "dequeue_task+0x42", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("        ffffffffb4408753 __schedule+0x3e3 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb4408753", "__schedule+0x3e3", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("        ffffffffb440982c schedule+0x5c (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb440982c", "schedule+0x5c", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("        ffffffffb379d3f8 futex_wait_queue+0x78 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb379d3f8", "futex_wait_queue+0x78", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("        ffffffffb379daba futex_wait+0x15a (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb379daba", "futex_wait+0x15a", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("        ffffffffb379a2f8 do_futex+0x138 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb379a2f8", "do_futex+0x138", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("        ffffffffb379a7c8 __x64_sys_futex+0x78 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb379a7c8", "__x64_sys_futex+0x78", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("        ffffffffb43f916c do_syscall_64+0x5c (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb43f916c", "do_syscall_64+0x5c", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("        ffffffffb460009b entry_SYSCALL_64_after_hwframe+0x63 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb460009b", "entry_SYSCALL_64_after_hwframe+0x63", "/lib/modules/5.19.0/build/vmlinux", true)
-	test("                   91197 __GI___strncasecmp_l_sse2+0x1547 (/usr/lib/x86_64-linux-gnu/libc.so.6)\n", "91197", "__GI___strncasecmp_l_sse2+0x1547", "/usr/lib/x86_64-linux-gnu/libc.so.6", true)
+	test("        ffffffffb37b3618 __cgroup_account_cputime+0x28 (/lib/modules/5.19.0/build/vmlinux)\n",
+		"ffffffffb37b3618", "__cgroup_account_cputime+0x28", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb37105ed update_curr+0x10d (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb37105ed",
+		"update_curr+0x10d", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb3712293 dequeue_entity+0x23 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb3712293",
+		"dequeue_entity+0x23", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb3712773 dequeue_task_fair+0xb3 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb3712773",
+		"dequeue_task_fair+0xb3", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb36ff7e2 dequeue_task+0x42 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb36ff7e2",
+		"dequeue_task+0x42", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb4408753 __schedule+0x3e3 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb4408753",
+		"__schedule+0x3e3", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb440982c schedule+0x5c (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb440982c",
+		"schedule+0x5c", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb379d3f8 futex_wait_queue+0x78 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb379d3f8",
+		"futex_wait_queue+0x78", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb379daba futex_wait+0x15a (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb379daba",
+		"futex_wait+0x15a", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb379a2f8 do_futex+0x138 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb379a2f8",
+		"do_futex+0x138", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb379a7c8 __x64_sys_futex+0x78 (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb379a7c8",
+		"__x64_sys_futex+0x78", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb43f916c do_syscall_64+0x5c (/lib/modules/5.19.0/build/vmlinux)\n", "ffffffffb43f916c",
+		"do_syscall_64+0x5c", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("        ffffffffb460009b entry_SYSCALL_64_after_hwframe+0x63 (/lib/modules/5.19.0/build/vmlinux)\n",
+		"ffffffffb460009b", "entry_SYSCALL_64_after_hwframe+0x63", "/lib/modules/5.19.0/build/vmlinux", true)
+	test("                   91197 __GI___strncasecmp_l_sse2+0x1547 (/usr/lib/x86_64-linux-gnu/libc.so.6)\n",
+		"91197", "__GI___strncasecmp_l_sse2+0x1547", "/usr/lib/x86_64-linux-gnu/libc.so.6", true)
 	test("                  3fa48f [unknown] ([unknown])\n", "3fa48f", "[unknown]", "[unknown]", true)
 	test("java 12688 [002] 6544038.708352: cpu-clock:", "", "", "", false)
 	test("V8 WorkerThread 25607 4794564.109216: cycles:", "", "", "", false)
@@ -131,7 +144,6 @@ func TestParseSingleEvent(t *testing.T) {
 			t.Fatalf("expected %s got %s", string(expected[i]), string(stack[i]))
 		}
 	}
-
 }
 
 func TestMultipleEvents(t *testing.T) {
@@ -169,5 +181,4 @@ func TestMultipleEvents(t *testing.T) {
 		[]byte("run_builtin+0x70"),
 		[]byte("do_syscall_64+0x69"),
 	}, events[1])
-
 }


### PR DESCRIPTION
The goal is to upload perf data to pyroscope/flamegraph:
- First idea was to try to parse perf data at server side with [perf_data_converter](https://github.com/google/perf_data_converter). But the perf and converted pprof has no symbols so we can't do it on serverside
- Second idea was to parse `perf script` output (what this pr does) like `perf script | curl  --data-binary @- http://flamegraph.com`, the problem with it is that it may be huge (like 65M for 16 cores profiling for 10 seconds).
- Third idea is to use embeded stackcollapse script `perf script report stackcollapse | curl --data-binary @- flamegraph.com`  . stackcollapse is not huge so it is better. We might decline this PR and go with third solution. Only flamegraph.com changes are required, to allow to post profiles to `/`.

I doubt someone would like to upload huge profiles when they can upload short(collapsed/) profiles

This PR allows to upload `perf script` output to adhoc/flamegraph.com

To try:
1. record
```
perf record -a -g
```
2.a upload directly to flamegraph.com
```
perf script | curl  --data-binary @- http://flamegraph.com
```
2.b or save to file and upload to  adhoc/flamegraph.com
```
perf script > events
```
