### PR TITLE
chore: set a transparent border on buttons

### DIFF
--- a/webapp/javascript/ui/Button.module.scss
+++ b/webapp/javascript/ui/Button.module.scss
@@ -46,7 +46,7 @@ $border-radius: 4px;
 }
 
 .primary {
-  border: none;
+  border-color: transparent;
   color: var(--ps-button-switch-text) !important;
   background-color: var(--ps-button-switch-bg);
 
@@ -60,7 +60,7 @@ $border-radius: 4px;
 }
 
 .secondary {
-  border: none;
+  border-color: transparent;
   color: var(--ps-immutable-off-white);
   background-color: var(--ps-blue-primary);
 
@@ -74,7 +74,7 @@ $border-radius: 4px;
 }
 
 .danger {
-  border: none;
+  border-color: transparent;
   color: var(--ps-neutral-2);
   background-color: var(--ps-red-primary);
   &:hover {


### PR DESCRIPTION
existing buttons with variation (secondary/primary) have `border: none`, which when paired with normal buttons show this lack of border, making them having different sizes:

<img width="285" alt="Screen Shot 2022-09-27 at 16 04 33" src="https://user-images.githubusercontent.com/6951209/192615367-acc0e9f1-8be7-473f-85d3-f7ffc596af6e.png">

This PR just sets a border with background color, so that's counted as the button size but not really visible.

Before:
![image](https://user-images.githubusercontent.com/6951209/192615607-46e14c47-c85b-4d50-a5ca-08d9e082817b.png)

After:
![image](https://user-images.githubusercontent.com/6951209/192615637-9fe9a4d9-90de-4d68-8485-06904958fa90.png)
