### PR TITLE
feat(webapp): [notifications] support 'warning' status and arbitrary jsx element

### DIFF
--- a/stories/Notifications.stories.tsx
+++ b/stories/Notifications.stories.tsx
@@ -4,7 +4,7 @@ import Button from '@ui/Button';
 import '../webapp/sass/profile.scss';
 
 export default {
-  title: 'Notifications',
+  title: 'components/Notifications',
 };
 
 export const notifications = () => {
@@ -29,11 +29,33 @@ export const notifications = () => {
       type: 'success',
     });
 
+  const warning = () =>
+    store.addNotification({
+      title: 'Warning',
+      message: 'Warning message',
+      type: 'warning',
+    });
+
+  const arbitraryJSXElement = () =>
+    store.addNotification({
+      title: 'Info',
+      message: (
+        <>
+          Info message <a href="">i am a link</a>
+        </>
+      ),
+      type: 'info',
+    });
+
   return (
     <div>
       <Button onClick={() => info()}>Info</Button>
       <Button onClick={() => danger()}>Danger</Button>
       <Button onClick={() => success()}>Success</Button>
+      <Button onClick={() => warning()}>Warning</Button>
+      <Button onClick={() => arbitraryJSXElement()}>
+        Arbitrary JSX Element
+      </Button>
       <Notifications />
     </div>
   );

--- a/webapp/javascript/ui/Notifications.tsx
+++ b/webapp/javascript/ui/Notifications.tsx
@@ -24,9 +24,9 @@ const defaultParams: Partial<ReactNotificationOptions> = {
 
 export type NotificationOptions = {
   title?: string;
-  message: string;
+  message: string | JSX.Element;
   additionalInfo?: string[];
-  type: 'success' | 'danger' | 'info';
+  type: 'success' | 'danger' | 'info' | 'warning';
 
   dismiss?: DismissOptions;
   onRemoval?: ((id: string, removedBy: ShamefulAny) => void) | undefined;
@@ -36,12 +36,13 @@ function Message({
   message,
   additionalInfo,
 }: {
-  message: string;
+  message: string | JSX.Element;
   additionalInfo?: string[];
 }) {
+  const msg = typeof message === 'string' ? <p>{message}</p> : message;
   return (
     <div>
-      {message && <p>{message}</p>}
+      {msg}
       {additionalInfo && <h4>Additional Info:</h4>}
 
       {additionalInfo && (


### PR DESCRIPTION
Support a `warning` level:
<img width="336" alt="Screen Shot 2022-11-01 at 09 21 24" src="https://user-images.githubusercontent.com/6951209/199201848-5c2d7abe-b261-4384-a0e2-995c30c1787e.png">

Also support an arbitrary JSX element to be passed as message, as opposed to only strings:
<img width="336" alt="Screen Shot 2022-11-01 at 09 21 35" src="https://user-images.githubusercontent.com/6951209/199201911-aa0317a1-8721-4987-aba2-eb3b7d80b87f.png">
