### PR TITLE
fix(webapp): make ui consistent when request is cancelled

### DIFF
--- a/webapp/javascript/redux/reducers/continuous.ts
+++ b/webapp/javascript/redux/reducers/continuous.ts
@@ -233,7 +233,7 @@ export const fetchSingleView = createAsyncThunk<
   }
 
   if (res.isErr && res.error instanceof RequestAbortedError) {
-    return thunkAPI.rejectWithValue({ rejectedWithValue: 'reloading' });
+    return Promise.reject(res.error);
   }
 
   thunkAPI.dispatch(
@@ -728,7 +728,19 @@ export const continuousSlice = createSlice({
       state.refreshToken = Math.random().toString();
     },
   },
+
   extraReducers: (builder) => {
+    /**********************/
+    /* GENERAL GUIDELINES */
+    /**********************/
+
+    // There are (currently) only 2 ways an action can be aborted:
+    // 1. The component is unmounting, eg when changing route
+    // 2. New data is loading, which means previous request is going to be superseeded
+    // In both cases, not doing state transitions is fine
+    // Specially in the second case, where a 'rejected' may happen AFTER a 'pending' is dispatched
+    // https://redux-toolkit.js.org/api/createAsyncThunk#checking-if-a-promise-rejection-was-from-an-error-or-cancellation
+
     /*************************/
     /*      Single View      */
     /*************************/
@@ -759,31 +771,19 @@ export const continuousSlice = createSlice({
     });
 
     builder.addCase(fetchSingleView.rejected, (state, action) => {
-      switch (state.singleView.type) {
-        // if previous state is loaded, let's continue displaying data
-        case 'reloading': {
-          let type: SingleView['type'] = 'reloading';
-          if (action.meta.rejectedWithValue) {
-            type = (
-              action?.payload as { rejectedWithValue: SingleView['type'] }
-            )?.rejectedWithValue;
-          } else if (action.error.message === 'cancel') {
-            type = 'loaded';
-          }
-          state.singleView = {
-            ...state.singleView,
-            type,
-          };
-          break;
-        }
-
-        default: {
-          // it failed to load for the first time, so far all effects it's pristine
-          state.singleView = {
-            type: 'pristine',
-          };
-        }
+      // There are (currently) only 2 ways an action can be aborted:
+      // 1. The component is unmounting, eg when changing route
+      // 2. New data is loading, which means previous request is going to be superseeded
+      // In both cases, not doing state transitions is fine
+      // Specially in the second case, where a 'rejected' may happen AFTER a 'pending' is dispatched
+      // https://redux-toolkit.js.org/api/createAsyncThunk#checking-if-a-promise-rejection-was-from-an-error-or-cancellation
+      if (action.meta.aborted) {
+        return;
       }
+
+      state.singleView = {
+        type: 'pristine',
+      };
     });
 
     /*****************************/
@@ -820,21 +820,13 @@ export const continuousSlice = createSlice({
     builder.addCase(fetchComparisonSide.rejected, (state, action) => {
       const { side } = action.meta.arg;
 
-      if (action?.meta?.rejectedWithValue) {
-        state.comparisonView[side] = {
-          profile: state.comparisonView[side].profile as Profile,
-          type: (
-            action?.payload as {
-              rejectedWithValue: ComparisonView['left' | 'right']['type'];
-            }
-          )?.rejectedWithValue,
-        };
-      } else {
-        state.comparisonView[side] = {
-          profile: state.comparisonView[side].profile as Profile,
-          type: 'loaded',
-        };
+      if (action.meta.aborted) {
+        return;
       }
+
+      state.comparisonView[side] = {
+        type: 'pristine',
+      };
     });
 
     /*****************************/
@@ -896,24 +888,13 @@ export const continuousSlice = createSlice({
       };
     });
     builder.addCase(fetchDiffView.rejected, (state, action) => {
-      switch (state.diffView.type) {
-        case 'reloading': {
-          state.diffView = {
-            profile: state.diffView.profile,
-            type: action.meta.rejectedWithValue
-              ? (action?.payload as { rejectedWithValue: DiffView['type'] })
-                  ?.rejectedWithValue
-              : 'loaded',
-          };
-          break;
-        }
-
-        default: {
-          state.diffView = {
-            type: 'pristine',
-          };
-        }
+      if (action.meta.aborted) {
+        return;
       }
+
+      state.diffView = {
+        type: 'pristine',
+      };
     });
 
     /*******************************/


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/1620

The problem is stated in the issue. 

To give more context, imagine the user has some data loading (let's call it `A`), then changes the app. The `useEffect` cleanup calls the action's abort. 
https://github.com/pyroscope-io/pyroscope/blob/f9f7d4c4fde0221419783fbf3ccb39c1986f3146/webapp/javascript/pages/ContinuousSingleView.tsx#L49

Then a new dispatch is sent https://github.com/pyroscope-io/pyroscope/blob/f9f7d4c4fde0221419783fbf3ccb39c1986f3146/webapp/javascript/pages/ContinuousSingleView.tsx#L48

Naturally one would think that the cancellation happens before the new dispatch. However, since the abort is only acted in the thunk 
https://github.com/pyroscope-io/pyroscope/blob/f9f7d4c4fde0221419783fbf3ccb39c1986f3146/webapp/javascript/redux/reducers/continuous.ts#L332-L334

It happens asynchronously, ie `dispatch fetchSingleView` happens which in the reducer we get `fetchSingleView/pending`, then `fetchSingleView/rejected` happens for the `A` data. However, at that point the state is `reloading` (due to `fetchSingleView/pending`). So cancelling it makes the UI inconsistent, since we still have data loading!

The simplest solution is to just ignore state transitions when it's rejection case is `abort` (ie thunk is running)

---

Another important point is that now, if the request fails, we don't show any data. Previously we would show stale data so that the user could interact with loaded data even if the server is down, but it turns out to be more trouble than it's worth, since it's never clear one is looking at stale data or not.


Previously:

https://user-images.githubusercontent.com/6951209/197541493-5b998c52-f877-4566-98fb-ca95b97c5503.mov


Now:

https://user-images.githubusercontent.com/6951209/197541256-75ee73ec-d7ac-4f06-9ec5-76f399939f4f.mov
