### PR TITLE
refactor: tree serialization improvements

### DIFF
--- a/.air.conf
+++ b/.air.conf
@@ -25,7 +25,7 @@ delay = 1000 # ms
 
 send_interrupt = true
 
-kill_delay = 100 # ms
+kill_delay = 2000000000 # ns
 
 # Stop to run old binary when build errors occur.
 stop_on_error = true

--- a/cmd/pyroscope/command/convert.go
+++ b/cmd/pyroscope/command/convert.go
@@ -39,7 +39,7 @@ func parse(input io.Reader, format string) error {
 		parser(input, func(name []byte, val int) {
 			t.Insert(name, uint64(val))
 		})
-		return t.SerializeNoDict(4096, os.Stdout)
+		return t.SerializeTruncateNoDict(4096, os.Stdout)
 	case "trie":
 		t := transporttrie.New()
 		parser(input, func(name []byte, val int) {

--- a/pkg/server/render.go
+++ b/pkg/server/render.go
@@ -147,13 +147,6 @@ func (rh *RenderHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			},
 		})
 
-		sum := uint64(0)
-		for _, v := range flame.Timeline.Samples {
-			sum += v - 1
-		}
-
-		logrus.WithField("samples", sum).Info("samples")
-
 		// Look up annotations
 		annotations, err := rh.annotationsService.FindAnnotationsByTimeRange(r.Context(), appName, p.gi.StartTime, p.gi.EndTime)
 		if err != nil {

--- a/pkg/server/render.go
+++ b/pkg/server/render.go
@@ -147,6 +147,13 @@ func (rh *RenderHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			},
 		})
 
