### PR TITLE
chore: add a dialog modal

### DIFF
--- a/packages/pyroscope-flamegraph/src/__snapshots__/Toolbar.spec.tsx.snap
+++ b/packages/pyroscope-flamegraph/src/__snapshots__/Toolbar.spec.tsx.snap
@@ -37,7 +37,7 @@ exports[`ProfileHeader shifts between visualization modes 1`] = `
         class="rc-menu-container"
       />
       <button
-        class="button  default undefined"
+        class="button default"
         data-testid="reset-view"
         disabled=""
         id="reset"
@@ -61,7 +61,7 @@ exports[`ProfileHeader shifts between visualization modes 1`] = `
         Reset View
       </button>
       <button
-        class="button  default undefined"
+        class="button default"
         disabled=""
         type="button"
       >
@@ -86,7 +86,7 @@ exports[`ProfileHeader shifts between visualization modes 1`] = `
         class="btn-group viz-switch"
       >
         <button
-          class="button grouped default undefined"
+          class="button grouped default"
           type="button"
         >
           <svg
@@ -107,7 +107,7 @@ exports[`ProfileHeader shifts between visualization modes 1`] = `
           Table
         </button>
         <button
-          class="button grouped primary undefined"
+          class="button grouped primary"
           type="button"
         >
           <svg
@@ -128,7 +128,7 @@ exports[`ProfileHeader shifts between visualization modes 1`] = `
           Both
         </button>
         <button
-          class="button grouped default undefined"
+          class="button grouped default"
           type="button"
         >
           <svg
@@ -191,7 +191,7 @@ exports[`ProfileHeader shifts between visualization modes 2`] = `
         class="rc-menu-container"
       />
       <button
-        class="button  default undefined"
+        class="button default"
         data-testid="reset-view"
         disabled=""
         id="reset"
