### PR TITLE
fix: make adhoc table fit width

### DIFF
--- a/webapp/javascript/components/FileList.module.scss
+++ b/webapp/javascript/components/FileList.module.scss
@@ -40,9 +40,9 @@ $tdHeight: 25px;
       }
 
       &:last-child {
-        width: 150px;
-        min-width: 150px;
-        max-width: 150px;
+        width: 220px;
+        min-width: 220px;
+        max-width: 220px;
         text-align: right;
         padding: 0px 10px;
       }

--- a/webapp/javascript/components/FileList.module.scss
+++ b/webapp/javascript/components/FileList.module.scss
@@ -40,9 +40,9 @@ $tdHeight: 25px;
       }
 
       &:last-child {
-        width: 220px;
-        min-width: 220px;
-        max-width: 220px;
+        width: 250px;
+        min-width: 250px;
+        max-width: 250px;
         padding: 0px 10px;
       }
     }

--- a/webapp/javascript/components/FileList.module.scss
+++ b/webapp/javascript/components/FileList.module.scss
@@ -30,6 +30,11 @@ $tdHeight: 25px;
         text-shadow: 0 0 1px var(--ps-table-row-text-shadow);
       }
 
+      width: 135px;
+      min-width: 135px;
+      max-width: 135px;
+      text-align: right;
+
       &:first-child {
         border-left: none;
         text-align: left;
@@ -43,7 +48,6 @@ $tdHeight: 25px;
         width: 220px;
         min-width: 220px;
         max-width: 220px;
-        text-align: right;
         padding: 0px 10px;
       }
     }

--- a/webapp/javascript/components/FileList.module.scss
+++ b/webapp/javascript/components/FileList.module.scss
@@ -40,11 +40,24 @@ $tdHeight: 25px;
       }
 
       &:last-child {
-        width: 400px;
-        min-width: 400px;
-        max-width: 400px;
+        width: 150px;
+        min-width: 150px;
+        max-width: 150px;
         text-align: right;
         padding: 0px 10px;
+      }
+    }
+
+    .profileName {
+      display: flex;
+      align-items: center;
+
+      span {
+        display: inline-block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        width: calc(100% - 30px);
+        margin-right: 10px;
       }
     }
   }

--- a/webapp/javascript/components/FileList.module.scss
+++ b/webapp/javascript/components/FileList.module.scss
@@ -30,11 +30,6 @@ $tdHeight: 25px;
         text-shadow: 0 0 1px var(--ps-table-row-text-shadow);
       }
 
