### PR TITLE
feat: add count and duration to heatmap tooltip

### DIFF
--- a/webapp/javascript/components/Heatmap/HeatmapTooltip.module.scss
+++ b/webapp/javascript/components/Heatmap/HeatmapTooltip.module.scss
@@ -1,0 +1,20 @@
+.tooltipWrapper {
+  padding: 0;
+  font-size: 14px;
+  font-weight: 600;
+
+  .tooltipHeader {
+    margin: 0;
+    padding: 10px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    background-color: var(--ps-tooltip-header-bg);
+  }
+
+  .dataRow {
+    width: 220px;
+    padding: 10px;
+    display: flex;
+    justify-content: space-between;
+  }
+}

--- a/webapp/javascript/components/Heatmap/HeatmapTooltip.module.scss
+++ b/webapp/javascript/components/Heatmap/HeatmapTooltip.module.scss
@@ -3,6 +3,11 @@
   font-size: 14px;
   font-weight: 600;
 
+  .tooltipHeader,
+  .tooltipBody {
+    padding: 10px;
+  }
+
   .tooltipHeader {
     margin: 0;
     padding: 10px;
@@ -13,8 +18,12 @@
 
   .dataRow {
     width: 220px;
-    padding: 10px;
+    margin-bottom: 10px;
     display: flex;
     justify-content: space-between;
+
+    &:last-child {
+      margin: 0;
+    }
   }
 }

--- a/webapp/javascript/components/Heatmap/HeatmapTooltip.spec.tsx
+++ b/webapp/javascript/components/Heatmap/HeatmapTooltip.spec.tsx
@@ -1,0 +1,28 @@
+import React, { RefObject } from 'react';
+import { render, screen } from '@testing-library/react';
+
+import HeatmapTooltip from './HeatmapTooltip';
+import { heatmapMockData } from '../../services/exemplarsTestData';
+
+const canvasEl = document.createElement('canvas');
+const canvasRef = { current: canvasEl } as RefObject<HTMLCanvasElement>;
+
+describe('Component: HeatmapTooltip', () => {
+  const renderTooltip = () => {
+    render(
+      <HeatmapTooltip
+        dataSourceElRef={canvasRef}
+        heatmapW={400}
+        heatmap={heatmapMockData}
+        timezone="browser"
+        sampleRate={100}
+      />
+    );
+  };
+
+  it('should render initial tooltip (not active)', () => {
+    renderTooltip();
+
+    expect(screen.getByTestId('heatmap-tooltip')).toBeInTheDocument();
+  });
+});

