### PR TITLE
chore: enable remote read for annotations

### DIFF
--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -279,6 +279,7 @@ func (ctrl *Controller) serverMux() (http.Handler, error) {
 				{"/merge", h},
 				{"/api/exemplars:merge", h},
 				{"/api/exemplars:query", h},
+				{"/api/annotations", h},
 			}...)
 		}
 	} else {


### PR DESCRIPTION
** WIP, this still requires further discussion **

# Goal
Support annotations (creation/fetching) in a remote read/write environment.

# Original problem
The original motivation is that the demo-dev env (https://demo-dev.pyroscope.io/) reads from the cloud.
However, it writes annotations to the local instance's db.
That creates a situation where the annotation is created, but when the flamegraph is reloaded, the annotations is lost. Since annotation was written to a local db, but retrieved from an external datasource (the cloud).
This is illustrated by the following video:
![Kapture 2022-09-26 at 11 16 03](https://user-images.githubusercontent.com/6951209/192299911-ca7d5577-6971-49d8-b84e-efe786f54711.gif)


# Questions
This is a confusing feature. Is it related to remote write or remote read?

When we originally developed remote write the goal was to use a pyroscope instance as relay the ingest path (`/ingest`) to another instance. 
With this in mind, enabling remoteWrite should also work for other write endpoints, like `POST /api/annotations`.

However, consider the following cases:
## Case 1: 
* User has remoteWrite enabled AND localWrite also enabled. (ie it writes data both locally and to another instance)
* User creates an annotation

Where should the annotation be sent to? 
If it only goes to the remote targets, then annotations would not appear when visualizing via UI in a local instance, which is confusing.
If it only goes to the local target, then it works locally, but not when accessing via the remote target UI (imagine the cloud)
So to keep the existing behaviour, **it should be written to all targets (both locally and remote ones)**

The implementation requires creating multiple proxies for **specific endpoints**. Ie same thing as here https://github.com/pyroscope-io/pyroscope/blob/main/pkg/cli/server.go#L172-L182, but instead of creating `remoteWrite` instances, would be proxies (aka `remoteRead`)

## Case 2:
* User ONLY has **remoteRead** available 

Setting up only `remoteRead` may have 2 interpretations:
* a) I want my instance to be read-only (eg our demo-dev or a generic read-only instance)
* b) I want to consume external data (eg from the cloud), but with custom data stored locally (as users and annotations)

For *a)* we would need to disable any kind of writing (including annotations). So it simply would not be possible to create annotations. The implementation would require turning off certain endpoints + disabling frontend features.
For *b)* annotations would need to be created locally. The implementation is exactly as it is before this PR.


Closes https://github.com/pyroscope-io/pyroscope/issues/1539