### PR TITLE
chore: make pair (timestamp, appName) unique

### DIFF
--- a/pkg/model/annotation.go
+++ b/pkg/model/annotation.go
@@ -16,8 +16,8 @@ var (
 )
 
 type Annotation struct {
-	AppName   string    `gorm:"index:annotation,unique;not null;default:null"`
-	Timestamp time.Time `gorm:"index:annotation,unique;not null;default:null"`
+	AppName   string    `gorm:"index:idx_appname_timestamp,unique;not null;default:null"`
+	Timestamp time.Time `gorm:"index:idx_appname_timestamp,unique;not null;default:null"`
 	Content   string    `gorm:"not null;default:null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/pkg/model/annotation.go
+++ b/pkg/model/annotation.go
@@ -16,8 +16,8 @@ var (
 )
 
 type Annotation struct {
-	AppName   string    `gorm:"not null;default:null"`
-	Timestamp time.Time `form:"not null;default:null"`
+	AppName   string    `gorm:"index:annotation,unique;not null;default:null"`
+	Timestamp time.Time `gorm:"index:annotation,unique;not null;default:null"`
 	Content   string    `gorm:"not null;default:null"`
 	CreatedAt time.Time
 	UpdatedAt time.Time

--- a/pkg/service/annotation.go
+++ b/pkg/service/annotation.go
@@ -36,6 +36,9 @@ func (svc AnnotationsService) CreateAnnotation(ctx context.Context, params model
 			{Name: "app_name"},
 			{Name: "timestamp"},
 		},
+		// Update fields we care about
+		DoUpdates: clause.AssignmentColumns([]string{"app_name", "timestamp", "content"}),
+		// Update updateAt fields
 		UpdateAll: true,
 	}).Create(&u).Error; err != nil {
 		return nil, err

--- a/pkg/service/annotation.go
+++ b/pkg/service/annotation.go
@@ -30,6 +30,7 @@ func (svc AnnotationsService) CreateAnnotation(ctx context.Context, params model
 
 	tx := svc.db.WithContext(ctx)
 
+	// Upsert
 	if err := tx.Clauses(clause.OnConflict{
 		Columns: []clause.Column{
 			{Name: "app_name"},

--- a/pkg/service/annotation_test.go
+++ b/pkg/service/annotation_test.go
@@ -34,7 +34,7 @@ var _ = Describe("AnnotationsService", func() {
 			Expect(annotation).ToNot(BeNil())
 			Expect(annotation.AppName).To(Equal("myapp"))
 			Expect(annotation.Content).To(Equal("mycontent"))
-			Expect(annotation.Timestamp).To(Equal(now))
+			Expect(annotation.Timestamp.Unix()).To(Equal(now.Unix()))
 
 			Expect(annotation.CreatedAt).ToNot(BeZero())
 			Expect(annotation.UpdatedAt).ToNot(BeZero())

--- a/pkg/sqlstore/migrations/migrations.go
+++ b/pkg/sqlstore/migrations/migrations.go
@@ -49,6 +49,7 @@ func Migrate(db *gorm.DB, c *config.Server) error {
 		createUserTableMigration(c.Auth.Internal.AdminUser),
 		createAPIKeyTableMigration(),
 		createAnnotationsTableMigration(),
+		addIndexesUniqueTableMigration(),
 	}).Migrate()
 }
 
@@ -129,6 +130,24 @@ func createAnnotationsTableMigration() *gormigrate.Migration {
 		},
 		Rollback: func(tx *gorm.DB) error {
 			return tx.Migrator().DropTable(&annotation{})
+		},
+	}
+}
+
+func addIndexesUniqueTableMigration() *gormigrate.Migration {
+	type annotation struct {
+		AppName   string    `gorm:"index:annotation,unique;not null;default:null"`
+		Timestamp time.Time `gorm:"index:annotation,unique;not null;default:null"`
+	}
+
+	return &gormigrate.Migration{
+		ID: "1663269650",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&annotation{})
+		},
+		Rollback: func(tx *gorm.DB) error {
+			// TODO(eh-am): implement
+			return nil
 		},
 	}
 }

--- a/pkg/sqlstore/migrations/migrations.go
+++ b/pkg/sqlstore/migrations/migrations.go
@@ -136,8 +136,8 @@ func createAnnotationsTableMigration() *gormigrate.Migration {
 
 func addIndexesUniqueTableMigration() *gormigrate.Migration {
 	type annotation struct {
-		AppName   string    `gorm:"index:annotation,unique;not null;default:null"`
-		Timestamp time.Time `gorm:"index:annotation,unique;not null;default:null"`
+		AppName   string    `gorm:"index:idx_appname_timestamp,unique;not null;default:null"`
+		Timestamp time.Time `gorm:"index:idx_appname_timestamp,unique;not null;default:null"`
 	}
 
 	return &gormigrate.Migration{
@@ -146,8 +146,7 @@ func addIndexesUniqueTableMigration() *gormigrate.Migration {
 			return tx.AutoMigrate(&annotation{})
 		},
 		Rollback: func(tx *gorm.DB) error {
-			// TODO(eh-am): implement
-			return nil
+			return tx.Migrator().DropIndex(&annotation{}, "idx_appname_timestamp")
 		},
 	}
 }


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/1509

Plus refactors the `upsert` as per @kolesnikovae's here https://github.com/pyroscope-io/pyroscope/pull/1508#discussion_r972034413

Here's the sql schema (generated with `.schema annotations`):
```
CREATE TABLE `annotations` (`id` integer,`app_name` text NOT NULL DEFAULT null,`timestamp` datetime,`content` text NOT NULL DEFAULT null,`created_at` datetime,`updated_at` datetime,PRIMARY KEY (`id`));
CREATE UNIQUE INDEX `idx_appname_timestamp` ON `annotations`(`app_name`,`timestamp`);
```

---
offtopic/self documenting: had to turn on sql log to make sense out of what the orm is doing

```diff
diff --git a/pkg/sqlstore/sqlstore.go b/pkg/sqlstore/sqlstore.go
index 642ad7ca..06c7e429 100644
--- a/pkg/sqlstore/sqlstore.go
+++ b/pkg/sqlstore/sqlstore.go
@@ -57,7 +57,8 @@ func (s *SQLStore) openSQLiteDB() (err error) {
 		path = s.config.Database.URL
 	}
 	s.orm, err = gorm.Open(sqlite.Open(path), &gorm.Config{
-		Logger: logger.Discard,
+		//		Logger: logger.Discard,
+		Logger: logger.Default.LogMode(logger.Info),
 	})
 	s.db, err = s.orm.DB()
 	return err
```