+		sum := uint64(0)
+		for _, v := range flame.Timeline.Samples {
+			sum += v - 1
+		}
+
+		logrus.WithField("samples", sum).Info("samples")
+
 		// Look up annotations
 		annotations, err := rh.annotationsService.FindAnnotationsByTimeRange(r.Context(), appName, p.gi.StartTime, p.gi.EndTime)
 		if err != nil {

--- a/pkg/storage/tree/flamebearer.go
+++ b/pkg/storage/tree/flamebearer.go
@@ -21,7 +21,7 @@ type Flamebearer struct {
 	Format     Format `json:"format"`
 }
 
-var otherJsonableSlice = jsonableSlice("other")
+var lostDuringRenderingName = jsonableSlice("other")
 
 func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 	t.RLock()
@@ -81,7 +81,7 @@ func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 			otherTotal := uint64(0)
 			var otherNode *treeNode
 			for _, n := range tn.ChildrenNodes {
-				if bytes.Equal(n.Name, otherName) {
+				if bytes.Equal(n.Name, lostDuringRenderingName) {
 					otherTotal += n.Total
 					continue
 				}
@@ -96,7 +96,7 @@ func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 			}
 			if otherTotal != 0 {
 				otherNode = &treeNode{
-					Name:  otherJsonableSlice,
+					Name:  lostDuringRenderingName,
 					Total: otherTotal,
 					Self:  otherTotal,
 				}

--- a/pkg/storage/tree/flamebearer.go
+++ b/pkg/storage/tree/flamebearer.go
@@ -1,5 +1,7 @@
 package tree
 
+import "bytes"
+
 type Format string
 
 const (
@@ -18,6 +20,8 @@ type Flamebearer struct {
 	Units      string `json:"units"`
 	Format     Format `json:"format"`
 }
+
+var otherJsonableSlice = jsonableSlice("other")
 
 func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 	t.RLock()
@@ -75,7 +79,12 @@ func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 
 			xOffset += int(tn.Self)
 			otherTotal := uint64(0)
+			var otherNode *treeNode
 			for _, n := range tn.ChildrenNodes {
+				if bytes.Equal(n.Name, otherName) {
+					otherTotal += n.Total
+					continue
+				}
 				if n.Total >= minVal {
 					xOffsets = append([]int{xOffset}, xOffsets...)
 					levels = append([]int{level + 1}, levels...)
@@ -86,14 +95,14 @@ func (t *Tree) FlamebearerStruct(maxNodes int) *Flamebearer {
 				}
 			}
 			if otherTotal != 0 {
-				n := &treeNode{
-					Name:  jsonableSlice("other"),
+				otherNode = &treeNode{
+					Name:  otherJsonableSlice,
 					Total: otherTotal,
 					Self:  otherTotal,
 				}
 				xOffsets = append([]int{xOffset}, xOffsets...)
 				levels = append([]int{level + 1}, levels...)
-				nodes = append([]*treeNode{n}, nodes...)
+				nodes = append([]*treeNode{otherNode}, nodes...)
 			}
 		}
 	}

--- a/pkg/storage/tree/minval.go
+++ b/pkg/storage/tree/minval.go
@@ -1,8 +1,13 @@
 package tree
 
-import "github.com/pyroscope-io/pyroscope/pkg/structs/cappedarr"
+import (
+	"github.com/pyroscope-io/pyroscope/pkg/structs/cappedarr"
+)
 
 func (t *Tree) minValue(maxNodes int) uint64 {
+	if maxNodes == -1 {
+		return 0
+	}
 	c := cappedarr.New(maxNodes)
 	t.iterateWithTotal(func(total uint64) bool {
 		return c.Push(total)

--- a/pkg/storage/tree/serialize_nodict_test.go
+++ b/pkg/storage/tree/serialize_nodict_test.go
@@ -17,7 +17,7 @@ var _ = Describe("tree package", func() {
 			tree.Insert([]byte("a;c"), uint64(2))
 
 			var buf bytes.Buffer
-			tree.SerializeNoDict(1024, &buf)
+			tree.SerializeTruncateNoDict(1024, &buf)
 			Expect(buf.Bytes()).To(Equal(serializationExample))
 		})
 	})

--- a/pkg/storage/tree/serialize_test.go
+++ b/pkg/storage/tree/serialize_test.go
@@ -21,7 +21,7 @@ var _ = Describe("tree", func() {
 		})
 	})
 
-	Describe("Serialize", func() {
+	Describe("SerializeTruncate", func() {
 		d := dict.New()
 		tree := New()
 		tree.Insert([]byte("a;b"), uint64(1))
@@ -29,16 +29,16 @@ var _ = Describe("tree", func() {
 
 		It("serializes tree", func() {
 			var buf bytes.Buffer
-			tree.Serialize(d, 1024, &buf)
+			tree.SerializeTruncate(d, 1024, &buf)
 			Expect(buf.Bytes()).To(Equal(dictSerializeExample))
 		})
 
 		Context("Ran 1000000 times", func() {
 			var buf1 bytes.Buffer
-			tree.Serialize(d, 1024, &buf1)
+			tree.SerializeTruncate(d, 1024, &buf1)
 			It("returns the same result", func() {
 				var buf2 bytes.Buffer
-				tree.Serialize(d, 1024, &buf2)
+				tree.SerializeTruncate(d, 1024, &buf2)
 				Expect(buf2).To(Equal(buf1))
 			})
 		})

--- a/pkg/storage/tree/truncation_test.go
+++ b/pkg/storage/tree/truncation_test.go
@@ -37,9 +37,21 @@ var _ = Describe("truncation", func() {
 			It("after serialization drops node 'a'", func() {
 				buf := &bytes.Buffer{}
 				treeA.SerializeTruncate(d, 3, buf)
-				treeB, err := Deserialize(d, buf)
+				b := buf.Bytes()
+				treeB, err := Deserialize(d, bytes.NewReader(b))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(treeB.StringWithEmpty()).To(Equal(treeStr(`"b" 2|"c" 3|"ls" 1|`)))
+
+				treeA.Insert([]byte("d"), uint64(1))
+
+				buf = &bytes.Buffer{}
+				treeA.SerializeTruncate(d, 3, buf)
+				b = buf.Bytes()
+
+				treeC, err := Deserialize(d, bytes.NewReader(b))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(treeC.StringWithEmpty()).To(Equal(treeStr(`"b" 2|"c" 3|"ls" 2|`)))
+				Expect(treeC.StringWithEmpty()).To(Equal(treeA.StringWithEmpty()))
 			})
 		})
 

--- a/pkg/storage/tree/truncation_test.go
+++ b/pkg/storage/tree/truncation_test.go
@@ -1,0 +1,58 @@
+package tree
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo/v2/dsl/core"
+	. "github.com/onsi/gomega"
+	"github.com/pyroscope-io/pyroscope/pkg/storage/dict"
+)
+
+var _ = Describe("truncation", func() {
+	defer GinkgoRecover()
+
+	BeforeEach(func() {
+		// we override these two to better see what's going on
+		lostDuringSerializationName = []byte("ls")
+		lostDuringRenderingName = jsonableSlice("lr")
+	})
+
+	AfterEach(func() {
+		lostDuringSerializationName = []byte("other")
+		lostDuringRenderingName = jsonableSlice("other")
+	})
+
+	Context("small tree", func() {
+		var treeA *Tree
+		// treeA := New()
+		BeforeEach(func() {
+			treeA = New()
+			treeA.Insert([]byte("a"), uint64(1))
+			treeA.Insert([]byte("b"), uint64(2))
+			treeA.Insert([]byte("c"), uint64(3))
+		})
+
+		Context("with dictionary", func() {
+			d := dict.New()
+			It("after serialization drops node 'a'", func() {
+				buf := &bytes.Buffer{}
+				treeA.SerializeTruncate(d, 3, buf)
+				treeB, err := Deserialize(d, buf)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(treeB.StringWithEmpty()).To(Equal(treeStr(`"b" 2|"c" 3|"ls" 1|`)))
+			})
+		})
+
+		Context("without dictionary", func() {
+			It("after serialization drops node 'a'", func() {
+				buf := &bytes.Buffer{}
+				treeA.SerializeTruncateNoDict(3, buf)
+				treeB, err := DeserializeNoDict(buf)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(treeB.StringWithEmpty()).To(Equal(treeStr(`"b" 2|"c" 3|"ls" 1|`)))
+			})
+		})
+	})
+
+	// TODO(petethepig): add more tests
+})


### PR DESCRIPTION
This PR improves tree truncation algorithm. This results in less nodes being dropped (and replaced with `other` nodes).

This also introduces ability to set `max-nodes-serialization` to `-1` which effectively disables truncation.

I ran some benchmarks with a ruby app with a very leafy flamegraph. I ingested 5000 profiles and measured storage size, wall time and cpu time for the ingestions and put together a table that represents the difference between old version, new version with defaults and new version with `max-nodes-serialization` set to -1.

  | storage size | profile time | flamegraph
-- | -- | --| --
old version | 220 MB | 47s | https://flamegraph.com/share/747cf1c2-4ab2-11ed-81e2-52cfe0251908
new version defaults | 228 MB | 52s | https://flamegraph.com/share/261eae6a-4aac-11ed-81e2-52cfe0251908
new version -1 | 293 MB | 52s | https://flamegraph.com/share/31edb3ac-4ab0-11ed-81e2-52cfe0251908

