### PR TITLE
fix: close databases in deterministic order

### DIFF
--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -134,15 +134,6 @@ func (s *Storage) newBadger(name string, p Prefix, codec cache.Codec) (BadgerDBW
 	return d, nil
 }
 
-func (d *db) Close() {
-	if d.Cache != nil {
-		d.Cache.Flush()
-	}
-	if err := d.DB.Close(); err != nil {
-		d.logger.WithError(err).Error("closing database")
-	}
-}
-
 func (d *db) Size() bytesize.ByteSize {
 	// The value is updated once per minute.
 	lsm, vlog := d.DB.Size()

--- a/pkg/storage/types.go
+++ b/pkg/storage/types.go
@@ -124,7 +124,6 @@ type BadgerDBWithCache interface {
 	BadgerDB
 	CacheLayer
 
-	Close()
 	Size() bytesize.ByteSize
 	CacheSize() uint64
 


### PR DESCRIPTION
The aim is to close databases and flush caches in deterministic order and allow using a single BadgerDB instance.