### PR TITLE
Support speedscope format

### DIFF
--- a/pkg/convert/speedscope/json.go
+++ b/pkg/convert/speedscope/json.go
@@ -1,0 +1,65 @@
+package speedscope
+
+// Description of Speedscope JSON
+// See spec: https://github.com/jlfwong/speedscope/blob/main/src/lib/file-format-spec.ts
+
+const (
+	schema = "https://www.speedscope.app/file-format-schema.json"
+
+	profileEvented = "evented"
+	profileSampled = "sampled"
+
+	unitNone         = "none"
+	unitNanoseconds  = "nanoseconds"
+	unitMicroseconds = "microseconds"
+	unitMilliseconds = "milliseconds"
+	unitSeconds      = "seconds"
+	unitBytes        = "bytes"
+
+	eventOpen  = "O"
+	eventClose = "C"
+)
+
+type speedscopeFile struct {
+	Schema             string `json:"$schema"`
+	Shared             shared
+	Profiles           []profile
+	Name               string
+	ActiveProfileIndex int
+	Exporter           string
+}
+
+type shared struct {
+	Frames []frame
+}
+
+type frame struct {
+	Name string
+	File string
+	Line int
+	Col  int
+}
+
+type profile struct {
+	Type       string
+	Name       string
+	Unit       string
+	StartValue int64
+	EndValue   int64
+
+	// Evented profile
+	Events []event
+
+	// Sample profile
+	Samples []sample
+	Weights []int64
+}
+
+type event struct {
+	Type  string
+	At    int64
+	Frame int
+}
+
+// Indexes into Frames
+type sample []int

--- a/pkg/convert/speedscope/json.go
+++ b/pkg/convert/speedscope/json.go
@@ -25,7 +25,7 @@ type speedscopeFile struct {
 	Shared             shared
 	Profiles           []profile
 	Name               string
-	ActiveProfileIndex int
+	ActiveProfileIndex float64
 	Exporter           string
 }
 
