### PR TITLE
fix: update regexes for deleted so names

### DIFF
--- a/pkg/convert/jfr/parser.go
+++ b/pkg/convert/jfr/parser.go
@@ -274,7 +274,8 @@ var zstdJniSoLibName = regexp.MustCompile("^(\\.?/tmp/)?(libzstd-jni-\\d+\\.\\d+
 var amazonCorrettoCryptoProvider = regexp.MustCompile("^(\\.?/tmp/)?(libamazonCorrettoCryptoProvider)([0-9a-f]{16})(\\.so)( \\(deleted\\))?$")
 
 // libasyncProfiler-linux-arm64-17b9a1d8156277a98ccc871afa9a8f69215f92.so
-var pyroscopeAsyncProfiler = regexp.MustCompile("^(\\.?/tmp/)?(libasyncProfiler)-(linux-arm64|linux-musl-x64|linux-x64|macos)-(17b9a1d8156277a98ccc871afa9a8f69215f92)(\\.so)( \\(deleted\\))?$")
+var pyroscopeAsyncProfiler = regexp.MustCompile(
+	"^(\\.?/tmp/)?(libasyncProfiler)-(linux-arm64|linux-musl-x64|linux-x64|macos)-(17b9a1d8156277a98ccc871afa9a8f69215f92)(\\.so)( \\(deleted\\))?$")
 
 func mergeJVMGeneratedClasses(frame string) string {
 	frame = generatedMethodAccessor.ReplaceAllString(frame, "${1}_")

--- a/pkg/convert/jfr/parser.go
+++ b/pkg/convert/jfr/parser.go
@@ -268,20 +268,20 @@ var generatedMethodAccessor = regexp.MustCompile("^(jdk/internal/reflect/Generat
 var lambdaGeneratedEnclosingClass = regexp.MustCompile("^(.+\\$\\$Lambda\\$)\\d+[./](0x[\\da-f]+|\\d+)$")
 
 // libzstd-jni-1.5.1-16931311898282279136.so.Java_com_github_luben_zstd_ZstdInputStreamNoFinalizer_decompressStream
-var zstdJniSoLibName = regexp.MustCompile("^(libzstd-jni-\\d+\\.\\d+\\.\\d+-)(\\d+)(\\.so)$")
+var zstdJniSoLibName = regexp.MustCompile("^(\\.?/tmp/)?(libzstd-jni-\\d+\\.\\d+\\.\\d+-)(\\d+)(\\.so)( \\(deleted\\))?$")
 
 // ./tmp/libamazonCorrettoCryptoProvider109b39cf33c563eb.so
-var amazonCorrettoCryptoProvider = regexp.MustCompile("^\\./tmp/(libamazonCorrettoCryptoProvider)([0-9a-f]{16})(\\.so)$")
+var amazonCorrettoCryptoProvider = regexp.MustCompile("^(\\.?/tmp/)?(libamazonCorrettoCryptoProvider)([0-9a-f]{16})(\\.so)( \\(deleted\\))?$")
 
 // libasyncProfiler-linux-arm64-17b9a1d8156277a98ccc871afa9a8f69215f92.so
-var pyroscopeAsyncProfiler = regexp.MustCompile("^(libasyncProfiler)-(linux-arm64|linux-musl-x64|linux-x64|macos)-(17b9a1d8156277a98ccc871afa9a8f69215f92)(\\.so)$")
+var pyroscopeAsyncProfiler = regexp.MustCompile("^(\\.?/tmp/)?(libasyncProfiler)-(linux-arm64|linux-musl-x64|linux-x64|macos)-(17b9a1d8156277a98ccc871afa9a8f69215f92)(\\.so)( \\(deleted\\))?$")
 
 func mergeJVMGeneratedClasses(frame string) string {
 	frame = generatedMethodAccessor.ReplaceAllString(frame, "${1}_")
 	frame = lambdaGeneratedEnclosingClass.ReplaceAllString(frame, "${1}_")
-	frame = zstdJniSoLibName.ReplaceAllString(frame, "${1}_${3}")
-	frame = amazonCorrettoCryptoProvider.ReplaceAllString(frame, "${1}_${3}")
-	frame = pyroscopeAsyncProfiler.ReplaceAllString(frame, "${1}-${2}-_${4}")
+	frame = zstdJniSoLibName.ReplaceAllString(frame, "libzstd-jni-_.so")
+	frame = amazonCorrettoCryptoProvider.ReplaceAllString(frame, "libamazonCorrettoCryptoProvider_.so")
+	frame = pyroscopeAsyncProfiler.ReplaceAllString(frame, "libasyncProfiler-_.so")
 	return frame
 }
 

--- a/pkg/convert/jfr/parser_jvm_generated_class_merge_test.go
+++ b/pkg/convert/jfr/parser_jvm_generated_class_merge_test.go
@@ -6,60 +6,82 @@ import (
 )
 
 var _ = ginkgo.Describe("mergeJVMGeneratedClasses", func() {
-	ginkgo.It("merges GeneratedMethodAccessor classes", func() {
-		src := "jdk/internal/reflect/GeneratedMethodAccessor31"
-		res := mergeJVMGeneratedClasses(src)
-		Expect(res).To(Equal("jdk/internal/reflect/GeneratedMethodAccessor_"))
-	})
-
-	ginkgo.It("does nothing for regular frames", func() {
-		src := "java/util/concurrent/Executors$RunnableAdapter"
-		res := mergeJVMGeneratedClasses(src)
-		Expect(res).To(Equal(src))
-	})
-
-	ginkgo.It("merges Lambdas", func() {
-		src := "org/example/rideshare/EnclosingClass$$Lambda$8/0x0000000800c01220"
-		res := mergeJVMGeneratedClasses(src)
-		Expect(res).To(Equal("org/example/rideshare/EnclosingClass$$Lambda$_"))
-	})
-
-	ginkgo.It("merges old Lambdas", func() {
-		src := "org/example/rideshare/EnclosingClass$$Lambda$4/1283928880"
-		res := mergeJVMGeneratedClasses(src)
-		Expect(res).To(Equal("org/example/rideshare/EnclosingClass$$Lambda$_"))
-	})
-
-	ginkgo.It("merges zstd com_github_luben_zstd", func() {
-		src := "libzstd-jni-1.5.1-16931311898282279136.so"
-		res := mergeJVMGeneratedClasses(src)
-		Expect(res).To(Equal("libzstd-jni-1.5.1-_.so"))
-	})
-
-	ginkgo.It("merges amazon correto crypto provider", func() {
-		src := "./tmp/libamazonCorrettoCryptoProvider109b39cf33c563eb.so"
-		res := mergeJVMGeneratedClasses(src)
-		Expect(res).To(Equal("libamazonCorrettoCryptoProvider_.so"))
-	})
-
-	ginkgo.When("async-profiler", func() {
-		testcases := [][]string{
-			{"libasyncProfiler-linux-arm64-17b9a1d8156277a98ccc871afa9a8f69215f92.so",
-				"libasyncProfiler-linux-arm64-_.so"},
-			{"libasyncProfiler-linux-musl-x64-17b9a1d8156277a98ccc871afa9a8f69215f92.so",
-				"libasyncProfiler-linux-musl-x64-_.so"},
-			{"libasyncProfiler-linux-x64-17b9a1d8156277a98ccc871afa9a8f69215f92.so",
-				"libasyncProfiler-linux-x64-_.so"},
-			{"libasyncProfiler-macos-17b9a1d8156277a98ccc871afa9a8f69215f92.so",
-				"libasyncProfiler-macos-_.so"},
-		}
-		for _, testcase := range testcases {
-			src := testcase[0]
-			expectedRes := testcase[1]
-			ginkgo.It("merges different versions "+src, func() {
-				res := mergeJVMGeneratedClasses(src)
-				Expect(res).To(Equal(expectedRes))
-			})
-		}
+	ginkgo.When("we parse jfr", func() {
+		ginkgo.When("we process jvm generated classes", func() {
+			testcases := [][]string{
+				{
+					"org/example/rideshare/EnclosingClass$$Lambda$4/1283928880",
+					"org/example/rideshare/EnclosingClass$$Lambda$_",
+				},
+				{
+					"org/example/rideshare/EnclosingClass$$Lambda$8/0x0000000800c01220",
+					"org/example/rideshare/EnclosingClass$$Lambda$_",
+				},
+				{
+					"java/util/concurrent/Executors$RunnableAdapter",
+					"java/util/concurrent/Executors$RunnableAdapter",
+				},
+				{
+					"jdk/internal/reflect/GeneratedMethodAccessor31",
+					"jdk/internal/reflect/GeneratedMethodAccessor_",
+				},
+			}
+			for _, testcase := range testcases {
+				src := testcase[0]
+				expectedRes := testcase[1]
+				ginkgo.It("merges so names - "+src, func() {
+					res := mergeJVMGeneratedClasses(src)
+					Expect(res).To(Equal(expectedRes))
+				})
+			}
+		})
+		ginkgo.When("we process shared libraries names", func() {
+			testcases := [][]string{
+				{
+					"libasyncProfiler-linux-arm64-17b9a1d8156277a98ccc871afa9a8f69215f92.so",
+					"libasyncProfiler-_.so",
+				},
+				{
+					"libasyncProfiler-linux-musl-x64-17b9a1d8156277a98ccc871afa9a8f69215f92.so",
+					"libasyncProfiler-_.so",
+				},
+				{
+					"libasyncProfiler-linux-x64-17b9a1d8156277a98ccc871afa9a8f69215f92.so",
+					"libasyncProfiler-_.so",
+				},
+				{
+					"libasyncProfiler-macos-17b9a1d8156277a98ccc871afa9a8f69215f92.so",
+					"libasyncProfiler-_.so",
+				},
+				{
+					"libamazonCorrettoCryptoProvider109b39cf33c563eb.so",
+					"libamazonCorrettoCryptoProvider_.so",
+				},
+				{
+					"libzstd-jni-1.5.1-16931311898282279136.so",
+					"libzstd-jni-_.so",
+				},
+			}
+			for _, testcase := range testcases {
+				src := testcase[0]
+				expectedRes := testcase[1]
+				ginkgo.It("merges generated so names - "+src, func() {
+					res := mergeJVMGeneratedClasses(src)
+					Expect(res).To(Equal(expectedRes))
+				})
+				ginkgo.It("merges generated so names even deleted - "+src, func() {
+					res := mergeJVMGeneratedClasses(src + " (deleted)")
+					Expect(res).To(Equal(expectedRes))
+				})
+				ginkgo.It("merges generated so names even deleted inside with /tmp prefix - "+src, func() {
+					res := mergeJVMGeneratedClasses("/tmp/" + src + " (deleted)")
+					Expect(res).To(Equal(expectedRes))
+				})
+				ginkgo.It("merges generated so names even deleted inside with ./tmp prefix - "+src, func() {
+					res := mergeJVMGeneratedClasses("./tmp/" + src + " (deleted)")
+					Expect(res).To(Equal(expectedRes))
+				})
+			}
+		})
 	})
 })


### PR DESCRIPTION
`./tmp/libamazonCorrettoCryptoProvider5bc2d45365367baa.so (deleted)`
update jfr symbol merge regexps for 
- ` (deleted)` suffix
- `/tmp` prefix
- `./tmp` prefix