@@ -215,7 +215,7 @@ exports[`ProfileHeader shifts between visualization modes 2`] = `
         Reset
       </button>
       <button
-        class="button  default undefined"
+        class="button default"
         disabled=""
         type="button"
       >

--- a/stories/Dialog.stories.tsx
+++ b/stories/Dialog.stories.tsx
@@ -6,7 +6,9 @@ import {
   DialogHeader,
   DialogBody,
 } from '../webapp/javascript/ui/Dialog';
+import Button from '../webapp/javascript/ui/Button';
 import '../webapp/sass/profile.scss';
+import DialogActions from '../webapp/javascript/ui/Dialog/Dialog';
 
 export default {
   title: 'Components/Dialog',
@@ -46,7 +48,14 @@ export function dialog() {
               sapien, vel fringilla risus porta at.
             </p>
           </DialogBody>
-          <DialogFooter>I am the Footer</DialogFooter>
+          <DialogFooter>
+            <DialogActions>
+              <Button onClick={() => setOpen(false)}>Cancel</Button>
+              <Button onClick={() => setOpen(false)} kind="secondary">
+                Ok
+              </Button>
+            </DialogActions>
+          </DialogFooter>
         </>
       </Dialog>
     </>

--- a/stories/Dialog.stories.tsx
+++ b/stories/Dialog.stories.tsx
@@ -20,7 +20,7 @@ export function dialog() {
 
   return (
     <>
-      <button onClick={() => setOpen(!open)}>toggle modal</button>
+      <Button onClick={() => setOpen(!open)}>Open Modal</Button>
       <Dialog
         open={open}
         onClose={() => {

--- a/stories/Dialog.stories.tsx
+++ b/stories/Dialog.stories.tsx
@@ -1,6 +1,11 @@
 import React, { useState } from 'react';
 import { ComponentMeta } from '@storybook/react';
-import { Dialog, DialogHeader } from '../webapp/javascript/ui/Dialog';
+import {
+  Dialog,
+  DialogFooter,
+  DialogHeader,
+  DialogBody,
+} from '../webapp/javascript/ui/Dialog';
 import '../webapp/sass/profile.scss';
 
 export default {
@@ -20,7 +25,27 @@ export function dialog() {
           setOpen(false);
         }}
       >
-        <DialogHeader>I am a Header</DialogHeader>
+        <>
+          <DialogHeader>I am the Header</DialogHeader>
+          <DialogBody>
+            <p>I am the body</p>
+            <p>
+              Phasellus at tellus iaculis nunc ornare porttitor vel at dolor.
+              Donec ornare diam sit amet eros posuere, quis vestibulum nunc
+              tempus. Vestibulum ante ipsum primis in faucibus orci luctus et
+              ultrices posuere cubilia curae; Etiam ullamcorper luctus gravida.
+              Quisque vitae euismod diam. Maecenas vulputate et massa hendrerit
+              dignissim. Donec consequat nisi eu nisl laoreet tincidunt. Nullam
+              dignissim ornare efficitur. Suspendisse at mollis dolor.
+              Suspendisse luctus tellus ut metus pretium, sed blandit elit
+              sagittis. Praesent arcu urna, consequat vel vehicula mattis,
+              viverra nec erat. Vestibulum mattis vehicula arcu, quis iaculis
+              dui elementum quis. In in massa tortor. Nullam volutpat nunc
+              sapien, vel fringilla risus porta at.
+            </p>
+          </DialogBody>
+          <DialogFooter>I am the Footer</DialogFooter>
+        </>
       </Dialog>
     </>
   );

--- a/stories/Dialog.stories.tsx
+++ b/stories/Dialog.stories.tsx
@@ -26,7 +26,7 @@ export function dialog() {
         }}
       >
         <>
-          <DialogHeader>I am the Header</DialogHeader>
+          <DialogHeader closeable>I am the Header</DialogHeader>
           <DialogBody>
             <p>I am the body</p>
             <p>

--- a/stories/Dialog.stories.tsx
+++ b/stories/Dialog.stories.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { ComponentMeta } from '@storybook/react';
+import { Dialog, DialogHeader } from '../webapp/javascript/ui/Dialog';
+import '../webapp/sass/profile.scss';
+
+export default {
+  title: 'Components/Dialog',
+  component: Dialog,
+} as ComponentMeta<typeof Dialog>;
+
+export function dialog() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setOpen(!open)}>toggle modal</button>
+      <Dialog
+        open={open}
+        onClose={() => {
+          setOpen(false);
+        }}
+      >
+        <DialogHeader>I am a Header</DialogHeader>
+      </Dialog>
+    </>
+  );
+}

--- a/stories/Dialog.stories.tsx
+++ b/stories/Dialog.stories.tsx
@@ -26,7 +26,9 @@ export function dialog() {
         }}
       >
         <>
-          <DialogHeader closeable>I am the Header</DialogHeader>
+          <DialogHeader closeable onClose={() => setOpen(false)}>
+            I am the Header
+          </DialogHeader>
           <DialogBody>
             <p>I am the body</p>
             <p>

--- a/webapp/__tests__/__snapshots__/RefreshButton.spec.js.snap
+++ b/webapp/__tests__/__snapshots__/RefreshButton.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`RefreshButton render correctly RefreshButton component 1`] = `
 <button
-  className="button  default undefined"
+  className="button default"
   data-testid="refresh-btn"
   disabled={false}
   onClick={[Function]}

--- a/webapp/javascript/ui/Button.module.scss
+++ b/webapp/javascript/ui/Button.module.scss
@@ -19,6 +19,12 @@ $border-radius: 4px;
   //min-width: 48px;
 }
 
+.noBox {
+  border: none;
+  border-radius: none;
+  background: inherit !important;
+}
+
 .iconWithText {
   // icon is on the left
   // some space between the icon and text

--- a/webapp/javascript/ui/Button.module.scss
+++ b/webapp/javascript/ui/Button.module.scss
@@ -14,9 +14,10 @@ $border-radius: 4px;
   &[type='submit'] {
     -webkit-appearance: button;
   }
+}
 