-      width: 135px;
-      min-width: 135px;
-      max-width: 135px;
-      text-align: right;
-
       &:first-child {
         border-left: none;
         text-align: left;

--- a/webapp/javascript/components/FileList.tsx
+++ b/webapp/javascript/components/FileList.tsx
@@ -30,6 +30,12 @@ const getBodyRows = (
       (profId) => profId === profile.id
     );
 
+    const date = parseISO(profile.updatedAt);
+    const timeString = `${format(date, 'MMM d, yyyy')} at ${format(
+      date,
+      'H:MM'
+    )}`;
+
     acc.push({
       cells: [
         {
@@ -40,7 +46,7 @@ const getBodyRows = (
             </div>
           ),
         },
-        { value: format(parseISO(profile.updatedAt), 'yyyy-MM-dd') },
+        { value: timeString },
       ],
       onClick: () => {
         // Optimize to not reload the same one

--- a/webapp/javascript/components/FileList.tsx
+++ b/webapp/javascript/components/FileList.tsx
@@ -9,8 +9,10 @@ import styles from './FileList.module.scss';
 
 const dateModifiedColName = 'updatedAt';
 const fileNameColName = 'name';
+const suffixColName = 'suffix';
 const headRow = [
   { name: fileNameColName, label: 'Filename', sortable: 1 },
+  { name: suffixColName, label: 'Suffix' },
   {
     name: dateModifiedColName,
     label: 'Date Modified',
@@ -46,6 +48,7 @@ const getBodyRows = (
             </div>
           ),
         },
+        { value: profile?.suffix || '' },
         { value: timeString },
       ],
       onClick: () => {

--- a/webapp/javascript/components/FileList.tsx
+++ b/webapp/javascript/components/FileList.tsx
@@ -36,7 +36,7 @@ const getBodyRows = (
     const date = parseISO(profile.updatedAt);
     const timeString = `${format(date, 'MMM d, yyyy')} at ${format(
       date,
-      'H:MM'
+      'H:mm'
     )}`;
 
     acc.push({

--- a/webapp/javascript/components/FileList.tsx
+++ b/webapp/javascript/components/FileList.tsx
@@ -9,11 +9,8 @@ import styles from './FileList.module.scss';
 
 const dateModifiedColName = 'updatedAt';
 const fileNameColName = 'name';
-const suffixColName = 'suffix';
 const headRow = [
   { name: fileNameColName, label: 'Filename', sortable: 1 },
-  // TODO(dogfrogfog): add sortable prop after BE implementation
-  { name: suffixColName, label: 'Suffix' },
   {
     name: dateModifiedColName,
     label: 'Date Modified',
@@ -49,7 +46,6 @@ const getBodyRows = (
             </div>
           ),
         },
-        { value: profile?.suffix || '' },
         { value: timeString },
       ],
       onClick: () => {

--- a/webapp/javascript/components/FileList.tsx
+++ b/webapp/javascript/components/FileList.tsx
@@ -33,7 +33,7 @@ const getBodyRows = (
     const date = parseISO(profile.updatedAt);
     const timeString = `${format(date, 'MMM d, yyyy')} at ${format(
       date,
-      'H:mm'
+      'h:mm a'
     )}`;
 
     acc.push({

--- a/webapp/javascript/components/FileList.tsx
+++ b/webapp/javascript/components/FileList.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { format, parseISO } from 'date-fns';
 
 import { Maybe } from '@webapp/util/fp';
 import { AllProfiles } from '@webapp/models/adhoc';
@@ -33,13 +34,13 @@ const getBodyRows = (
       cells: [
         {
           value: (
-            <>
-              {profile.name}
+            <div className={styles.profileName}>
+              <span title={profile.name}>{profile.name}</span>
               {isRowSelected && <CheckIcon className={styles.checkIcon} />}
-            </>
+            </div>
           ),
         },
-        { value: profile.updatedAt },
+        { value: format(parseISO(profile.updatedAt), 'yyyy-MM-dd') },
       ],
       onClick: () => {
         // Optimize to not reload the same one

--- a/webapp/javascript/components/FileList.tsx
+++ b/webapp/javascript/components/FileList.tsx
@@ -12,6 +12,7 @@ const fileNameColName = 'name';
 const suffixColName = 'suffix';
 const headRow = [
   { name: fileNameColName, label: 'Filename', sortable: 1 },
+  // TODO(dogfrogfog): add sortable prop after BE implementation
   { name: suffixColName, label: 'Suffix' },
   {
     name: dateModifiedColName,

--- a/webapp/javascript/models/adhoc.ts
+++ b/webapp/javascript/models/adhoc.ts
@@ -6,6 +6,7 @@ export const AllProfilesSchema = z.record(
     id: z.string(),
     name: z.string(),
     updatedAt: z.string(),
+    suffix: z.string().optional(),
   })
 );
 

--- a/webapp/javascript/models/adhoc.ts
+++ b/webapp/javascript/models/adhoc.ts
@@ -6,6 +6,7 @@ export const AllProfilesSchema = z.record(
     id: z.string(),
     name: z.string(),
     updatedAt: z.string(),
+    // TODO(dogfrogfog): remove .optional() after BE implementation
     suffix: z.string().optional(),
   })
 );

--- a/webapp/javascript/models/adhoc.ts
+++ b/webapp/javascript/models/adhoc.ts
@@ -6,8 +6,6 @@ export const AllProfilesSchema = z.record(
     id: z.string(),
     name: z.string(),
     updatedAt: z.string(),
-    // TODO(dogfrogfog): remove .optional() after BE implementation
-    suffix: z.string().optional(),
   })
 );
 

--- a/webapp/javascript/ui/Table.module.scss
+++ b/webapp/javascript/ui/Table.module.scss
@@ -1,5 +1,6 @@
 .table {
   width: 100%;
+  table-layout: fixed;
 
   thead th {
     &.sortable {


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1581

## Changes
- make adhoc table fit width
- change adhoc table time format to _MMM d, yyyy_ at _H:mm_ 
- add "tooltip" (`title` span attribute) to Filename cells
- ~~add suffix column, the `suffix` value should be part of `/api/adhoc/v1/profiles` reponse~~

<img width="1127" alt="Screenshot 2022-10-05 at 12 28 33" src="https://user-images.githubusercontent.com/47758224/194039895-183a4841-a6c7-4fe7-87b3-498df673dc59.png">
<img width="1073" alt="Screenshot 2022-10-05 at 12 25 59" src="https://user-images.githubusercontent.com/47758224/194039900-79028db7-e356-4d66-912c-949b2c868cfa.png">



## Concerns
- ~~FileNames column values are hidden when  screen width is small (thats not a problem since we are adding suffix column?)~~
<img width="850" alt="Screenshot 2022-10-05 at 12 27 16" src="https://user-images.githubusercontent.com/47758224/194040569-72a4679d-e1ac-4358-9b10-2d07ae69452a.png">
