### PR TITLE
chore(webapp): don't make loading granular

### DIFF
--- a/webapp/javascript/pages/ContinuousComparisonView.tsx
+++ b/webapp/javascript/pages/ContinuousComparisonView.tsx
@@ -11,6 +11,7 @@ import {
   fetchComparisonSide,
   fetchTagValues,
   selectQueries,
+  selectTimelineSides,
 } from '@webapp/redux/reducers/continuous';
 import TimelineChartWrapper from '@webapp/components/TimelineChart/TimelineChartWrapper';
 import SyncTimelines from '@webapp/components/TimelineChart/SyncTimelines';
@@ -48,6 +49,14 @@ function ComparisonApp() {
   const { leftTags, rightTags } = useTags({ leftQuery, rightQuery });
   const { leftTimeline, rightTimeline } = useTimelines();
   const sharedQuery = useFlamegraphSharedQuery();
+
+  const timelines = useAppSelector(selectTimelineSides);
+  const isLoading = isLoadingOrReloading([
+    comparisonView.left.type,
+    comparisonView.right.type,
+    timelines.left.type,
+    timelines.right.type,
+  ]);
 
   useEffect(() => {
     if (leftQuery) {
@@ -92,12 +101,7 @@ function ComparisonApp() {
           }}
         />
         <Box>
-          <LoadingOverlay
-            active={isLoadingOrReloading([
-              comparisonView.left.type,
-              comparisonView.right.type,
-            ])}
-          >
+          <LoadingOverlay active={isLoading}>
             <TimelineChartWrapper
               data-testid="timeline-main"
               id="timeline-chart-double"
@@ -145,10 +149,7 @@ function ComparisonApp() {
           data-testid="comparison-container"
         >
           <Box className={styles.comparisonPane}>
-            <LoadingOverlay
-              active={isLoadingOrReloading([comparisonView.left.type])}
-              spinnerPosition="baseline"
-            >
+            <LoadingOverlay active={isLoading} spinnerPosition="baseline">
               <TimelineTitle titleKey="baseline" color={leftColor} />
               <TagsBar
                 query={leftQuery}
@@ -209,10 +210,7 @@ function ComparisonApp() {
           </Box>
 
           <Box className={styles.comparisonPane}>
-            <LoadingOverlay
-              spinnerPosition="baseline"
-              active={isLoadingOrReloading([comparisonView.right.type])}
-            >
+            <LoadingOverlay spinnerPosition="baseline" active={isLoading}>
               <TimelineTitle titleKey="comparison" color={rightColor} />
               <TagsBar
                 query={rightQuery}

--- a/webapp/javascript/pages/ContinuousDiffView.tsx
+++ b/webapp/javascript/pages/ContinuousDiffView.tsx
@@ -58,6 +58,12 @@ function ComparisonDiffApp() {
   const { offset } = useTimeZone();
   const timezone = offset === 0 ? 'utc' : 'browser';
 
+  const isLoading = isLoadingOrReloading([
+    diffView.type,
+    timelines.left.type,
+    timelines.right.type,
+  ]);
+
   useEffect(() => {
     if (rightQuery && leftQuery) {
       const fetchData = dispatch(
@@ -108,12 +114,7 @@ function ComparisonDiffApp() {
           }}
         />
         <Box>
-          <LoadingOverlay
-            active={isLoadingOrReloading([
-              timelines.left.type,
-              timelines.right.type,
-            ])}
-          >
+          <LoadingOverlay active={isLoading}>
             <TimelineChartWrapper
               data-testid="timeline-main"
               id="timeline-chart-diff"
@@ -156,9 +157,7 @@ function ComparisonDiffApp() {
         </Box>
         <div className="diff-instructions-wrapper">
           <Box className="diff-instructions-wrapper-side">
-            <LoadingOverlay
-              active={isLoadingOrReloading([timelines.left.type])}
-            >
+            <LoadingOverlay active={isLoading}>
               <TimelineTitle titleKey="baseline" color={leftColor} />
               <TagsBar
                 query={leftQuery}
@@ -196,9 +195,7 @@ function ComparisonDiffApp() {
             </LoadingOverlay>
           </Box>
           <Box className="diff-instructions-wrapper-side">
-            <LoadingOverlay
-              active={isLoadingOrReloading([timelines.right.type])}
-            >
+            <LoadingOverlay active={isLoading}>
               <TimelineTitle titleKey="comparison" color={rightColor} />
               <TagsBar
                 query={rightQuery}
@@ -237,10 +234,7 @@ function ComparisonDiffApp() {
           </Box>
         </div>
         <Box>
-          <LoadingOverlay
-            active={isLoadingOrReloading([diffView.type])}
-            spinnerPosition="baseline"
-          >
+          <LoadingOverlay active={isLoading} spinnerPosition="baseline">
             <TimelineTitle titleKey="diff" />
             <FlamegraphRenderer
               showCredit={false}


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/1675

Don't make loading spinners granular (timelines/left/right side). Instead, if any of them is loading, all of them are loading.