### PR TITLE
fix: disable ptrace capability check for dotnetspy

### DIFF
--- a/examples/dotnet/fast-slow/docker-compose.yml
+++ b/examples/dotnet/fast-slow/docker-compose.yml
@@ -9,5 +9,3 @@ services:
       - 'server'
   app:
     build: ''
-    cap_add:
-      - SYS_PTRACE

--- a/examples/dotnet/web/docker-compose.yml
+++ b/examples/dotnet/web/docker-compose.yml
@@ -13,5 +13,3 @@ services:
     ports:
       - '5000:5000'
     build: ''
-    cap_add:
-      - SYS_PTRACE

--- a/pkg/exec/cli_linux.go
+++ b/pkg/exec/cli_linux.go
@@ -7,18 +7,17 @@ import (
 )
 
 func performOSChecks(spyName string) error {
-	if disableLinuxChecks {
-		return nil
-	}
-	if spyName == "ebpfspy" {
+	var err error
+	switch {
+	case disableLinuxChecks:
+	case spyName == "dotnetspy":
+	case spyName == "ebpfspy":
 		if !isRoot() {
-			return errors.New("when using eBPF you're required to run the agent with sudo")
+			err = errors.New("when using eBPF you're required to run the agent with sudo")
 		}
-	} else {
-		if !caps.HasSysPtraceCap() {
-			return errors.New("if you're running pyroscope in a Docker container, add --cap-add=sys_ptrace. " +
-				"See our Docker Guide for more information: https://pyroscope.io/docs/docker-guide")
-		}
+	case !caps.HasSysPtraceCap():
+		err = errors.New("if you're running pyroscope in a Docker container, add --cap-add=sys_ptrace. " +
+			"See our Docker Guide for more information: https://pyroscope.io/docs/docker-guide")
 	}
-	return nil
+	return err
 }


### PR DESCRIPTION
`dotnetspy` currently requires setting `SYS_PTRACE` capability when running on linux. However, this check is redundant: ptrace is never called by the agent.