### PR TITLE
fix(webapp): format annotation using timezone

### DIFF
--- a/webapp/javascript/components/TimelineChart/Annotation.spec.tsx
+++ b/webapp/javascript/components/TimelineChart/Annotation.spec.tsx
@@ -6,6 +6,7 @@ describe('AnnotationTooltipBody', () => {
   it('return null when theres no annotation', () => {
     const { container } = render(
       <AnnotationTooltipBody
+        timezone="utc"
         annotations={[]}
         coordsToCanvasPos={jest.fn()}
         canvasX={0}
@@ -31,6 +32,7 @@ describe('AnnotationTooltipBody', () => {
 
     const { container } = render(
       <AnnotationTooltipBody
+        timezone="utc"
         annotations={annotations}
         coordsToCanvasPos={coordsToCanvasPos}
         canvasX={200}
@@ -55,6 +57,7 @@ describe('AnnotationTooltipBody', () => {
 
       render(
         <AnnotationTooltipBody
+          timezone="utc"
           annotations={annotations}
           coordsToCanvasPos={coordsToCanvasPos}
           canvasX={100}
@@ -91,6 +94,7 @@ describe('AnnotationTooltipBody', () => {
 
       render(
         <AnnotationTooltipBody
+          timezone="utc"
           annotations={annotations}
           coordsToCanvasPos={coordsToCanvasPos}
           canvasX={98}

--- a/webapp/javascript/components/TimelineChart/Annotation.tsx
+++ b/webapp/javascript/components/TimelineChart/Annotation.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Maybe } from 'true-myth';
 import { format } from 'date-fns';
 import { Annotation } from '@webapp/models/annotation';
+import { getUTCdate, timezoneToOffset } from '@webapp/util/formatDate';
 import styles from './Annotation.module.scss';
 
 // TODO(eh-am): what are these units?
@@ -16,6 +17,8 @@ interface AnnotationTooltipBodyProps {
 
   /* where in the canvas the mouse is */
   canvasX: number;
+
+  timezone: 'browser' | 'utc';
 }
 
 export default function Annotations(props: AnnotationTooltipBodyProps) {
@@ -30,6 +33,7 @@ export default function Annotations(props: AnnotationTooltipBodyProps) {
   )
     .map((annotation: Annotation) => (
       <AnnotationComponent
+        timezone={props.timezone}
         timestamp={annotation.timestamp}
         content={annotation.content}
       />
@@ -40,15 +44,20 @@ export default function Annotations(props: AnnotationTooltipBodyProps) {
 function AnnotationComponent({
   timestamp,
   content,
+  timezone,
 }: {
   timestamp: number;
   content: string;
+  timezone: AnnotationTooltipBodyProps['timezone'];
 }) {
   // TODO: these don't account for timezone
   return (
     <div className={styles.wrapper}>
       <header className={styles.header}>
-        {format(timestamp, 'yyyy-MM-dd hh:mm aa')}
+        {format(
+          getUTCdate(new Date(timestamp), timezoneToOffset(timezone)),
+          'yyyy-MM-dd HH:mm'
+        )}
       </header>
       <div className={styles.body}>{content}</div>
     </div>

--- a/webapp/javascript/components/TimelineChart/TimelineChartWrapper.tsx
+++ b/webapp/javascript/components/TimelineChart/TimelineChartWrapper.tsx
@@ -228,6 +228,7 @@ class TimelineChartWrapper extends React.Component<
   setOnHoverDisplayTooltip = (
     data: ITooltipWrapperProps & ExploreTooltipProps
   ) => {
+    const { timezone } = this.props;
     let tooltipContent = [];
 
     const TooltipBody: React.FC<ExploreTooltipProps> | undefined =
@@ -257,6 +258,7 @@ class TimelineChartWrapper extends React.Component<
         data.canvasX
       ) {
         const an = Annotation({
+          timezone,
           annotations,
           canvasX: data.canvasX,
           coordsToCanvasPos: data.coordsToCanvasPos,
@@ -269,6 +271,7 @@ class TimelineChartWrapper extends React.Component<
           tooltipContent = [
             <Annotation
               key="annotation"
+              timezone={timezone}
               annotations={annotations}
               canvasX={data.canvasX}
               coordsToCanvasPos={data.coordsToCanvasPos}

--- a/webapp/javascript/util/formatDate.ts
+++ b/webapp/javascript/util/formatDate.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-underscore-dangle */
 import { add, format } from 'date-fns';
-import { formatInTimeZone } from 'date-fns-tz';
 
 const multiplierMapping = new Map(
   Object.entries({

--- a/webapp/javascript/util/formatDate.ts
+++ b/webapp/javascript/util/formatDate.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import { add, format } from 'date-fns';
+import { formatInTimeZone } from 'date-fns-tz';
 
 const multiplierMapping = new Map(
   Object.entries({
@@ -120,3 +121,14 @@ export const getTimelineFormatDate = (date: Date, hours: number) => {
   }
   return format(date, 'MMM do HH:mm');
 };
+
+export function timezoneToOffset(timezone: 'utc' | 'browser'): number {
+  if (timezone === 'utc') {
+    return 0;
+  }
+
+  // Use browser's
+  // FIXME: this does not account for arbitrary timezones
+  // eg one that is not the user's browser
+  return new Date().getTimezoneOffset();
+}


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/1506

(UTC)
<img width="428" alt="Screen Shot 2022-09-16 at 14 57 36" src="https://user-images.githubusercontent.com/6951209/190702982-ea846696-2975-4d43-b94c-a280092cd99c.png">

(BROWSER, mine is currently utc - 3)
<img width="428" alt="Screen Shot 2022-09-16 at 14 57 51" src="https://user-images.githubusercontent.com/6951209/190703004-e92a2c0b-fc53-4ac2-b410-d7cd79660c91.png">

Ideally we would handle this better in https://github.com/pyroscope-io/pyroscope/issues/1521