-  /* when we have an icon only button */
-  //min-width: 48px;
+.noIcon {
+  min-width: 48px;
 }
 
 .noBox {

--- a/webapp/javascript/ui/Button.tsx
+++ b/webapp/javascript/ui/Button.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { IconDefinition } from '@fortawesome/fontawesome-common-types';
+import cx from 'classnames';
 import styles from './Button.module.scss';
 
 export interface ButtonProps {
@@ -27,6 +28,9 @@ export interface ButtonProps {
 
   id?: string;
   form?: React.ButtonHTMLAttributes<HTMLButtonElement>['form'];
+
+  /** disable a box around it */
+  noBox?: boolean;
 }
 
 export default function Button({
@@ -40,6 +44,7 @@ export default function Button({
   id,
   className,
   form,
+  noBox,
   ...props
 }: ButtonProps) {
   return (
@@ -51,9 +56,13 @@ export default function Button({
       onClick={onClick}
       form={form}
       aria-label={props['aria-label']}
-      className={`${styles.button} ${
-        grouped ? styles.grouped : ''
-      } ${getKindStyles(kind)} ${className}`}
+      className={cx(
+        styles.button,
+        grouped ? styles.grouped : '',
+        getKindStyles(kind),
+        className,
+        noBox && styles.noBox
+      )}
     >
       {icon ? (
         <FontAwesomeIcon

--- a/webapp/javascript/ui/Button.tsx
+++ b/webapp/javascript/ui/Button.tsx
@@ -61,7 +61,8 @@ export default function Button({
         grouped ? styles.grouped : '',
         getKindStyles(kind),
         className,
-        noBox && styles.noBox
+        noBox && styles.noBox,
+        !icon && styles.noIcon
       )}
     >
       {icon ? (

--- a/webapp/javascript/ui/Dialog/Dialog.module.css
+++ b/webapp/javascript/ui/Dialog/Dialog.module.css
@@ -16,6 +16,7 @@
   box-shadow: 0px 16px 16px -16px rgba(0, 0, 0, 0.35);
   border-radius: 5px;
   border: 1px solid rgba(255, 255, 255, 0.1);
+  /* TODO(eh-am): support light background */
   background-color: #222;
 
   max-width: 500px;
@@ -41,10 +42,6 @@
   position: absolute;
   right: 8px;
   top: 8px;
-}
-
-.modalContent {
-  padding: 0 20px 20px;
 }
 
 .backdrop {

--- a/webapp/javascript/ui/Dialog/Dialog.module.css
+++ b/webapp/javascript/ui/Dialog/Dialog.module.css
@@ -16,11 +16,24 @@
   box-shadow: 0px 16px 16px -16px rgba(0, 0, 0, 0.35);
   border-radius: 5px;
   border: 1px solid rgba(255, 255, 255, 0.1);
+  background-color: #222;
+
+  max-width: 500px;
 }
 
 .header {
   padding: 15px 20px 10px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  display: flex;
+}
+
+.body {
+  padding: 15px 20px 10px;
+}
+
+.footer {
+  padding: 15px 20px 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
   display: flex;
 }
 

--- a/webapp/javascript/ui/Dialog/Dialog.module.css
+++ b/webapp/javascript/ui/Dialog/Dialog.module.css
@@ -37,12 +37,6 @@
   overflow-y: auto;
 }
 
-.footer {
-  padding: 15px 20px 10px;
-  border-top: 1px solid rgba(255, 255, 255, 0.2);
-  display: flex;
-}
-
 .closeButton {
   position: absolute;
   right: 8px;
@@ -62,4 +56,19 @@
   left: 0;
   background-color: rgba(0, 0, 0, 0.5);
   -webkit-tap-highlight-color: transparent;
+}
+
+.footer {
+  padding: 15px 20px 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  display: flex;
+  flex-direction: column;
+}
+
+.dialogActions {
+  align-self: end;
+}
+.dialogActions > *:not(:last-child) {
+  margin-right: 8px;
+  align-self: end;
 }

--- a/webapp/javascript/ui/Dialog/Dialog.module.css
+++ b/webapp/javascript/ui/Dialog/Dialog.module.css
@@ -19,6 +19,10 @@
   background-color: #222;
 
   max-width: 500px;
+  max-height: calc(100% - 64px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
 }
 
 .header {
@@ -29,6 +33,7 @@
 
 .body {
   padding: 15px 20px 10px;
+  overflow-y: auto;
 }
 
 .footer {

--- a/webapp/javascript/ui/Dialog/Dialog.module.css
+++ b/webapp/javascript/ui/Dialog/Dialog.module.css
@@ -1,0 +1,62 @@
+.modal {
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  margin: auto;
+  z-index: 2000;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modalContainer {
+  box-shadow: 0px 16px 16px -16px rgba(0, 0, 0, 0.35);
+  border-radius: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.header {
+  padding: 15px 20px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  display: flex;
+}
+
+.closeButton {
+  border: none;
+  padding: 0;
+  width: 34px;
+  height: 34px;
+  cursor: pointer;
+  position: relative;
+}
+
+.closeButton::after {
+  /* useful to visualize hit area: */
+  /* background-color: red; */
+  width: 34px;
+  height: 34px;
+  line-height: 34px;
+  font-size: 1.5em;
+  position: absolute;
+  content: '\00d7';
+  top: -4px;
+  right: -10px;
+}
+
+.modalContent {
+  padding: 0 20px 20px;
+}
+
+.backdrop {
+  z-index: -1;
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  -webkit-tap-highlight-color: transparent;
+}

--- a/webapp/javascript/ui/Dialog/Dialog.module.css
+++ b/webapp/javascript/ui/Dialog/Dialog.module.css
@@ -23,6 +23,7 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .header {
@@ -43,25 +44,9 @@
 }
 
 .closeButton {
-  border: none;
-  padding: 0;
-  width: 34px;
-  height: 34px;
-  cursor: pointer;
-  position: relative;
-}
-
-.closeButton::after {
-  /* useful to visualize hit area: */
-  /* background-color: red; */
-  width: 34px;
-  height: 34px;
-  line-height: 34px;
-  font-size: 1.5em;
   position: absolute;
-  content: '\00d7';
-  top: -4px;
-  right: -10px;
+  right: 8px;
+  top: 8px;
 }
 
 .modalContent {

--- a/webapp/javascript/ui/Dialog/Dialog.tsx
+++ b/webapp/javascript/ui/Dialog/Dialog.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { Ref, ReactNode } from 'react';
 import ModalUnstyled from '@mui/base/ModalUnstyled';
-import Button from '@ui/Button';
+import Button from '@webapp/ui/Button';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import styles from './Dialog.module.css';
 

--- a/webapp/javascript/ui/Dialog/Dialog.tsx
+++ b/webapp/javascript/ui/Dialog/Dialog.tsx
@@ -34,6 +34,34 @@ export const DialogHeader = React.forwardRef(
   }
 );
 
+interface DialogFooterProps {
+  children: ReactNode;
+}
+export const DialogFooter = React.forwardRef(
+  (props: DialogFooterProps, ref?: Ref<HTMLInputElement>) => {
+    const { children } = props;
+    return (
+      <div className={styles.footer} ref={ref}>
+        {children}
+      </div>
+    );
+  }
+);
+
+interface DialogBodyProps {
+  children: ReactNode;
+}
+export const DialogBody = React.forwardRef(
+  (props: DialogBodyProps, ref?: Ref<HTMLInputElement>) => {
+    const { children } = props;
+    return (
+      <div className={styles.body} ref={ref}>
+        {children}
+      </div>
+    );
+  }
+);
+
 type DialogProps = Exclude<
   React.ComponentProps<typeof ModalUnstyled>,
   'components'

--- a/webapp/javascript/ui/Dialog/Dialog.tsx
+++ b/webapp/javascript/ui/Dialog/Dialog.tsx
@@ -80,3 +80,11 @@ export function Dialog(props: DialogProps) {
     </ModalUnstyled>
   );
 }
+
+export default function DialogActions({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <div className={styles.dialogActions}>{children}</div>;
+}

--- a/webapp/javascript/ui/Dialog/Dialog.tsx
+++ b/webapp/javascript/ui/Dialog/Dialog.tsx
@@ -1,0 +1,51 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React, { Ref, ReactNode } from 'react';
+import ModalUnstyled from '@mui/base/ModalUnstyled';
+import styles from './Dialog.module.css';
+
+const Backdrop = React.forwardRef<
+  HTMLDivElement,
+  { open?: boolean; className: string }
+>((props, ref) => {
+  const { open, className, ...other } = props;
+  return <div className={styles.backdrop} ref={ref} {...other} />;
+});
+
+interface DialogHeaderProps {
+  children: ReactNode;
+  closeable?: boolean;
+  onClose?: () => void;
+}
+export const DialogHeader = React.forwardRef(
+  (props: DialogHeaderProps, ref?: Ref<HTMLInputElement>) => {
+    const { children, closeable, onClose } = props;
+    return (
+      <div className={styles.header} ref={ref}>
+        {children}
+        {closeable ? (
+          <button
+            aria-label="Close"
+            className={styles.closeButton}
+            onClick={onClose}
+          />
+        ) : null}
+      </div>
+    );
+  }
+);
+
+type DialogProps = Exclude<
+  React.ComponentProps<typeof ModalUnstyled>,
+  'components'
+>;
+export function Dialog(props: DialogProps) {
+  return (
+    <ModalUnstyled
+      {...props}
+      components={{ Backdrop }}
+      className={styles.modal}
+    >
+      <div className={styles.modalContainer}>{props.children}</div>
+    </ModalUnstyled>
+  );
+}

--- a/webapp/javascript/ui/Dialog/Dialog.tsx
+++ b/webapp/javascript/ui/Dialog/Dialog.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React, { Ref, ReactNode } from 'react';
 import ModalUnstyled from '@mui/base/ModalUnstyled';
+import Button from '@ui/Button';
+import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import styles from './Dialog.module.css';
 
 const Backdrop = React.forwardRef<
@@ -11,11 +13,10 @@ const Backdrop = React.forwardRef<
   return <div className={styles.backdrop} ref={ref} {...other} />;
 });
 
-interface DialogHeaderProps {
-  children: ReactNode;
-  closeable?: boolean;
-  onClose?: () => void;
-}
+type DialogHeaderProps = { children: ReactNode } & (
+  | { closeable: true; onClose: () => void }
+  | { closeable?: false }
+);
 export const DialogHeader = React.forwardRef(
   (props: DialogHeaderProps, ref?: Ref<HTMLInputElement>) => {
     const { children, closeable, onClose } = props;
@@ -23,10 +24,12 @@ export const DialogHeader = React.forwardRef(
       <div className={styles.header} ref={ref}>
         {children}
         {closeable ? (
-          <button
+          <Button
             aria-label="Close"
-            className={styles.closeButton}
+            icon={faTimes}
             onClick={onClose}
+            noBox
+            className={styles.closeButton}
           />
         ) : null}
       </div>

--- a/webapp/javascript/ui/Dialog/Dialog.tsx
+++ b/webapp/javascript/ui/Dialog/Dialog.tsx
@@ -19,7 +19,7 @@ type DialogHeaderProps = { children: ReactNode } & (
 );
 export const DialogHeader = React.forwardRef(
   (props: DialogHeaderProps, ref?: Ref<HTMLInputElement>) => {
-    const { children, closeable, onClose } = props;
+    const { children, closeable } = props;
     return (
       <div className={styles.header} ref={ref}>
         {children}
@@ -27,7 +27,7 @@ export const DialogHeader = React.forwardRef(
           <Button
             aria-label="Close"
             icon={faTimes}
-            onClick={onClose}
+            onClick={() => props.onClose()}
             noBox
             className={styles.closeButton}
           />

--- a/webapp/javascript/ui/Dialog/index.ts
+++ b/webapp/javascript/ui/Dialog/index.ts
@@ -1,0 +1,1 @@
+export * from './Dialog';


### PR DESCRIPTION
Add a generic dialog, based off https://mui.com/base/api/modal-unstyled/

* breaks down the api into 4 elements: `<Dialog><DialogBody><DialogHeader><DialogFooter>`
* supports scrolling `<DialogBody>` (see video below)
* automatically set a backdrop

![Kapture 2022-09-23 at 16 34 38](https://user-images.githubusercontent.com/6951209/192044094-07a8cd74-e7c7-409f-84d3-3efe141a7858.gif)

Related https://github.com/pyroscope-io/pyroscope/issues/1542

After this we should refactor the multiple dialogs we have to use this one.