### PR TITLE
fix: exemplars page shows weird y-axis numbers

### DIFF
--- a/webapp/javascript/components/Heatmap/Heatmap.module.scss
+++ b/webapp/javascript/components/Heatmap/Heatmap.module.scss
@@ -38,6 +38,7 @@ $svg-side-margin: 40px;
     .tickValues {
       margin: -10px 0px;
       width: 30px;
+      word-break: initial;
     }
 
     .ticksContainer {

--- a/webapp/javascript/components/Heatmap/utils.ts
+++ b/webapp/javascript/components/Heatmap/utils.ts
@@ -119,7 +119,7 @@ export const getTicks = (
   max: number,
   options: TickOptions,
   sampleRate?: number
-) => {
+): string[] => {
   let formatter;
   if (sampleRate && options.formatter) {
     formatter = (v: number) => options.formatter.format(v, sampleRate, false);


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1634

## Changes
- fix heatmap y-axis tick value align

demo link: https://pr-1644.pyroscope.io/exemplars/single?query=rideshare-app-golang.cpu%7B%7D&from=now-3h
<img width="1179" alt="Screenshot 2022-10-27 at 17 36 04" src="https://user-images.githubusercontent.com/47758224/198334570-07661ca4-6a8f-4338-9397-6d1f06ec4ed4.png">

## Concerns
- 