### PR TITLE
perf: optimize segment key parser allocations

### DIFF
--- a/pkg/storage/segment/key.go
+++ b/pkg/storage/segment/key.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pyroscope-io/pyroscope/pkg/flameql"
@@ -33,7 +34,9 @@ func NewKey(labels map[string]string) *Key { return &Key{labels: labels} }
 
 func ParseKey(name string) (*Key, error) {
 	k := &Key{labels: make(map[string]string)}
-	p := parser{parserState: nameParserState}
+	p := parserPool.Get().(*parser)
+	defer parserPool.Put(p)
+	p.reset()
 	var err error
 	for _, r := range name + "{" {
 		switch p.parserState {
@@ -53,8 +56,24 @@ func ParseKey(name string) (*Key, error) {
 
 type parser struct {
 	parserState ParserState
-	key         string
-	value       string
+	key         *strings.Builder
+	value       *strings.Builder
+}
+
+var parserPool = sync.Pool{
+	New: func() any {
+		return &parser{
+			parserState: nameParserState,
+			key:         new(strings.Builder),
+			value:       new(strings.Builder),
+		}
+	},
+}
+
+func (p *parser) reset() {
+	p.parserState = nameParserState
+	p.key.Reset()
+	p.value.Reset()
 }
 
 // ParseKey's nameParserState switch case
@@ -62,45 +81,45 @@ func (p *parser) nameParserCase(r int32, k *Key) error {
 	switch r {
 	case '{':
 		p.parserState = tagKeyParserState
-		appName := strings.TrimSpace(p.value)
+		appName := strings.TrimSpace(p.value.String())
 		if err := flameql.ValidateAppName(appName); err != nil {
 			return err
 		}
 		k.labels["__name__"] = appName
 	default:
-		p.value += string(r)
+		p.value.WriteRune(r)
 	}
 	return nil
 }
 
 // ParseKey's tagKeyParserState switch case
-func (p *parser) tagKeyParserCase(r int32) {
+func (p *parser) tagKeyParserCase(r rune) {
 	switch r {
 	case '}':
 		p.parserState = doneParserState
 	case '=':
 		p.parserState = tagValueParserState
-		p.value = ""
+		p.value.Reset()
 	default:
-		p.key += string(r)
+		p.key.WriteRune(r)
 	}
 }
 
 // ParseKey's tagValueParserState switch case
-func (p *parser) tagValueParserCase(r int32, k *Key) error {
+func (p *parser) tagValueParserCase(r rune, k *Key) error {
 	switch r {
 	case ',', '}':
 		p.parserState = tagKeyParserState
-		key := strings.TrimSpace(p.key)
+		key := strings.TrimSpace(p.key.String())
 		if !flameql.IsTagKeyReserved(key) {
 			if err := flameql.ValidateTagKey(key); err != nil {
 				return err
 			}
 		}
-		k.labels[key] = strings.TrimSpace(p.value)
-		p.key = ""
+		k.labels[key] = strings.TrimSpace(p.value.String())
+		p.key.Reset()
 	default:
-		p.value += string(r)
+		p.value.WriteRune(r)
 	}
 	return nil
 }

--- a/pkg/storage/segment/key.go
+++ b/pkg/storage/segment/key.go
@@ -1,6 +1,7 @@
 package segment
 
 import (
+	"bytes"
 	"errors"
 	"strconv"
 	"strings"
@@ -56,16 +57,16 @@ func ParseKey(name string) (*Key, error) {
 
 type parser struct {
 	parserState ParserState
-	key         *strings.Builder
-	value       *strings.Builder
+	key         *bytes.Buffer
+	value       *bytes.Buffer
 }
 
 var parserPool = sync.Pool{
 	New: func() any {
 		return &parser{
 			parserState: nameParserState,
-			key:         new(strings.Builder),
-			value:       new(strings.Builder),
+			key:         new(bytes.Buffer),
+			value:       new(bytes.Buffer),
 		}
 	},
 }

--- a/pkg/storage/segment/key_bech_test.go
+++ b/pkg/storage/segment/key_bech_test.go
@@ -1,0 +1,45 @@
+package segment
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkKey_Parse(b *testing.B) {
+	const (
+		labelsSize = 10
+		minLen     = 6
+		maxLen     = 16
+	)
+
+	// Duplicates are okay.
+	labels := make(map[string]string, labelsSize+1)
+	for i := 0; i < labelsSize; i++ {
+		labels[randString(randInt(minLen, maxLen))] = randString(randInt(minLen, maxLen))
+	}
+
+	labels["__name__"] = "benchmark.key.parse"
+	keyStr := NewKey(labels).Normalized()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		if _, err := ParseKey(keyStr); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// TODO(kolesnikovae): This is not near perfect way of generating strings.
+//  It makes sense to create a package for util functions like this.
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func randString(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
In certain scenarios we observe surprisingly high CPU consumption and allocation rate in the key parser:

<img src="https://user-images.githubusercontent.com/12090599/196393251-02827e76-33e7-42e1-a0c4-c3a14375dc14.png" width=50% height=50%>

<img src="https://user-images.githubusercontent.com/12090599/196393269-d75ac480-a7d4-4591-8588-45b9fb22bf10.png" width=50% height=50%>

This is a quick and safe optimisation that should decrease the overall CPU time consumption by ~3-5% (GC will have to do less work):

Before:
```
BenchmarkKey_Parse-10    	  142854	      8411 ns/op	    4178 B/op	     445 allocs/op
```

After:
```
BenchmarkKey_Parse-10    	  456100	      2302 ns/op	    1475 B/op	      26 allocs/op
```

Further optimisation may replace the labels map with a slice.