### PR TITLE
fix(webapp): weird marking when adding annotation

### DIFF
--- a/webapp/javascript/components/TimelineChart/Selection.plugin.ts
+++ b/webapp/javascript/components/TimelineChart/Selection.plugin.ts
@@ -422,7 +422,10 @@ const handleHeight = 22;
     plot.hooks.draw.push(function (plot: PlotType, ctx: CtxType) {
       const opts = plot.getOptions();
 
-      if (opts?.selection?.selectionType === 'single') {
+      if (
+        opts?.selection?.selectionType === 'single' &&
+        opts?.selection?.selectionWithHandler
+      ) {
         const axes = plot.getAxes();
         const plotOffset = plot.getPlotOffset();
         const extractedY = extractRange(axes, 'y');

--- a/webapp/javascript/components/TimelineChart/TimelineChartWrapper.tsx
+++ b/webapp/javascript/components/TimelineChart/TimelineChartWrapper.tsx
@@ -76,6 +76,10 @@ type TimelineChartWrapperProps = TimelineDataProps & {
   timezone: 'browser' | 'utc';
   title?: ReactNode;
 
+  /** whether to show a selection with grabbable handle
+   * ATTENTION: it only works with a single selection */
+  selectionWithHandler?: boolean;
+
   /** selection type 'single' => gray selection, 'double' => color selection */
   selectionType: 'single' | 'double';
   onHoverDisplayTooltip?: React.FC<ExploreTooltipProps>;
@@ -109,6 +113,7 @@ class TimelineChartWrapper extends React.Component<
         right: 0,
       },
       selection: {
+        selectionWithHandler: props.selectionWithHandler || false,
         mode: 'x',
         // custom selection works for 'single' selection type,
         // 'double' selection works in old fashion way

--- a/webapp/javascript/pages/ContinuousComparisonView.tsx
+++ b/webapp/javascript/pages/ContinuousComparisonView.tsx
@@ -166,6 +166,7 @@ function ComparisonApp() {
                 key="timeline-chart-left"
                 id="timeline-chart-left"
                 data-testid="timeline-left"
+                selectionWithHandler
                 timelineA={leftTimeline}
                 selection={{
                   left: {
@@ -225,6 +226,7 @@ function ComparisonApp() {
                 id="timeline-chart-right"
                 data-testid="timeline-right"
                 timelineA={rightTimeline}
+                selectionWithHandler
                 selection={{
                   right: {
                     from: rightFrom,

--- a/webapp/javascript/pages/ContinuousDiffView.tsx
+++ b/webapp/javascript/pages/ContinuousDiffView.tsx
@@ -155,6 +155,7 @@ function ComparisonDiffApp() {
               key="timeline-chart-left"
               id="timeline-chart-left"
               timelineA={leftTimeline}
+              selectionWithHandler
               onSelect={(from, until) => {
                 dispatch(actions.setLeft({ from, until }));
               }}
@@ -189,6 +190,7 @@ function ComparisonDiffApp() {
               data-testid="timeline-right"
               key="timeline-chart-right"
               id="timeline-chart-right"
+              selectionWithHandler
               timelineA={rightTimeline}
               onSelect={(from, until) => {
                 dispatch(actions.setRight({ from, until }));


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/1497

Before:
![image](https://user-images.githubusercontent.com/6951209/190477711-aef6bbc0-ec52-4734-a0b5-c55865db4f0d.png)


After:
![image](https://user-images.githubusercontent.com/6951209/190477671-6d786575-8477-43c1-995d-2c459122be86.png)


tl;dr
Problem is that we mix `markings` with `selection`, as pointed by this commented https://github.com/pyroscope-io/pyroscope/blob/d8e0d21bde92d7c5f6a07c9cb728607d1c2cd2c0/webapp/javascript/components/TimelineChart/TimelineChartWrapper.tsx#L205-L208

But anyway, the `selection` plugin ALWAYS 
https://github.com/pyroscope-io/pyroscope/blob/main/webapp/javascript/components/TimelineChart/Selection.plugin.ts#L425 draws a selection, using markings https://github.com/pyroscope-io/pyroscope/blob/main/webapp/javascript/components/TimelineChart/Selection.plugin.ts#L429 

But in the annotations case, we draw a marking that's not an annotation!

This will be solved after we create our own plugin (https://github.com/pyroscope-io/pyroscope/issues/1495), so that an annotation is a first class concept, as opposed to a marking as it currently is.

But right now this is a hotfix that should do the job.
