### PR TITLE
chore(webapp): identify server returned HTML

### DIFF
--- a/webapp/javascript/services/base.spec.ts
+++ b/webapp/javascript/services/base.spec.ts
@@ -218,7 +218,7 @@ describe('Base HTTP', () => {
 
       expect(res.error).toBeInstanceOf(ResponseNotOkInHTMLFormat);
       expect(res.error.message).toBe(
-        "Server returned with code: '500'. The body contains a HTML page"
+        "Server returned with code: '500'. The body contains an HTML page"
       );
     });
   });

--- a/webapp/javascript/services/base.ts
+++ b/webapp/javascript/services/base.ts
@@ -171,7 +171,15 @@ export async function request(
     } catch (e) {
       // We couldn't parse, but there's definitly some data
       // We must handle this case since the go server sometimes responds with plain text
-      // TODO(eh-am): identify it's html
+
+      // It's HTML
+      // Which normally happens when hitting a broken URL, which makes the server return the SPA
+      // Poor heuristic for identifying it's a html file
+      if (/<\/?[a-z][\s\S]*>/i.test(textBody)) {
+        return Result.err(
+          new ResponseNotOkInHTMLFormat(response.status, textBody)
+        );
+      }
       return Result.err(new RequestNotOkError(response.status, textBody));
     }
   }

--- a/webapp/javascript/services/base.ts
+++ b/webapp/javascript/services/base.ts
@@ -40,7 +40,7 @@ export class RequestNotOkWithErrorsList extends CustomError {
 export class ResponseNotOkInHTMLFormat extends CustomError {
   public constructor(public code: number, public body: string) {
     super(
-      `Server returned with code: '${code}'. The body contains a HTML page`
+      `Server returned with code: '${code}'. The body contains an HTML page`
     );
   }
 }

--- a/webapp/javascript/services/base.ts
+++ b/webapp/javascript/services/base.ts
@@ -37,6 +37,14 @@ export class RequestNotOkWithErrorsList extends CustomError {
   }
 }
 
+export class ResponseNotOkInHTMLFormat extends CustomError {
+  public constructor(public code: number, public body: string) {
+    super(
+      `Server returned with code: '${code}'. The body contains a HTML page`
+    );
+  }
+}
+
 export class ResponseOkNotInJSONFormat extends CustomError {
   public constructor(public code: number, public body: string) {
     super(
@@ -49,7 +57,8 @@ export type RequestError =
   | RequestNotOkError
   | RequestNotOkWithErrorsList
   | RequestIncompleteError
-  | ResponseOkNotInJSONFormat;
+  | ResponseOkNotInJSONFormat
+  | ResponseNotOkInHTMLFormat;
 
 function join(base: string, path: string): string {
   path = path.replace(/^\/+/, '');
@@ -162,6 +171,7 @@ export async function request(
     } catch (e) {
       // We couldn't parse, but there's definitly some data
       // We must handle this case since the go server sometimes responds with plain text
+      // TODO(eh-am): identify it's html
       return Result.err(new RequestNotOkError(response.status, textBody));
     }
   }

--- a/webapp/javascript/services/testdata/example.html
+++ b/webapp/javascript/services/testdata/example.html
@@ -1,0 +1,55 @@
+<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/><meta name="viewport" content="width=device-width"/><title>Pyroscope</title><link rel="stylesheet" href="/assets/styles.a6cc79c79f4055c0781a.css"/><link rel="stylesheet" href="/assets/app.a6cc79c79f4055c0781a.css"/><!-- extra metadata + analytics for demo page -->
+<meta property="og:title" content="Pyroscope Demo">
+<meta name="description" content="Fix performance issues in your code">
+<meta property="og:description" content="Fix performance issues in your code">
+<meta property="og:image" content="https://pyroscope.io/img/demo-thumbnail.png">
+<meta property="twitter:image" content="https://pyroscope.io/img/demo-thumbnail.png">
+<meta name="twitter:image:alt" content="Image for Pyroscope Demo">
+<meta data-react-helmet="true" name="twitter:card" content="summary_large_image">
+<meta data-react-helmet="true" name="og:image" content="https://pyroscope.io/img/demo-thumbnail.png">
+
+<link rel="preconnect" href="https://www.google-analytics.com">
+<script>window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)},ga.l=+new Date,ga("create","UA-185672451-2","auto"),ga("send","pageview")</script>
+<script async src="https://www.google-analytics.com/analytics.js"></script>
+
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-MNRS8XR');</script>
+<!-- End Google Tag Manager -->
+
+
+<!-- Facebook Pixel Code -->
+<script>
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)}(window, document,'script',
+    'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '223853962474196');
+  fbq('track', 'PageView');
+</script>
+<!-- End Facebook Pixel Code -->
+
+<script>
+  var script = document.createElement('script');
+  script.src = "https://pyroscope-other.s3.amazonaws.com/demo_addons/addGithubStarBanner.js";
+  document.getElementsByTagName('head')[0].appendChild(script);
+</script>
+
+<script>
+  window.intercomSettings = {
+    app_id: "n4cr7229",
+  };
+</script>
+
+<script>
+  // We pre-filled your app ID in the widget URL: 'https://widget.intercom.io/widget/n4cr7229'
+  (function(){var w=window;var ic=w.Intercom;if(typeof ic==="function"){ic('reattach_activator');ic('update',w.intercomSettings);}else{var d=document;var i=function(){i.c(arguments);};i.q=[];i.c=function(args){i.q.push(args);};w.Intercom=i;var l=function(){var s=d.createElement('script');s.type='text/javascript';s.async=true;s.src='https://widget.intercom.io/widget/n4cr7229';var x=d.getElementsByTagName('script')[0];x.parentNode.insertBefore(s,x);};if(w.attachEvent){w.attachEvent('onload',l);}else{w.addEventListener('load',l,false);}}})();
+</script>
+<link rel="icon" href="/assets/images/favicon.ico"/></head><body><div id="root"></div><script>window.notificationText = '';</script><script>window.buildInfo = {"goos":"linux","goarch":"amd64","goVersion":"go1.19.2","version":"v0.33.0","id":"N/A","time":"2022-10-24T16:51:05Z","gitSHA":"23900aa1","gitDirty":0,"useEmbeddedAssets":true,"phpspyGitSHA":"be3abd72e8e2dd5dd4e61008fcd702f90c6eb238"};</script><script>window.latestVersionInfo = {"latest_version":"v0.33.0"};</script><script>window.features = {"enableAdhocUI":true,"googleEnabled":false,"gitlabEnabled":false,"githubEnabled":false,"internalAuthEnabled":false,"signupEnabled":false,"exportToFlamegraphDotComEnabled":true,"isAuthRequired":false};</script><script src="/assets/app.a6cc79c79f4055c0781a.js"></script></body></html>


### PR DESCRIPTION
Sometimes server returns HTML, normally when a URL is malformed, which produces an error message such as

![Screenshot 2022-10-25 at 16-50-04 Single nodejs inuse_objects{} Pyroscope](https://user-images.githubusercontent.com/6951209/197821801-d22f0354-8b7b-4cb1-bcb2-883651fe215a.png)

Now we try to handle this case and just return a generic message instead
![Screenshot 2022-10-25 at 16-49-04 Single nodejs inuse_objects{} Pyroscope](https://user-images.githubusercontent.com/6951209/197821888-672bc7b9-1125-490e-ae81-8b925258f891.png)

