### PR TITLE
fix(webapp): make app selector/timerange dropdowns to be above loading overlay

### DIFF
--- a/webapp/javascript/components/AppSelector/AppSelector.module.scss
+++ b/webapp/javascript/components/AppSelector/AppSelector.module.scss
@@ -14,6 +14,7 @@
     width: 600px;
     right: unset;
     left: -100px;
+    z-index: 999;
   }
 
   .headerTitle {

--- a/webapp/sass/components/daterangepicker.scss
+++ b/webapp/sass/components/daterangepicker.scss
@@ -33,8 +33,8 @@
     box-shadow: 0px 10px 20px var(--ps-dropdown-shadow);
     border-radius: 4px;
 
-    // 2 so that it's above the '.tags-bar .tags-highlighted' element
-    z-index: 2;
+    // so that's above any overlay
+    z-index: 999;
   }
 
   h4:nth-child(1),


### PR DESCRIPTION
Before:
<img width="629" alt="Screen Shot 2022-10-14 at 09 30 12" src="https://user-images.githubusercontent.com/6951209/195847373-92668466-2abe-4f07-9d43-78546ae2123f.png">

After:
![Screenshot 2022-10-14 at 09-24-27 Single pyroscope server cpu{} Pyroscope](https://user-images.githubusercontent.com/6951209/195846977-addd7034-088b-4915-baa8-99fe7dcbd33f.png)


---
Implementation: values may seem arbitrary, but the intention is to create different layers (0-9, 10-99, 100-999 etc). Didn't think too much through about this so feel free to change if a better approach comes up.