### PR TITLE
chore(webapp): improve acessibility

### DIFF
--- a/stories/Dialog.stories.tsx
+++ b/stories/Dialog.stories.tsx
@@ -5,10 +5,10 @@ import {
   DialogFooter,
   DialogHeader,
   DialogBody,
+  DialogActions,
 } from '../webapp/javascript/ui/Dialog';
 import Button from '../webapp/javascript/ui/Button';
 import '../webapp/sass/profile.scss';
-import DialogActions from '../webapp/javascript/ui/Dialog/Dialog';
 
 export default {
   title: 'Components/Dialog',
@@ -22,6 +22,7 @@ export function dialog() {
     <>
       <Button onClick={() => setOpen(!open)}>Open Modal</Button>
       <Dialog
+        aria-labelledby="dialog-header"
         open={open}
         onClose={() => {
           setOpen(false);
@@ -29,7 +30,7 @@ export function dialog() {
       >
         <>
           <DialogHeader closeable onClose={() => setOpen(false)}>
-            I am the Header
+            <h3 id="dialog-header">I am the Header</h3>
           </DialogHeader>
           <DialogBody>
             <p>I am the body</p>
@@ -51,7 +52,13 @@ export function dialog() {
           <DialogFooter>
             <DialogActions>
               <Button onClick={() => setOpen(false)}>Cancel</Button>
-              <Button onClick={() => setOpen(false)} kind="secondary">
+              <Button
+                autoFocus
+                onClick={() => {
+                  setOpen(false);
+                }}
+                kind="secondary"
+              >
                 Ok
               </Button>
             </DialogActions>

--- a/webapp/javascript/ui/Button.tsx
+++ b/webapp/javascript/ui/Button.tsx
@@ -51,7 +51,6 @@ export default function Button({
   autoFocus,
   ...props
 }: ButtonProps) {
-  // eslint-disable jsx-a11y/no-autofocus
   return (
     <button
       id={id}

--- a/webapp/javascript/ui/Button.tsx
+++ b/webapp/javascript/ui/Button.tsx
@@ -31,6 +31,9 @@ export interface ButtonProps {
 
   /** disable a box around it */
   noBox?: boolean;
+
+  /** ONLY use this if within a modal (https://stackoverflow.com/a/71848275 and https://citizensadvice.github.io/react-dialogs/modal/auto_focus/index.html) */
+  autoFocus?: React.ButtonHTMLAttributes<HTMLButtonElement>['autoFocus'];
 }
 
 export default function Button({
@@ -45,8 +48,10 @@ export default function Button({
   className,
   form,
   noBox,
+  autoFocus,
   ...props
 }: ButtonProps) {
+  // eslint-disable jsx-a11y/no-autofocus
   return (
     <button
       id={id}
@@ -55,6 +60,7 @@ export default function Button({
       disabled={disabled}
       onClick={onClick}
       form={form}
+      autoFocus={autoFocus} // eslint-disable-line jsx-a11y/no-autofocus
       aria-label={props['aria-label']}
       className={cx(
         styles.button,

--- a/webapp/javascript/ui/Dialog/Dialog.module.css
+++ b/webapp/javascript/ui/Dialog/Dialog.module.css
@@ -33,6 +33,13 @@
   display: flex;
 }
 
+/* reset immediate headers */
+.header > h1,
+h2,
+h3,
+h4 {
+  margin: 0;
+}
 .body {
   padding: 15px 20px 10px;
   overflow-y: auto;

--- a/webapp/javascript/ui/Dialog/Dialog.tsx
+++ b/webapp/javascript/ui/Dialog/Dialog.tsx
@@ -3,6 +3,7 @@ import React, { Ref, ReactNode } from 'react';
 import ModalUnstyled from '@mui/base/ModalUnstyled';
 import Button from '@webapp/ui/Button';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
+import cx from 'classnames';
 import styles from './Dialog.module.css';
 
 const Backdrop = React.forwardRef<
@@ -13,15 +14,15 @@ const Backdrop = React.forwardRef<
   return <div className={styles.backdrop} ref={ref} {...other} />;
 });
 
-type DialogHeaderProps = { children: ReactNode } & (
+type DialogHeaderProps = { children: ReactNode; className?: string } & (
   | { closeable: true; onClose: () => void }
   | { closeable?: false }
 );
 export const DialogHeader = React.forwardRef(
   (props: DialogHeaderProps, ref?: Ref<HTMLInputElement>) => {
-    const { children, closeable } = props;
+    const { children, className, closeable } = props;
     return (
-      <div className={styles.header} ref={ref}>
+      <div className={cx(styles.header, className)} ref={ref}>
         {children}
         {closeable ? (
           <Button
@@ -39,12 +40,13 @@ export const DialogHeader = React.forwardRef(
 
 interface DialogFooterProps {
   children: ReactNode;
+  className?: string;
 }
 export const DialogFooter = React.forwardRef(
   (props: DialogFooterProps, ref?: Ref<HTMLInputElement>) => {
-    const { children } = props;
+    const { children, className } = props;
     return (
-      <div className={styles.footer} ref={ref}>
+      <div className={cx(styles.footer, className)} ref={ref}>
         {children}
       </div>
     );
@@ -53,12 +55,13 @@ export const DialogFooter = React.forwardRef(
 
 interface DialogBodyProps {
   children: ReactNode;
+  className?: string;
 }
 export const DialogBody = React.forwardRef(
   (props: DialogBodyProps, ref?: Ref<HTMLInputElement>) => {
-    const { children } = props;
+    const { children, className } = props;
     return (
-      <div className={styles.body} ref={ref}>
+      <div className={cx(styles.body, className)} ref={ref}>
         {children}
       </div>
     );
@@ -68,15 +71,26 @@ export const DialogBody = React.forwardRef(
 type DialogProps = Exclude<
   React.ComponentProps<typeof ModalUnstyled>,
   'components'
->;
+> & {
+  className?: string;
+  /** The header ID */
+  ['aria-labelledby']: string;
+};
 export function Dialog(props: DialogProps) {
+  const { className } = props;
   return (
     <ModalUnstyled
       {...props}
       components={{ Backdrop }}
-      className={styles.modal}
+      className={cx(styles.modal, className)}
     >
-      <div className={styles.modalContainer}>{props.children}</div>
+      <div
+        aria-modal="true"
+        aria-labelledby={props['aria-labelledby']}
+        className={styles.modalContainer}
+      >
+        {props.children}
+      </div>
     </ModalUnstyled>
   );
 }

--- a/webapp/sass/reset.scss
+++ b/webapp/sass/reset.scss
@@ -4,3 +4,8 @@
 // However that does not happen when inlining
 @import './sanitize.css/sanitize';
 @import './sanitize.css/forms';
+
+:focus-visible {
+  /* sanitize uses dotted, let's use the browser's default */
+  outline: revert !important;
+}


### PR DESCRIPTION
Follow up from https://github.com/pyroscope-io/pyroscope/pull/1544

* Force the `Dialog` to have a `aria-labelledby`, which should be the header id.
* Remove `sanitize.css`'s `outline` styling to use the browser's. This is due to `sanitize`'s being too difficult to see, specially next to buttons
* allow buttons to have an `autoFocus` attribute, althought with a disclaimer that it should ONLY be used with modals.
It works, although there's no visual indicator that it is focused. I haven't investigated much further.

Also
* reset Heading's (`h1, h2, h3, h4`) margins in `DialogHeader`, this is just to make it easier for users (not having to redefine them every time)
* allow `Dialog{Footer, Body, Header}` to pass custom `className`


Some references for anybody interested:
* https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element
* https://allyjs.io/tutorials/accessible-dialog.html#reacting-to-kbdenterkbd-and-kbdescapekbd
* https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/
* https://www.w3.org/WAI/ARIA/apg/example-index/dialog-modal/dialog.html
* https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role