### PR TITLE
fix: remove tmp multipart files

### DIFF
--- a/pkg/convert/jfr/profile.go
+++ b/pkg/convert/jfr/profile.go
@@ -62,6 +62,9 @@ func loadJFRFromForm(r io.Reader, contentType string) (io.Reader, *LabelsSnapsho
 	if err != nil {
 		return nil, nil, err
 	}
+	defer func() {
+		_ = f.RemoveAll()
+	}()
 
 	jfrField, err := form.ReadField(f, "jfr")
 	if err != nil {

--- a/pkg/convert/pprof/profile.go
+++ b/pkg/convert/pprof/profile.go
@@ -186,14 +186,14 @@ func (p *RawProfile) loadPprofFromForm() error {
 		return err
 	}
 
-	// maxMemory 32MB.
-	// TODO(kolesnikovae): If the limit is exceeded, parts will be written
-	//  to disk. It may be better to limit the request body size to be sure
-	//  that they loaded into memory entirely.
 	f, err := multipart.NewReader(bytes.NewReader(p.RawData), boundary).ReadForm(32 << 20)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		_ = f.RemoveAll()
+	}()
+
 	p.Profile, err = form.ReadField(f, formFieldProfile)
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently, when ingesting a JFR or pprof profile exceeding 32MB, pyroscope server uses /tmp file system. The problem is that after parsing, files remain that are never deleted automatically (by the pyroscope server).

May fix https://github.com/pyroscope-io/pyroscope/issues/1665