--- a/webapp/javascript/components/Heatmap/HeatmapTooltip.tsx
+++ b/webapp/javascript/components/Heatmap/HeatmapTooltip.tsx
@@ -72,7 +72,7 @@ function HeatmapTooltip({
       ];
 
       // to fix tooltip on window edge
-      const maxPageX = window.innerWidth - 130;
+      const maxPageX = window.innerWidth - 250;
 
       setTooltipParams({
         pageX: e.pageX < maxPageX ? e.pageX - 10 : maxPageX,

--- a/webapp/javascript/components/Heatmap/HeatmapTooltip.tsx
+++ b/webapp/javascript/components/Heatmap/HeatmapTooltip.tsx
@@ -129,15 +129,13 @@ function HeatmapTooltip({
           pageX={tooltipParams.pageX}
           pageY={tooltipParams.pageY}
         >
-          <p role="textbox" className={styles.tooltipHeader}>
-            {tooltipParams.time}
-          </p>
+          <p className={styles.tooltipHeader}>{tooltipParams.time}</p>
           <div className={styles.tooltipBody}>
-            <div role="textbox" className={styles.dataRow}>
+            <div className={styles.dataRow}>
               <span>Count: </span>
               <span>{tooltipParams.count} profiles</span>
             </div>
-            <div role="textbox" className={styles.dataRow}>
+            <div className={styles.dataRow}>
               <span>Latency: </span>
               <span>{tooltipParams.latency}</span>
             </div>

--- a/webapp/javascript/components/Heatmap/HeatmapTooltip.tsx
+++ b/webapp/javascript/components/Heatmap/HeatmapTooltip.tsx
@@ -53,7 +53,7 @@ function HeatmapTooltip({
       if (!tooltipRef || !tooltipRef.current) {
         throw new Error('Missing tooltipElement');
       }
-      const canvas = e.target as HTMLCanvasElement;
+      const canvas = dataSourceElRef.current as HTMLCanvasElement;
       const { left, top } = canvas.getBoundingClientRect();
 
       const xCursorPosition = e.pageX - left;
@@ -82,7 +82,7 @@ function HeatmapTooltip({
         count: heatmap.values[matrixCoords[0]][matrixCoords[1]],
       });
     },
-    [tooltipRef, setTooltipParams, heatmapW, heatmap, timezone]
+    [tooltipRef, setTooltipParams, heatmapW, heatmap, timezone, dataSourceElRef]
   );
 
   // to show tooltip when move mouse over selected area

--- a/webapp/javascript/components/Heatmap/HeatmapTooltip.tsx
+++ b/webapp/javascript/components/Heatmap/HeatmapTooltip.tsx
@@ -129,13 +129,15 @@ function HeatmapTooltip({
           pageX={tooltipParams.pageX}
           pageY={tooltipParams.pageY}
         >
-          <p className={styles.tooltipHeader}>{tooltipParams.time}</p>
+          <p role="textbox" className={styles.tooltipHeader}>
+            {tooltipParams.time}
+          </p>
           <div className={styles.tooltipBody}>
-            <div className={styles.dataRow}>
+            <div role="textbox" className={styles.dataRow}>
               <span>Count: </span>
               <span>{tooltipParams.count} profiles</span>
             </div>
-            <div className={styles.dataRow}>
+            <div role="textbox" className={styles.dataRow}>
               <span>Latency: </span>
               <span>{tooltipParams.latency}</span>
             </div>

--- a/webapp/javascript/components/Heatmap/HeatmapTooltip.tsx
+++ b/webapp/javascript/components/Heatmap/HeatmapTooltip.tsx
@@ -39,7 +39,7 @@ function HeatmapTooltip({
         pageX: number;
         pageY: number;
         time: string;
-        duration: string;
+        latency: string;
         count: number;
       }
     | undefined
@@ -78,7 +78,7 @@ function HeatmapTooltip({
         pageX: e.pageX < maxPageX ? e.pageX - 10 : maxPageX,
         pageY: e.pageY + 10,
         time: formatter(time).toString(),
-        duration: valueFormatter.format(bucketsDuration, sampleRate),
+        latency: valueFormatter.format(bucketsDuration, sampleRate),
         count: heatmap.values[matrixCoords[0]][matrixCoords[1]],
       });
     },
@@ -130,13 +130,15 @@ function HeatmapTooltip({
           pageY={tooltipParams.pageY}
         >
           <p className={styles.tooltipHeader}>{tooltipParams.time}</p>
-          <div className={styles.dataRow}>
-            <span>Count: </span>
-            <span>{tooltipParams.count} profiles</span>
-          </div>
-          <div className={styles.dataRow}>
-            <span>Duration: </span>
-            <span>{tooltipParams.duration}</span>
+          <div className={styles.tooltipBody}>
+            <div className={styles.dataRow}>
+              <span>Count: </span>
+              <span>{tooltipParams.count} profiles</span>
+            </div>
+            <div className={styles.dataRow}>
+              <span>Latency: </span>
+              <span>{tooltipParams.latency}</span>
+            </div>
           </div>
         </TooltipWrapper>
       )}

--- a/webapp/javascript/components/Heatmap/index.tsx
+++ b/webapp/javascript/components/Heatmap/index.tsx
@@ -186,6 +186,7 @@ export function Heatmap({
         heatmapW={heatmapW}
         heatmap={heatmap}
         timezone={timezone}
+        sampleRate={sampleRate}
       />
     </div>
   );

--- a/webapp/javascript/components/Heatmap/useHeatmapSelection.hook.spec.tsx
+++ b/webapp/javascript/components/Heatmap/useHeatmapSelection.hook.spec.tsx
@@ -8,7 +8,7 @@ import tracingReducer from '@webapp/redux/reducers/tracing';
 import { useHeatmapSelection } from './useHeatmapSelection.hook';
 import { heatmapMockData } from '../../services/exemplarsTestData';
 
-const canvasEl = document.createElement('canvasEl');
+const canvasEl = document.createElement('canvas');
 const divEl = document.createElement('div');
 const canvasRef = { current: canvasEl } as RefObject<HTMLCanvasElement>;
 const resizedSelectedAreaRef = { current: divEl } as RefObject<HTMLDivElement>;

--- a/webapp/javascript/components/Heatmap/utils.ts
+++ b/webapp/javascript/components/Heatmap/utils.ts
@@ -44,15 +44,20 @@ interface SelectionData {
   selectionEndTime: number;
 }
 
-// TODO(dogfrogfog): extend calculating data
 export const getTimeDataByXCoord = (
   heatmap: Heatmap,
   heatmapW: number,
   x: number
 ) => {
-  const timeForPixel = (heatmap.endTime - heatmap.startTime) / heatmapW;
+  const unitsForPixel = (heatmap.endTime - heatmap.startTime) / heatmapW;
 
-  return x * timeForPixel + heatmap.startTime;
+  return x * unitsForPixel + heatmap.startTime;
+};
+
+export const getBucketsDurationByYCoord = (heatmap: Heatmap, y: number) => {
+  const unitsForPixel = (heatmap.maxValue - heatmap.minValue) / HEATMAP_HEIGHT;
+
+  return (HEATMAP_HEIGHT - y) * unitsForPixel;
 };
 
 export const getSelectionData = (

--- a/webapp/javascript/components/TimelineChart/TooltipWrapper/index.tsx
+++ b/webapp/javascript/components/TimelineChart/TooltipWrapper/index.tsx
@@ -11,9 +11,11 @@ export interface ITooltipWrapperProps {
   pageY: number;
   align: 'left' | 'right';
   children: React.ReactNode | React.ReactNode[];
+  className?: string;
 }
 
 const TooltipWrapper = ({
+  className,
   pageX,
   pageY,
   align,
@@ -32,6 +34,7 @@ const TooltipWrapper = ({
       className={cx({
         [styles.tooltip]: true,
         [styles.hidden]: isHidden,
+        [className || '']: className,
       })}
       id={EXPLORE_TOOLTIP_WRAPPER_ID}
     >

--- a/webapp/javascript/components/TimelineChart/TooltipWrapper/styles.module.scss
+++ b/webapp/javascript/components/TimelineChart/TooltipWrapper/styles.module.scss
@@ -1,4 +1,5 @@
 .tooltip {
+  z-index: 2;
   height: auto;
   width: auto;
   display: flex;


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1577

## Changes
- add buckets duration and buckets count to heatmap tooltip


https://user-images.githubusercontent.com/47758224/193300399-a9bdb3cd-5de1-4658-8f2b-2a1d27e7b1d8.mov


## Concerns
-