### PR TITLE
build: skip publish npm if user not part of pyroscope org

### DIFF
--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - run: echo ${{ needs.check.outputs.inputsChecked }}
   build:
+    if: ${{ needs.check.outputs.inputsChecked == 'true'
     runs-on: ubuntu-latest
     needs: check
     steps:

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     # Don't run if not created by one member of pyroscope org
-    if: needs.check.github_token_gate.outputs.inputsChecked == 'true'
+    if: needs.check.github_token_gate.outputs.inputsChecked == 'false'
     steps:
       #######################
       #      Checkout      #

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -17,7 +17,8 @@ jobs:
         with:
           inputsToCheck: 'token'
         env:
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          # token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_GITHUB_TOKEN2 }}
   test:
     runs-on: ubuntu-latest
     needs: check
@@ -26,8 +27,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: check
-    # Don't run if not created by one member of pyroscope org
-    if: ${{ needs.check.outputs.inputsChecked }} == 'true'
     steps:
       #######################
       #      Checkout      #

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     # Don't run if not created by one member of pyroscope org
-    if: needs.check.github_token_gate.outputs.inputsChecked == 'false'
+    if: needs.check.github_token_gate.outputs.inputsChecked == 'true'
     steps:
       #######################
       #      Checkout      #

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     # Don't run if not created by one member of pyroscope org
-    if: needs.check.github_token_gate.outputs.inputsChecked == 'true'
+    if: needs.check.github_token_gate.outputs.inputsChecked == true
     steps:
       #######################
       #      Checkout      #

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - run: echo ${{ needs.check.outputs.inputsChecked }}
   build:
-    if: ${{ needs.check.outputs.inputsChecked }} == 'true'
+    if: needs.check.outputs.inputsChecked == 'true'
     runs-on: ubuntu-latest
     needs: check
     steps:

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    outputs:
+      inputsChecked: ${{ steps.check.outputs.inputsChecked }}
     steps:
       - uses: svrooij/secret-gate-action@v1
         id: github_token_gate
@@ -20,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     # Don't run if not created by one member of pyroscope org
-    if: steps.github_token_gate.outputs.inputsChecked == 'true'
+    if: needs.check.github_token_gate.outputs.inputsChecked == 'true'
     steps:
-      # For non-pull requests, fetch all tags
       #######################
       #      Checkout      #
       ######################
+      # For non-pull requests, fetch all tags
       - uses: actions/checkout@v2
         if: github.event_name != 'pull_request'
         with:

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     # Don't run if not created by one member of pyroscope org
-    if: needs.check.outputs.inputsChecked == true
+    if: ${{ needs.check.outputs.inputsChecked }} == 'true'
     steps:
       #######################
       #      Checkout      #

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -17,8 +17,7 @@ jobs:
         with:
           inputsToCheck: 'token'
         env:
-          # token: ${{ secrets.BOT_GITHUB_TOKEN }}
-          token: ${{ secrets.BOT_GITHUB_TOKEN2 }}
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
   test:
     runs-on: ubuntu-latest
     needs: check

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -7,20 +7,30 @@ on:
     branches: [main]
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: svrooij/secret-gate-action@v1
+        id: github_token_gate
+        with:
+          inputsToCheck: 'token'
+        env:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
   build:
     runs-on: ubuntu-latest
-    # Don't run for forks
+    needs: check
+    # Don't run if not created by one member of pyroscope org
+    if: steps.github_token_gate.outputs.inputsChecked == 'true'
     steps:
+      # For non-pull requests, fetch all tags
       #######################
       #      Checkout      #
       ######################
-      # For non-pull requests, fetch all tags
       - uses: actions/checkout@v2
         if: github.event_name != 'pull_request'
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
-
       # For pull requests, also checkout out the REAL commit (as opposed to a merge commit with main)
       - uses: actions/checkout@v2
         if: github.event_name == 'pull_request'

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -18,12 +18,8 @@ jobs:
           inputsToCheck: 'token'
         env:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
-  test:
-    runs-on: ubuntu-latest
-    needs: check
-    steps:
-      - run: echo ${{ needs.check.outputs.inputsChecked }}
   build:
+    # skip if user has not access to the token
     if: needs.check.outputs.inputsChecked == 'true'
     runs-on: ubuntu-latest
     needs: check

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - run: echo ${{ needs.check.outputs.inputsChecked }}
   build:
-    if: ${{ needs.check.outputs.inputsChecked == 'true'
+    if: ${{ needs.check.outputs.inputsChecked }} == 'true'
     runs-on: ubuntu-latest
     needs: check
     steps:

--- a/.github/workflows/publish-lib-to-npm.yml
+++ b/.github/workflows/publish-lib-to-npm.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     outputs:
-      inputsChecked: ${{ steps.check.outputs.inputsChecked }}
+      inputsChecked: ${{ steps.github_token_gate.outputs.inputsChecked }}
     steps:
       - uses: svrooij/secret-gate-action@v1
         id: github_token_gate
@@ -18,11 +18,16 @@ jobs:
           inputsToCheck: 'token'
         env:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
+  test:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - run: echo ${{ needs.check.outputs.inputsChecked }}
   build:
     runs-on: ubuntu-latest
     needs: check
     # Don't run if not created by one member of pyroscope org
-    if: needs.check.github_token_gate.outputs.inputsChecked == true
+    if: needs.check.outputs.inputsChecked == true
     steps:
       #######################
       #      Checkout      #


### PR DESCRIPTION
Previously when PRs were created by a non member of the pyroscope org, this `checkout` step would fail, due to the lack of access to the secrets:

![image](https://user-images.githubusercontent.com/6951209/193899420-a30a625a-e537-4308-b9fb-9aeba2635fbf.png)

This PR basically skips the entire pipeline if that secret is not present.
