### PR TITLE
chore: skip ebpfspy test outside linux

### DIFF
--- a/pkg/agent/ebpfspy/symtab/gosym_test.go
+++ b/pkg/agent/ebpfspy/symtab/gosym_test.go
@@ -1,3 +1,6 @@
+//go:build linux
+// +build linux
+
 package symtab
 
 import (


### PR DESCRIPTION
since /proc filesystem is only available on linux
https://man7.org/linux/man-pages/man5/proc.5.html

Otherwise it fails with (on a mac, assume the same happens in windows)
```
--- FAIL: TestGoSymSelfTest (0.00s)                                                                                                              
    gosym_test.go:15: failed to create symtab open /proc/self/exe: no such file or directory
FAIL
```