@@ -36,30 +36,30 @@ type shared struct {
 type frame struct {
 	Name string
 	File string
-	Line int
-	Col  int
+	Line float64
+	Col  float64
 }
 
 type profile struct {
 	Type       string
 	Name       string
 	Unit       string
-	StartValue int64
-	EndValue   int64
+	StartValue float64
+	EndValue   float64
 
 	// Evented profile
 	Events []event
 
 	// Sample profile
 	Samples []sample
-	Weights []int64
+	Weights []float64
 }
 
 type event struct {
 	Type  string
-	At    int64
-	Frame int
+	At    float64
+	Frame float64
 }
 
 // Indexes into Frames
-type sample []int
+type sample []float64

--- a/pkg/convert/speedscope/parser.go
+++ b/pkg/convert/speedscope/parser.go
@@ -1,0 +1,41 @@
+package speedscope
+
+import (
+	"context"
+
+	"github.com/pyroscope-io/pyroscope/pkg/ingestion"
+	"github.com/pyroscope-io/pyroscope/pkg/storage"
+)
+
+// RawProfile implements ingestion.RawProfile for Speedscope format
+type RawProfile struct {
+	RawData []byte
+}
+
+// Parse parses a profile
+func (p *RawProfile) Parse(ctx context.Context, putter storage.Putter, _ storage.MetricsExporter, md ingestion.Metadata) error {
+	input := storage.PutInput{
+		StartTime:       md.StartTime,
+		EndTime:         md.EndTime,
+		Key:             md.Key,
+		SpyName:         md.SpyName,
+		SampleRate:      md.SampleRate,
+		Units:           md.Units,
+		AggregationType: md.AggregationType,
+	}
+	return p.convert(putter, &input)
+}
+
+func (p *RawProfile) convert(putter storage.Putter, input *storage.PutInput) error {
+	panic("TODO")
+}
+
+// Bytes returns the raw bytes of the profile
+func (p *RawProfile) Bytes() ([]byte, error) {
+	return p.RawData, nil
+}
+
+// ContentType returns the HTTP ContentType of the profile
+func (p *RawProfile) ContentType() string {
+	return "application/json"
+}

--- a/pkg/convert/speedscope/speedscope_suite_test.go
+++ b/pkg/convert/speedscope/speedscope_suite_test.go
@@ -1,0 +1,13 @@
+package speedscope_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConvert(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Speedscope Suite")
+}

--- a/pkg/convert/speedscope/speedscope_test.go
+++ b/pkg/convert/speedscope/speedscope_test.go
@@ -46,4 +46,30 @@ a;b;d 4
 `
 		Expect(input.Val.String()).To(Equal(expectedResult))
 	})
+
+	It("Can parse a sample-format profile", func() {
+		data, err := os.ReadFile("testdata/two-sampled.speedscope.json")
+		Expect(err).ToNot(HaveOccurred())
+
+		key, err := segment.ParseKey("foo{x=y}")
+		Expect(err).ToNot(HaveOccurred())
+
+		ingester := new(mockIngester)
+		profile := &RawProfile{RawData: data}
+
+		md := ingestion.Metadata{Key: key}
+		err = profile.Parse(context.Background(), ingester, nil, md)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(ingester.actual).To(HaveLen(2))
+
+		input := ingester.actual[0]
+		Expect(input.Units).To(Equal(metadata.SamplesUnits))
+		Expect(input.Key.Normalized()).To(Equal("foo.seconds{x=y}"))
+		expectedResult := `a;b 5
+a;b;c 5
+a;b;d 4
+`
+		Expect(input.Val.String()).To(Equal(expectedResult))
+	})
 })

--- a/pkg/convert/speedscope/speedscope_test.go
+++ b/pkg/convert/speedscope/speedscope_test.go
@@ -1,0 +1,33 @@
+package speedscope
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/pyroscope-io/pyroscope/pkg/storage"
+)
+
+type mockIngester struct{ actual []*storage.PutInput }
+
+func (m *mockIngester) Put(_ context.Context, p *storage.PutInput) error {
+	m.actual = append(m.actual, p)
+	return nil
+}
+
+var _ = Describe("Speedscope", func() {
+	It("Can parse an event-format profile", func() {
+		data, err := os.ReadFile("testdata/simple.speedscope.json")
+		Expect(err).ToNot(HaveOccurred())
+
+		ingester := new(mockIngester)
+		profile := &RawProfile{RawData: data}
+		input := storage.PutInput{}
+		err = profile.convert(ingester, &input)
+		Expect(err).ToNot(HaveOccurred())
+
+		// TODO: test what was put
+	})
+})

--- a/pkg/convert/speedscope/testdata/simple.speedscope.json
+++ b/pkg/convert/speedscope/testdata/simple.speedscope.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://www.speedscope.app/file-format-schema.json",
+  "profiles": [
+    {
+      "endValue": 14,
+      "events": [
+        {
+          "at": 0,
+          "frame": 0,
+          "type": "O"
+        },
+        {
+          "at": 0,
+          "frame": 1,
+          "type": "O"
+        },
+        {
+          "at": 0,
+          "frame": 2,
+          "type": "O"
+        },
+        {
+          "at": 2,
+          "frame": 2,
+          "type": "C"
+        },
+        {
+          "at": 2,
+          "frame": 3,
+          "type": "O"
+        },
+        {
+          "at": 6,
+          "frame": 3,
+          "type": "C"
+        },
+        {
+          "at": 6,
+          "frame": 2,
+          "type": "O"
+        },
+        {
+          "at": 9,
+          "frame": 2,
+          "type": "C"
+        },
+        {
+          "at": 14,
+          "frame": 1,
+          "type": "C"
+        },
+        {
+          "at": 14,
+          "frame": 0,
+          "type": "C"
+        }
+      ],
+      "name": "simple.txt",
+      "startValue": 0,
+      "type": "evented",
+      "unit": "none"
+    }
+  ],
+  "shared": {
+    "frames": [
+      {
+        "name": "a"
+      },
+      {
+        "name": "b"
+      },
+      {
+        "name": "c"
+      },
+      {
+        "name": "d"
+      }
+    ]
+  },
+  "version": "0.0.1"
+}

--- a/pkg/convert/speedscope/testdata/two-sampled.speedscope.json
+++ b/pkg/convert/speedscope/testdata/two-sampled.speedscope.json
@@ -1,0 +1,46 @@
+{
+  "exporter": "speedscope@0.6.0",
+  "$schema": "https://www.speedscope.app/file-format-schema.json",
+  "name": "Two Samples",
+  "activeProfileIndex": 1,
+  "profiles": [
+    {
+      "type": "sampled",
+      "name": "one",
+      "unit": "seconds",
+      "startValue": 0,
+      "endValue": 14,
+      "samples": [
+        [0, 1, 2],
+        [0, 1, 2],
+        [0, 1, 3],
+        [0, 1, 2],
+        [0, 1]
+      ],
+      "weights": [1, 1, 4, 3, 5]
+    },
+    {
+      "type": "sampled",
+      "name": "two",
+      "unit": "seconds",
+      "startValue": 0,
+      "endValue": 14,
+      "samples": [
+        [0, 1, 2],
+        [0, 1, 2],
+        [0, 1, 3],
+        [0, 1, 2],
+        [0, 1]
+      ],
+      "weights": [1, 1, 4, 3, 5]
+    }
+  ],
+  "shared": {
+    "frames": [
+      { "name": "a" },
+      { "name": "b" },
+      { "name": "c" },
+      { "name": "d" }
+    ]
+  }
+}

--- a/pkg/ingestion/ingestion.go
+++ b/pkg/ingestion/ingestion.go
@@ -23,12 +23,13 @@ type IngestInput struct {
 type Format string
 
 const (
-	FormatPprof  Format = "pprof"
-	FormatJFR    Format = "jfr"
-	FormatTrie   Format = "trie"
-	FormatTree   Format = "tree"
-	FormatLines  Format = "lines"
-	FormatGroups Format = "groups"
+	FormatPprof      Format = "pprof"
+	FormatJFR        Format = "jfr"
+	FormatTrie       Format = "trie"
+	FormatTree       Format = "tree"
+	FormatLines      Format = "lines"
+	FormatGroups     Format = "groups"
+	FormatSpeedscope Format = "speedscope"
 )
 
 type RawProfile interface {

--- a/pkg/server/ingest.go
+++ b/pkg/server/ingest.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pyroscope-io/pyroscope/pkg/convert/speedscope"
 	"github.com/sirupsen/logrus"
 
 	"github.com/pyroscope-io/pyroscope/pkg/agent/types"
@@ -148,6 +149,12 @@ func (h ingestHandler) ingestInputFromRequest(r *http.Request) (*ingestion.Inges
 	case format == "pprof":
 		input.Format = ingestion.FormatPprof
 		input.Profile = &pprof.RawProfile{
+			RawData: b,
+		}
+
+	case format == "speedscope":
+		input.Format = ingestion.FormatSpeedscope
+		input.Profile = &speedscope.RawProfile{
 			RawData: b,
 		}
 


### PR DESCRIPTION
This supports both variants (evented and sampled) of Speedscope's [native format](https://github.com/jlfwong/speedscope/blob/main/src/lib/file-format-spec.ts). This would allow supporting more agents, eg [pyinstrument](https://github.com/joerick/pyinstrument).

Ingestion using the API appears to work with some sample profiles I have lying arounds. I added a couple of fixture tests [from upstream](https://github.com/jlfwong/speedscope/tree/main/sample/profiles/speedscope).

Possible issues:
* Technically, the times in Speedscope format are allowed to be doubles. It looks like they really are non-integers for pyinstrument! But the tree API only allows uint64 weights, and there's no simple way to decide what resolution the client intends.
* It's awkward to figure out the right units. The Speedscope format mixes up the concepts of time-units (s/ms/µs) and measurement-units (bytes/allocations/time). I guess at least for time-based units, we base sampleRate on them?
* It's not obvious to me how we should build keys when there are multiple profiles present of the same type
* It's not obvious how we should tell when to use metadata from the HTTP params vs. the profile format's metadata. Would be nice if we could distinguish between "HTTP param default" vs. "HTTP client explicitly chose this".
* It looks like adhoc mode uses a whole different set of converters, so I didn't build that for Speedscope (yet?)
* Evented mode is often used for flamegraphs, but Pyroscope doesn't really do those, we prefer to aggregate. Seems fine, as long as users expect this.

Closes #172
