### PR TITLE
fix: tag explorer modal should close when another one is clicked

### DIFF
--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.tsx
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.tsx
@@ -6,9 +6,7 @@ import { actions } from '@webapp/redux/reducers/continuous';
 import { appendLabelToQuery } from '@webapp/util/query';
 import { brandQuery } from '@webapp/models/query';
 import { PAGES } from '@webapp/pages/constants';
-import ModalWithToggle, {
-  TOGGLE_BTN_ID,
-} from '@webapp/ui/Modals/ModalWithToggle';
+import ModalWithToggle from '@webapp/ui/Modals/ModalWithToggle';
 import styles from './TagsSelector.module.scss';
 
 const emptyTagsTag = 'No tags available';
@@ -115,11 +113,9 @@ function TagSelector({
     setModalOpenStatus(false);
   };
 
-  const handleOutsideClick = (e: MouseEvent) => {
-    if ((e.target as { id?: string })?.id !== TOGGLE_BTN_ID) {
-      setSelectedTags(defaultSelectedTags);
-      setModalOpenStatus(false);
-    }
+  const handleOutsideClick = () => {
+    setSelectedTags(defaultSelectedTags);
+    setModalOpenStatus(false);
   };
 
   return (

--- a/webapp/javascript/ui/Modals/ModalWithToggle.tsx
+++ b/webapp/javascript/ui/Modals/ModalWithToggle.tsx
@@ -17,8 +17,6 @@ export interface ModalWithToggleProps {
   modalHeight?: string;
 }
 
-export const TOGGLE_BTN_ID = 'modal-toggler';
-
 function ModalWithToggle({
   isModalOpen,
   setModalOpenStatus,
@@ -32,27 +30,25 @@ function ModalWithToggle({
   modalClassName,
   modalHeight,
 }: ModalWithToggleProps) {
-  const handleOutsideClick = (e: MouseEvent) => {
-    if ((e.target as { id?: string })?.id !== TOGGLE_BTN_ID) {
-      setModalOpenStatus(false);
-    }
+  const handleOutsideClick = () => {
+    setModalOpenStatus(false);
   };
 
   return (
     <div data-testid="modal-with-toggle" className={styles.container}>
-      <button
-        id={TOGGLE_BTN_ID}
-        type="button"
-        data-testid="toggler"
-        className={styles.toggle}
-        onClick={() => setModalOpenStatus((v) => !v)}
+      <OutsideClickHandler
+        onOutsideClick={customHandleOutsideClick || handleOutsideClick}
       >
-        {toggleText}
-      </button>
-      {isModalOpen && (
-        <OutsideClickHandler
-          onOutsideClick={customHandleOutsideClick || handleOutsideClick}
+        <button
+          id="modal-toggler"
+          type="button"
+          data-testid="toggler"
+          className={styles.toggle}
+          onClick={() => setModalOpenStatus((v) => !v)}
         >
+          {toggleText}
+        </button>
+        {isModalOpen && (
           <div
             className={classnames(styles.modal, modalClassName)}
             data-testid="modal"
@@ -82,8 +78,8 @@ function ModalWithToggle({
               {footerEl}
             </div>
           </div>
-        </OutsideClickHandler>
-      )}
+        )}
+      </OutsideClickHandler>
     </div>
   );
 }


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1518

## Changes
- close modal when clicking outside 

https://user-images.githubusercontent.com/47758224/193231881-bed4cc05-83ab-41ae-bce2-86a0a5f7bdb7.mov


## Concerns
-