### PR TITLE
refactor(webapp): cleanup store

### DIFF
--- a/webapp/javascript/redux/reducers/continuous.ts
+++ b/webapp/javascript/redux/reducers/continuous.ts
@@ -10,16 +10,14 @@ import {
 import { fetchAppNames } from '@webapp/services/appNames';
 import { Query, brandQuery, queryToAppName } from '@webapp/models/query';
 import type { Timeline } from '@webapp/models/timeline';
-import * as tagsService from '@webapp/services/tags';
 import * as annotationsService from '@webapp/services/annotations';
 import { RequestAbortedError } from '@webapp/services/base';
 import { appendLabelToQuery } from '@webapp/util/query';
-import { createBiggestInterval } from '@webapp/util/timerange';
-import { formatAsOBject, toUnixTimestamp } from '@webapp/util/formatDate';
 import type { RootState } from '@webapp/redux/store';
 import { addNotification } from './notifications';
 import { createAsyncThunk } from '../async-thunk';
 import { ContinuousState, TagsState } from './continuous/state';
+import { fetchTagValues, fetchTags } from './continuous/tags.thunks';
 
 let singleViewAbortController: AbortController | undefined;
 let sideTimelinesAbortController: AbortController | undefined;
@@ -399,182 +397,6 @@ export const fetchDiffView = createAsyncThunk<
 
   return Promise.reject(res.error);
 });
-
-export const fetchTags = createAsyncThunk<
-  { appName: string; tags: string[]; from: number; until: number },
-  Query,
-  { state: { continuous: ContinuousState } }
->(
-  'continuous/fetchTags',
-  async (query: Query, thunkAPI) => {
-    const appName = queryToAppName(query);
-    if (appName.isNothing) {
-      return Promise.reject(
-        new Error(
-          `Query '${appName}' is not a valid app, and it can't have any tags`
-        )
-      );
-    }
-
-    const state = thunkAPI.getState().continuous;
-    const timerange = biggestTimeRangeInUnix(state);
-    const res = await tagsService.fetchTags(
-      query,
-      timerange.from,
-      timerange.until
-    );
-
-    if (res.isOk) {
-      return Promise.resolve({
-        appName: appName.value,
-        tags: res.value,
-        from: timerange.from,
-        until: timerange.until,
-      });
-    }
-
-    thunkAPI.dispatch(
-      addNotification({
-        type: 'danger',
-        title: 'Failed to load tags',
-        message: res.error.message,
-      })
-    );
-
-    return Promise.reject(res.error);
-  },
-  {
-    // If we already loaded the tags for that application
-    // And we are trying to load tags for a smaller range
-    // Skip it, since we most likely already have that data
-    condition: (query, thunkAPI) => {
-      const appName = queryToAppName(query);
-      if (appName.isNothing) {
-        throw Error(
-          `Query '${appName}' is not a valid app, and it can't have any tags`
-        );
-      }
-
-      const state = thunkAPI.getState().continuous;
-      const timerange = biggestTimeRangeInUnix(state);
-
-      const s = state.tags[appName.value];
-
-      // Haven't loaded yet
-      if (!s) {
-        return true;
-      }
-
-      // Already loading that tag
-      if (s.type === 'loading') {
-        return false;
-      }
-
-      // Any other state that's not loaded
-      if (s.type !== 'loaded') {
-        return true;
-      }
-
-      const isInRange = (target: number) => {
-        return target >= s.from && target <= s.until;
-      };
-
-      const isSmallerThanLoaded =
-        isInRange(timerange.from) && isInRange(timerange.until);
-
-      return !isSmallerThanLoaded;
-    },
-  }
-);
-
-export const fetchTagValues = createAsyncThunk<
-  {
-    appName: string;
-    label: string;
-    values: string[];
-  },
-  {
-    query: Query;
-    label: string;
-  },
-  { state: { continuous: ContinuousState } }
->(
-  'continuous/fetchTagsValues',
-  async (payload: { query: Query; label: string }, thunkAPI) => {
-    const appName = queryToAppName(payload.query);
-    if (appName.isNothing) {
-      return Promise.reject(
-        new Error(
-          `Query '${appName}' is not a valid app, and it can't have any tags`
-        )
-      );
-    }
-
-    const state = thunkAPI.getState().continuous.tags[appName.value];
-    if (!state || state.type !== 'loaded') {
-      return Promise.reject(
-        new Error(
-          `Trying to load label-values for an unloaded label. This is likely due to a race condition.`
-        )
-      );
-    }
-
-    const res = await tagsService.fetchLabelValues(
-      payload.label,
-      payload.query,
-      state.from,
-      state.until
-    );
-
-    if (res.isOk) {
-      return Promise.resolve({
-        appName: appName.value,
-        label: payload.label,
-        values: res.value,
-      });
-    }
-
-    thunkAPI.dispatch(
-      addNotification({
-        type: 'danger',
-        title: 'Failed to load tag values',
-        message: res.error.message,
-      })
-    );
-
-    return Promise.reject(res.error);
-  },
-  {
-    condition: ({ query, label }, thunkAPI) => {
-      const appName = queryToAppName(query);
-      if (appName.isNothing) {
-        throw Error(
-          `Query '${appName}' is not a valid app, and it can't have any tags`
-        );
-      }
-
-      const tagState = thunkAPI.getState().continuous.tags[appName.value];
-      if (!tagState || tagState.type !== 'loaded') {
-        return false;
-      }
-
-      const tagValueState = tagState.tags[label];
-
-      // Haven't loaded yet
-      if (!tagValueState) {
-        return true;
-      }
-
-      // Already loading that tag
-      // Or we already loaded it
-      if (tagValueState.type === 'loading' || tagValueState.type === 'loaded') {
-        return false;
-      }
-
-      return true;
-    },
-  }
-);
 
 export const reloadAppNames = createAsyncThunk(
   'names/reloadAppNames',
@@ -1097,13 +919,4 @@ function getNextStateFromPending(
   return 'reloading';
 }
 
-function biggestTimeRangeInUnix(state: ContinuousState) {
-  return createBiggestInterval({
-    from: [state.from, state.leftFrom, state.rightFrom]
-      .map(formatAsOBject)
-      .map(toUnixTimestamp),
-    until: [state.until, state.leftUntil, state.leftUntil]
-      .map(formatAsOBject)
-      .map(toUnixTimestamp),
-  });
-}
+export * from './continuous/tags.thunks';

--- a/webapp/javascript/redux/reducers/continuous.ts
+++ b/webapp/javascript/redux/reducers/continuous.ts
@@ -462,6 +462,7 @@ function getNextStateFromPending(
 
 export * from './continuous/selectors';
 
+export * from './continuous/state';
 export * from './continuous/tags.thunks';
 export * from './continuous/singleView.thunks';
 export * from './continuous/annotations.thunks';

--- a/webapp/javascript/redux/reducers/continuous.ts
+++ b/webapp/javascript/redux/reducers/continuous.ts
@@ -1,7 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { fetchAppNames } from '@webapp/services/appNames';
-import { Query, brandQuery, queryToAppName } from '@webapp/models/query';
-import type { RootState } from '@webapp/redux/store';
+import { Query } from '@webapp/models/query';
 import { addNotification } from './notifications';
 import { createAsyncThunk } from '../async-thunk';
 import { ContinuousState, TagsState } from './continuous/state';
@@ -447,111 +446,9 @@ export const continuousSlice = createSlice({
   },
 });
 
-export const selectContinuousState = (state: RootState) => state.continuous;
 export default continuousSlice.reducer;
 export const { actions } = continuousSlice;
 export const { setDateRange, setQuery } = continuousSlice.actions;
-export const selectApplicationName = (state: RootState) => {
-  const { query } = selectQueries(state);
-
-  const appName = queryToAppName(query);
-
-  return appName.map((q) => q.split('{')[0]).unwrapOrElse(() => '');
-};
-
-export const selectAppNamesState = (state: RootState) =>
-  state.continuous.appNames;
-export const selectAppNames = (state: RootState) => {
-  const sorted = [...state.continuous.appNames.data].sort();
-  return sorted;
-};
-
-export const selectComparisonState = (state: RootState) =>
-  state.continuous.comparisonView;
-
-export const selectIsLoadingData = (state: RootState) => {
-  const loadingStates = ['loading', 'reloading'];
-
-  // TODO: should we check if timelines are being reloaded too?
-  return (
-    loadingStates.includes(state.continuous.singleView.type) ||
-    // Comparison
-    loadingStates.includes(state.continuous.comparisonView.left.type) ||
-    loadingStates.includes(state.continuous.comparisonView.right.type) ||
-    // Diff
-    loadingStates.includes(state.continuous.diffView.type) ||
-    // Timeline Sides
-    loadingStates.includes(state.continuous.leftTimeline.type) ||
-    loadingStates.includes(state.continuous.rightTimeline.type) ||
-    // Exemplars
-    loadingStates.includes(state.tracing.exemplarsSingleView.type)
-  );
-};
-
-export const selectAppTags = (query?: Query) => (state: RootState) => {
-  if (query) {
-    const appName = queryToAppName(query);
-    if (appName.isJust) {
-      if (state.continuous.tags[appName.value]) {
-        return state.continuous.tags[appName.value];
-      }
-    }
-  }
-
-  return {
-    type: 'pristine',
-    tags: {},
-  } as TagsState;
-};
-
-export const selectTimelineSides = (state: RootState) => {
-  return {
-    left: state.continuous.leftTimeline,
-    right: state.continuous.rightTimeline,
-  };
-};
-
-export const selectTimelineSidesData = (state: RootState) => {
-  return {
-    left: state.continuous.leftTimeline.timeline,
-    right: state.continuous.rightTimeline.timeline,
-  };
-};
-
-export const selectQueries = (state: RootState) => {
-  return {
-    leftQuery: brandQuery(state.continuous.leftQuery || ''),
-    rightQuery: brandQuery(state.continuous.rightQuery || ''),
-    query: brandQuery(state.continuous.query),
-  };
-};
-
-// TODO: accept a side (continuous / leftside)
-export const selectAnnotationsOrDefault = (state: RootState) => {
-  if ('annotations' in state.continuous.singleView) {
-    return state.continuous.singleView.annotations;
-  }
-  return [];
-};
-
-export const selectRanges = (rootState: RootState) => {
-  const state = rootState.continuous;
-
-  return {
-    left: {
-      from: state.leftFrom,
-      until: state.leftUntil,
-    },
-    right: {
-      from: state.rightFrom,
-      until: state.rightUntil,
-    },
-    regular: {
-      from: state.from,
-      until: state.until,
-    },
-  };
-};
 
 function getNextStateFromPending(
   prevState: 'pristine' | 'loading' | 'reloading' | 'loaded'
@@ -562,6 +459,8 @@ function getNextStateFromPending(
 
   return 'reloading';
 }
+
+export * from './continuous/selectors';
 
 export * from './continuous/tags.thunks';
 export * from './continuous/singleView.thunks';

--- a/webapp/javascript/redux/reducers/continuous.ts
+++ b/webapp/javascript/redux/reducers/continuous.ts
@@ -1,5 +1,4 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import type { Profile, Groups } from '@pyroscope/models/src';
 import {
   renderSingle,
   renderDiff,
@@ -9,10 +8,8 @@ import {
   RenderDiffResponse,
 } from '@webapp/services/render';
 import { fetchAppNames } from '@webapp/services/appNames';
-import type { AppNames } from '@webapp/models/appNames';
 import { Query, brandQuery, queryToAppName } from '@webapp/models/query';
 import type { Timeline } from '@webapp/models/timeline';
-import type { Annotation } from '@webapp/models/annotation';
 import * as tagsService from '@webapp/services/tags';
 import * as annotationsService from '@webapp/services/annotations';
 import { RequestAbortedError } from '@webapp/services/base';
@@ -22,136 +19,7 @@ import { formatAsOBject, toUnixTimestamp } from '@webapp/util/formatDate';
 import type { RootState } from '@webapp/redux/store';
 import { addNotification } from './notifications';
 import { createAsyncThunk } from '../async-thunk';
-
-type NewAnnotationState =
-  | {
-      type: 'pristine';
-    }
-  | { type: 'saving' };
-
-type SingleView =
-  | { type: 'pristine'; profile?: Profile }
-  | { type: 'loading'; profile?: Profile }
-  | {
-      type: 'loaded';
-      timeline: Timeline;
-      profile: Profile;
-      annotations: Annotation[];
-    }
-  | {
-      type: 'reloading';
-      timeline: Timeline;
-      profile: Profile;
-      annotations: Annotation[];
-    };
-
-type TagExplorerView =
-  | {
-      type: 'pristine';
-      groups: Groups;
-      groupByTag: string;
-      groupByTagValue: string;
-    }
-  | {
-      type: 'loading';
-      groups: Groups;
-      groupByTag: string;
-      groupByTagValue: string;
-    }
-  | {
-      type: 'loaded';
-      groups: Groups;
-      groupByTag: string;
-      activeTagProfile?: Profile;
-      groupByTagValue: string;
-    }
-  | {
-      type: 'reloading';
-      groups: Groups;
-      groupByTag: string;
-      activeTagProfile?: Profile;
-      groupByTagValue: string;
-    };
-
-type ComparisonView = {
-  left:
-    | { type: 'pristine'; profile?: Profile }
-    | { type: 'loading'; profile?: Profile }
-    | { type: 'loaded'; profile: Profile }
-    | { type: 'reloading'; profile: Profile };
-
-  right:
-    | { type: 'pristine'; profile?: Profile }
-    | { type: 'loading'; profile?: Profile }
-    | { type: 'loaded'; profile: Profile }
-    | { type: 'reloading'; profile: Profile };
-};
-
-type DiffView =
-  | { type: 'pristine'; profile?: Profile }
-  | { type: 'loading'; profile?: Profile }
-  | { type: 'loaded'; profile: Profile }
-  | { type: 'reloading'; profile: Profile };
-
-type TimelineState =
-  | { type: 'pristine'; timeline: Timeline }
-  | { type: 'loading'; timeline: Timeline }
-  | { type: 'reloading'; timeline: Timeline }
-  | { type: 'loaded'; timeline: Timeline };
-
-type TagsData =
-  | { type: 'pristine' }
-  | { type: 'loading' }
-  | { type: 'failed' }
-  | { type: 'loaded'; values: string[] };
-
-// Tags really refer to each application
-// Should we nest them to an application?
-export type TagsState =
-  | { type: 'pristine'; tags: Record<string, TagsData> }
-  | { type: 'loading'; tags: Record<string, TagsData> }
-  | {
-      type: 'loaded';
-      tags: Record<string, TagsData>;
-      from: number;
-      until: number;
-    }
-  | { type: 'failed'; tags: Record<string, TagsData> };
-
-// TODO
-type appName = string;
-type Tags = Record<appName, TagsState>;
-
-interface ContinuousState {
-  from: string;
-  until: string;
-  leftFrom: string;
-  leftUntil: string;
-  rightFrom: string;
-  rightUntil: string;
-  query: string;
-  leftQuery?: string;
-  rightQuery?: string;
-  maxNodes: string;
-  refreshToken?: string;
-
-  singleView: SingleView;
-  diffView: DiffView;
-  comparisonView: ComparisonView;
-  tagExplorerView: TagExplorerView;
-  newAnnotation: NewAnnotationState;
-  tags: Tags;
-
-  appNames:
-    | { type: 'loaded'; data: AppNames }
-    | { type: 'reloading'; data: AppNames }
-    | { type: 'failed'; data: AppNames };
-
-  // Since both comparison and diff use the same timeline
-  // Makes sense storing them separately
-  leftTimeline: TimelineState;
-  rightTimeline: TimelineState;
-}
+import { ContinuousState, TagsState } from './continuous/state';
 
 let singleViewAbortController: AbortController | undefined;
 let sideTimelinesAbortController: AbortController | undefined;

--- a/webapp/javascript/redux/reducers/continuous/annotations.thunks.ts
+++ b/webapp/javascript/redux/reducers/continuous/annotations.thunks.ts
@@ -1,0 +1,27 @@
+import * as annotationsService from '@webapp/services/annotations';
+import { addNotification } from '../notifications';
+import { createAsyncThunk } from '../../async-thunk';
+
+// TODO(eh-am): support different views
+export const addAnnotation = createAsyncThunk(
+  'continuous/addAnnotation',
+  async (newAnnotation: annotationsService.NewAnnotation, thunkAPI) => {
+    const res = await annotationsService.addAnnotation(newAnnotation);
+
+    if (res.isOk) {
+      return Promise.resolve({
+        annotation: res.value,
+      });
+    }
+
+    thunkAPI.dispatch(
+      addNotification({
+        type: 'danger',
+        title: 'Failed to add annotation',
+        message: res.error.message,
+      })
+    );
+
+    return Promise.reject(res.error);
+  }
+);

--- a/webapp/javascript/redux/reducers/continuous/comparisonView.thunks.ts
+++ b/webapp/javascript/redux/reducers/continuous/comparisonView.thunks.ts
@@ -1,0 +1,85 @@
+import { renderSingle, RenderOutput } from '@webapp/services/render';
+import { RequestAbortedError } from '@webapp/services/base';
+import { addNotification } from '../notifications';
+import { createAsyncThunk } from '../../async-thunk';
+import { ContinuousState } from './state';
+
+let comparisonSideAbortControllerLeft: AbortController | undefined;
+let comparisonSideAbortControllerRight: AbortController | undefined;
+
+export const fetchComparisonSide = createAsyncThunk<
+  { side: 'left' | 'right'; data: Pick<RenderOutput, 'profile'> },
+  { side: 'left' | 'right'; query: string },
+  { state: { continuous: ContinuousState } }
+>('continuous/fetchComparisonSide', async ({ side, query }, thunkAPI) => {
+  const state = thunkAPI.getState();
+
+  const res = await (() => {
+    switch (side) {
+      case 'left': {
+        if (comparisonSideAbortControllerLeft) {
+          comparisonSideAbortControllerLeft.abort();
+        }
+
+        comparisonSideAbortControllerLeft = new AbortController();
+        thunkAPI.signal = comparisonSideAbortControllerLeft.signal;
+
+        return renderSingle(
+          {
+            ...state.continuous,
+            query,
+
+            from: state.continuous.leftFrom,
+            until: state.continuous.leftUntil,
+          },
+          comparisonSideAbortControllerLeft
+        );
+      }
+      case 'right': {
+        if (comparisonSideAbortControllerRight) {
+          comparisonSideAbortControllerRight.abort();
+        }
+
+        comparisonSideAbortControllerRight = new AbortController();
+        thunkAPI.signal = comparisonSideAbortControllerRight.signal;
+
+        return renderSingle(
+          {
+            ...state.continuous,
+            query,
+
+            from: state.continuous.rightFrom,
+            until: state.continuous.rightUntil,
+          },
+          comparisonSideAbortControllerRight
+        );
+      }
+      default: {
+        throw new Error('invalid side');
+      }
+    }
+  })();
+
+  if (res?.isErr && res?.error instanceof RequestAbortedError) {
+    return thunkAPI.rejectWithValue({ rejectedWithValue: 'reloading' });
+  }
+
+  if (res.isOk) {
+    return Promise.resolve({
+      side,
+      data: {
+        profile: res.value.profile,
+      },
+    });
+  }
+
+  thunkAPI.dispatch(
+    addNotification({
+      type: 'danger',
+      title: `Failed to load the ${side} side comparison`,
+      message: res.error.message,
+    })
+  );
+
+  return Promise.reject(res.error);
+});

--- a/webapp/javascript/redux/reducers/continuous/diffView.thunks.ts
+++ b/webapp/javascript/redux/reducers/continuous/diffView.thunks.ts
@@ -1,0 +1,54 @@
+import { renderDiff, RenderDiffResponse } from '@webapp/services/render';
+import { RequestAbortedError } from '@webapp/services/base';
+import { addNotification } from '../notifications';
+import { createAsyncThunk } from '../../async-thunk';
+import { ContinuousState } from './state';
+
+let diffViewAbortController: AbortController | undefined;
+
+export const fetchDiffView = createAsyncThunk<
+  { profile: RenderDiffResponse },
+  {
+    leftQuery: string;
+    leftFrom: string;
+    leftUntil: string;
+    rightQuery: string;
+    rightFrom: string;
+    rightUntil: string;
+  },
+  { state: { continuous: ContinuousState } }
+>('continuous/diffView', async (params, thunkAPI) => {
+  if (diffViewAbortController) {
+    diffViewAbortController.abort();
+  }
+
+  diffViewAbortController = new AbortController();
+  thunkAPI.signal = diffViewAbortController.signal;
+
+  const state = thunkAPI.getState();
+  const res = await renderDiff(
+    {
+      ...params,
+      maxNodes: state.continuous.maxNodes,
+    },
+    diffViewAbortController
+  );
+
+  if (res.isOk) {
+    return Promise.resolve({ profile: res.value });
+  }
+
+  if (res.isErr && res.error instanceof RequestAbortedError) {
+    return thunkAPI.rejectWithValue({ rejectedWithValue: 'reloading' });
+  }
+
+  thunkAPI.dispatch(
+    addNotification({
+      type: 'danger',
+      title: 'Failed to load diff view',
+      message: res.error.message,
+    })
+  );
+
+  return Promise.reject(res.error);
+});

--- a/webapp/javascript/redux/reducers/continuous/selectors.ts
+++ b/webapp/javascript/redux/reducers/continuous/selectors.ts
@@ -1,0 +1,106 @@
+import { brandQuery, Query, queryToAppName } from '@webapp/models/query';
+import type { RootState } from '@webapp/redux/store';
+import { TagsState } from './state';
+
+export const selectContinuousState = (state: RootState) => state.continuous;
+export const selectApplicationName = (state: RootState) => {
+  const { query } = selectQueries(state);
+
+  const appName = queryToAppName(query);
+
+  return appName.map((q) => q.split('{')[0]).unwrapOrElse(() => '');
+};
+
+export const selectAppNamesState = (state: RootState) =>
+  state.continuous.appNames;
+export const selectAppNames = (state: RootState) => {
+  const sorted = [...state.continuous.appNames.data].sort();
+  return sorted;
+};
+
+export const selectComparisonState = (state: RootState) =>
+  state.continuous.comparisonView;
+
+export const selectIsLoadingData = (state: RootState) => {
+  const loadingStates = ['loading', 'reloading'];
+
+  // TODO: should we check if timelines are being reloaded too?
+  return (
+    loadingStates.includes(state.continuous.singleView.type) ||
+    // Comparison
+    loadingStates.includes(state.continuous.comparisonView.left.type) ||
+    loadingStates.includes(state.continuous.comparisonView.right.type) ||
+    // Diff
+    loadingStates.includes(state.continuous.diffView.type) ||
+    // Timeline Sides
+    loadingStates.includes(state.continuous.leftTimeline.type) ||
+    loadingStates.includes(state.continuous.rightTimeline.type) ||
+    // Exemplars
+    loadingStates.includes(state.tracing.exemplarsSingleView.type)
+  );
+};
+
+export const selectAppTags = (query?: Query) => (state: RootState) => {
+  if (query) {
+    const appName = queryToAppName(query);
+    if (appName.isJust) {
+      if (state.continuous.tags[appName.value]) {
+        return state.continuous.tags[appName.value];
+      }
+    }
+  }
+
+  return {
+    type: 'pristine',
+    tags: {},
+  } as TagsState;
+};
+
+export const selectTimelineSides = (state: RootState) => {
+  return {
+    left: state.continuous.leftTimeline,
+    right: state.continuous.rightTimeline,
+  };
+};
+
+export const selectTimelineSidesData = (state: RootState) => {
+  return {
+    left: state.continuous.leftTimeline.timeline,
+    right: state.continuous.rightTimeline.timeline,
+  };
+};
+
+export const selectQueries = (state: RootState) => {
+  return {
+    leftQuery: brandQuery(state.continuous.leftQuery || ''),
+    rightQuery: brandQuery(state.continuous.rightQuery || ''),
+    query: brandQuery(state.continuous.query),
+  };
+};
+
+// TODO: accept a side (continuous / leftside)
+export const selectAnnotationsOrDefault = (state: RootState) => {
+  if ('annotations' in state.continuous.singleView) {
+    return state.continuous.singleView.annotations;
+  }
+  return [];
+};
+
+export const selectRanges = (rootState: RootState) => {
+  const state = rootState.continuous;
+
+  return {
+    left: {
+      from: state.leftFrom,
+      until: state.leftUntil,
+    },
+    right: {
+      from: state.rightFrom,
+      until: state.rightUntil,
+    },
+    regular: {
+      from: state.from,
+      until: state.until,
+    },
+  };
+};

--- a/webapp/javascript/redux/reducers/continuous/singleView.thunks.ts
+++ b/webapp/javascript/redux/reducers/continuous/singleView.thunks.ts
@@ -1,0 +1,41 @@
+import { renderSingle, RenderOutput } from '@webapp/services/render';
+import { RequestAbortedError } from '@webapp/services/base';
+import { addNotification } from '../notifications';
+import { createAsyncThunk } from '../../async-thunk';
+import { ContinuousState } from './state';
+
+let singleViewAbortController: AbortController | undefined;
+
+export const fetchSingleView = createAsyncThunk<
+  RenderOutput,
+  null,
+  { state: { continuous: ContinuousState } }
+>('continuous/singleView', async (_, thunkAPI) => {
+  if (singleViewAbortController) {
+    singleViewAbortController.abort();
+  }
+
+  singleViewAbortController = new AbortController();
+  thunkAPI.signal = singleViewAbortController.signal;
+
+  const state = thunkAPI.getState();
+  const res = await renderSingle(state.continuous, singleViewAbortController);
+
+  if (res.isOk) {
+    return Promise.resolve(res.value);
+  }
+
+  if (res.isErr && res.error instanceof RequestAbortedError) {
+    return Promise.reject(res.error);
+  }
+
+  thunkAPI.dispatch(
+    addNotification({
+      type: 'danger',
+      title: 'Failed to load single view data',
+      message: res.error.message,
+    })
+  );
+
+  return Promise.reject(res.error);
+});

--- a/webapp/javascript/redux/reducers/continuous/state.ts
+++ b/webapp/javascript/redux/reducers/continuous/state.ts
@@ -1,0 +1,134 @@
+import type { Profile, Groups } from '@pyroscope/models/src';
+import type { Timeline } from '@webapp/models/timeline';
+import type { Annotation } from '@webapp/models/annotation';
+import type { AppNames } from '@webapp/models/appNames';
+
+type NewAnnotationState =
+  | {
+      type: 'pristine';
+    }
+  | { type: 'saving' };
+
+type SingleView =
+  | { type: 'pristine'; profile?: Profile }
+  | { type: 'loading'; profile?: Profile }
+  | {
+      type: 'loaded';
+      timeline: Timeline;
+      profile: Profile;
+      annotations: Annotation[];
+    }
+  | {
+      type: 'reloading';
+      timeline: Timeline;
+      profile: Profile;
+      annotations: Annotation[];
+    };
+
+type TagExplorerView =
+  | {
+      type: 'pristine';
+      groups: Groups;
+      groupByTag: string;
+      groupByTagValue: string;
+    }
+  | {
+      type: 'loading';
+      groups: Groups;
+      groupByTag: string;
+      groupByTagValue: string;
+    }
+  | {
+      type: 'loaded';
+      groups: Groups;
+      groupByTag: string;
+      activeTagProfile?: Profile;
+      groupByTagValue: string;
+    }
+  | {
+      type: 'reloading';
+      groups: Groups;
+      groupByTag: string;
+      activeTagProfile?: Profile;
+      groupByTagValue: string;
+    };
+
+type ComparisonView = {
+  left:
+    | { type: 'pristine'; profile?: Profile }
+    | { type: 'loading'; profile?: Profile }
+    | { type: 'loaded'; profile: Profile }
+    | { type: 'reloading'; profile: Profile };
+
+  right:
+    | { type: 'pristine'; profile?: Profile }
+    | { type: 'loading'; profile?: Profile }
+    | { type: 'loaded'; profile: Profile }
+    | { type: 'reloading'; profile: Profile };
+};
+
+type DiffView =
+  | { type: 'pristine'; profile?: Profile }
+  | { type: 'loading'; profile?: Profile }
+  | { type: 'loaded'; profile: Profile }
+  | { type: 'reloading'; profile: Profile };
+
+type TimelineState =
+  | { type: 'pristine'; timeline: Timeline }
+  | { type: 'loading'; timeline: Timeline }
+  | { type: 'reloading'; timeline: Timeline }
+  | { type: 'loaded'; timeline: Timeline };
+
+type TagsData =
+  | { type: 'pristine' }
+  | { type: 'loading' }
+  | { type: 'failed' }
+  | { type: 'loaded'; values: string[] };
+
+// Tags really refer to each application
+// Should we nest them to an application?
+export type TagsState =
+  | { type: 'pristine'; tags: Record<string, TagsData> }
+  | { type: 'loading'; tags: Record<string, TagsData> }
+  | {
+      type: 'loaded';
+      tags: Record<string, TagsData>;
+      from: number;
+      until: number;
+    }
+  | { type: 'failed'; tags: Record<string, TagsData> };
+
+// TODO
+type appName = string;
+type Tags = Record<appName, TagsState>;
+
+export interface ContinuousState {
+  from: string;
+  until: string;
+  leftFrom: string;
+  leftUntil: string;
+  rightFrom: string;
+  rightUntil: string;
+  query: string;
+  leftQuery?: string;
+  rightQuery?: string;
+  maxNodes: string;
+  refreshToken?: string;
+
+  singleView: SingleView;
+  diffView: DiffView;
+  comparisonView: ComparisonView;
+  tagExplorerView: TagExplorerView;
+  newAnnotation: NewAnnotationState;
+  tags: Tags;
+
+  appNames:
+    | { type: 'loaded'; data: AppNames }
+    | { type: 'reloading'; data: AppNames }
+    | { type: 'failed'; data: AppNames };
+
+  // Since both comparison and diff use the same timeline
+  // Makes sense storing them separately
+  leftTimeline: TimelineState;
+  rightTimeline: TimelineState;
+}

--- a/webapp/javascript/redux/reducers/continuous/tagExplorer.thunks.ts
+++ b/webapp/javascript/redux/reducers/continuous/tagExplorer.thunks.ts
@@ -1,0 +1,112 @@
+import {
+  RenderExploreOutput,
+  renderSingle,
+  RenderOutput,
+  renderExplore,
+} from '@webapp/services/render';
+import { RequestAbortedError } from '@webapp/services/base';
+import { appendLabelToQuery } from '@webapp/util/query';
+import { addNotification } from '../notifications';
+import { createAsyncThunk } from '../../async-thunk';
+import { ContinuousState } from './state';
+
+export const ALL_TAGS = 'All';
+
+let tagExplorerViewAbortController: AbortController | undefined;
+let tagExplorerViewProfileAbortController: AbortController | undefined;
+
+export const fetchTagExplorerView = createAsyncThunk<
+  RenderExploreOutput,
+  null,
+  { state: { continuous: ContinuousState } }
+>('continuous/tagExplorerView', async (_, thunkAPI) => {
+  if (tagExplorerViewAbortController) {
+    tagExplorerViewAbortController.abort();
+  }
+
+  tagExplorerViewAbortController = new AbortController();
+  thunkAPI.signal = tagExplorerViewAbortController.signal;
+
+  const state = thunkAPI.getState();
+  const res = await renderExplore(
+    {
+      query: state.continuous.query,
+      from: state.continuous.from,
+      until: state.continuous.until,
+      groupBy: state.continuous.tagExplorerView.groupByTag,
+      grouByTagValue: state.continuous.tagExplorerView.groupByTagValue,
+      refreshToken: state.continuous.refreshToken,
+    },
+    tagExplorerViewAbortController
+  );
+
+  if (res.isOk) {
+    return Promise.resolve(res.value);
+  }
+
+  if (res.isErr && res.error instanceof RequestAbortedError) {
+    return Promise.reject(res.error);
+  }
+
+  thunkAPI.dispatch(
+    addNotification({
+      type: 'danger',
+      title: 'Failed to load explore view data',
+      message: res.error.message,
+    })
+  );
+
+  return Promise.reject(res.error);
+});
+
+export const fetchTagExplorerViewProfile = createAsyncThunk<
+  RenderOutput,
+  null,
+  { state: { continuous: ContinuousState } }
+>('continuous/fetchTagExplorerViewProfile', async (_, thunkAPI) => {
+  if (tagExplorerViewProfileAbortController) {
+    tagExplorerViewProfileAbortController.abort();
+  }
+
+  tagExplorerViewProfileAbortController = new AbortController();
+  thunkAPI.signal = tagExplorerViewProfileAbortController.signal;
+
+  const state = thunkAPI.getState();
+  const { groupByTag, groupByTagValue } = state.continuous.tagExplorerView;
+  // if "All" option is selected we dont need to modify query to fetch profile
+  const queryProps =
+    ALL_TAGS === groupByTagValue
+      ? { groupBy: groupByTag, query: state.continuous.query }
+      : {
+          query: appendLabelToQuery(
+            state.continuous.query,
+            state.continuous.tagExplorerView.groupByTag,
+            state.continuous.tagExplorerView.groupByTagValue
+          ),
+        };
+  const res = await renderSingle(
+    {
+      ...state.continuous,
+      ...queryProps,
+    },
+    tagExplorerViewProfileAbortController
+  );
+
+  if (res.isOk) {
+    return Promise.resolve(res.value);
+  }
+
+  if (res.isErr && res.error instanceof RequestAbortedError) {
+    return Promise.reject(res.error);
+  }
+
+  thunkAPI.dispatch(
+    addNotification({
+      type: 'danger',
+      title: 'Failed to load explore view profile',
+      message: res.error.message,
+    })
+  );
+
+  return Promise.reject(res.error);
+});

--- a/webapp/javascript/redux/reducers/continuous/tags.thunks.ts
+++ b/webapp/javascript/redux/reducers/continuous/tags.thunks.ts
@@ -1,0 +1,177 @@
+import { Query, queryToAppName } from '@webapp/models/query';
+import * as tagsService from '@webapp/services/tags';
+import { createBiggestInterval } from '@webapp/util/timerange';
+import { formatAsOBject, toUnixTimestamp } from '@webapp/util/formatDate';
+import { ContinuousState } from './state';
+import { addNotification } from '../notifications';
+import { createAsyncThunk } from '../../async-thunk';
+
+function biggestTimeRangeInUnix(state: ContinuousState) {
+  return createBiggestInterval({
+    from: [state.from, state.leftFrom, state.rightFrom]
+      .map(formatAsOBject)
+      .map(toUnixTimestamp),
+    until: [state.until, state.leftUntil, state.leftUntil]
+      .map(formatAsOBject)
+      .map(toUnixTimestamp),
+  });
+}
+
+function assertIsValidAppName(query: Query) {
+  const appName = queryToAppName(query);
+  if (appName.isNothing) {
+    throw Error(`Query '${query}' is not a valid app`);
+  }
+
+  return appName.value;
+}
+
+export const fetchTags = createAsyncThunk<
+  { appName: string; tags: string[]; from: number; until: number },
+  Query,
+  { state: { continuous: ContinuousState } }
+>(
+  'continuous/fetchTags',
+  async (query: Query, thunkAPI) => {
+    const appName = assertIsValidAppName(query);
+
+    const state = thunkAPI.getState().continuous;
+    const timerange = biggestTimeRangeInUnix(state);
+    const res = await tagsService.fetchTags(
+      query,
+      timerange.from,
+      timerange.until
+    );
+
+    if (res.isOk) {
+      return Promise.resolve({
+        appName,
+        tags: res.value,
+        from: timerange.from,
+        until: timerange.until,
+      });
+    }
+
+    thunkAPI.dispatch(
+      addNotification({
+        type: 'danger',
+        title: 'Failed to load tags',
+        message: res.error.message,
+      })
+    );
+
+    return Promise.reject(res.error);
+  },
+  {
+    // If we already loaded the tags for that application
+    // And we are trying to load tags for a smaller range
+    // Skip it, since we most likely already have that data
+    condition: (query, thunkAPI) => {
+      const appName = assertIsValidAppName(query);
+      const state = thunkAPI.getState().continuous;
+      const timerange = biggestTimeRangeInUnix(state);
+
+      const s = state.tags[appName];
+
+      // Haven't loaded yet
+      if (!s) {
+        return true;
+      }
+
+      // Already loading that tag
+      if (s.type === 'loading') {
+        return false;
+      }
+
+      // Any other state that's not loaded
+      if (s.type !== 'loaded') {
+        return true;
+      }
+
+      const isInRange = (target: number) => {
+        return target >= s.from && target <= s.until;
+      };
+
+      const isSmallerThanLoaded =
+        isInRange(timerange.from) && isInRange(timerange.until);
+
+      return !isSmallerThanLoaded;
+    },
+  }
+);
+export const fetchTagValues = createAsyncThunk<
+  {
+    appName: string;
+    label: string;
+    values: string[];
+  },
+  {
+    query: Query;
+    label: string;
+  },
+  { state: { continuous: ContinuousState } }
+>(
+  'continuous/fetchTagsValues',
+  async (payload: { query: Query; label: string }, thunkAPI) => {
+    const appName = assertIsValidAppName(payload.query);
+
+    const state = thunkAPI.getState().continuous.tags[appName];
+    if (!state || state.type !== 'loaded') {
+      return Promise.reject(
+        new Error(
+          `Trying to load label-values for an unloaded label. This is likely due to a race condition.`
+        )
+      );
+    }
+
+    const res = await tagsService.fetchLabelValues(
+      payload.label,
+      payload.query,
+      state.from,
+      state.until
+    );
+
+    if (res.isOk) {
+      return Promise.resolve({
+        appName,
+        label: payload.label,
+        values: res.value,
+      });
+    }
+
+    thunkAPI.dispatch(
+      addNotification({
+        type: 'danger',
+        title: 'Failed to load tag values',
+        message: res.error.message,
+      })
+    );
+
+    return Promise.reject(res.error);
+  },
+  {
+    condition: ({ query, label }, thunkAPI) => {
+      const appName = assertIsValidAppName(query);
+
+      // Are we trying to load values from a tag that wasn't loaded?
+      // If so it's most likely due to a race condition
+      const tagState = thunkAPI.getState().continuous.tags[appName];
+      if (!tagState || tagState.type !== 'loaded') {
+        return false;
+      }
+
+      const tagValueState = tagState.tags[label];
+      // Have not being loaded yet
+      if (!tagValueState) {
+        return true;
+      }
+
+      // Loading or already loaded
+      if (tagValueState.type === 'loading' || tagValueState.type === 'loaded') {
+        return false;
+      }
+
+      return true;
+    },
+  }
+);

--- a/webapp/javascript/redux/reducers/continuous/timelines.thunks.ts
+++ b/webapp/javascript/redux/reducers/continuous/timelines.thunks.ts
@@ -1,0 +1,75 @@
+import { renderSingle } from '@webapp/services/render';
+import type { Timeline } from '@webapp/models/timeline';
+import { RequestAbortedError } from '@webapp/services/base';
+import { addNotification } from '../notifications';
+import { createAsyncThunk } from '../../async-thunk';
+import { ContinuousState } from './state';
+
+let sideTimelinesAbortController: AbortController | undefined;
+
+export const fetchSideTimelines = createAsyncThunk<
+  { left: Timeline; right: Timeline },
+  null,
+  { state: { continuous: ContinuousState } }
+>('continuous/fetchSideTimelines', async (_, thunkAPI) => {
+  if (sideTimelinesAbortController) {
+    sideTimelinesAbortController.abort();
+  }
+
+  sideTimelinesAbortController = new AbortController();
+  thunkAPI.signal = sideTimelinesAbortController.signal;
+
+  const state = thunkAPI.getState();
+
+  const res = await Promise.all([
+    renderSingle(
+      {
+        query: state.continuous.leftQuery || '',
+        from: state.continuous.from,
+        until: state.continuous.until,
+        maxNodes: state.continuous.maxNodes,
+        refreshToken: state.continuous.refreshToken,
+      },
+      sideTimelinesAbortController
+    ),
+    renderSingle(
+      {
+        query: state.continuous.rightQuery || '',
+        from: state.continuous.from,
+        until: state.continuous.until,
+        maxNodes: state.continuous.maxNodes,
+        refreshToken: state.continuous.refreshToken,
+      },
+      sideTimelinesAbortController
+    ),
+  ]);
+
+  if (
+    (res?.[0]?.isErr && res?.[0]?.error instanceof RequestAbortedError) ||
+    (res?.[1]?.isErr && res?.[1]?.error instanceof RequestAbortedError) ||
+    (!res && thunkAPI.signal.aborted)
+  ) {
+    return Promise.reject();
+  }
+
+  if (res?.[0].isOk && res?.[1].isOk) {
+    return Promise.resolve({
+      left: res[0].value.timeline,
+      right: res[1].value.timeline,
+    });
+  }
+
+  thunkAPI.dispatch(
+    addNotification({
+      type: 'danger',
+      title: `Failed to load the timelines`,
+      message: '',
+      additionalInfo: [
+        res?.[0].error.message,
+        res?.[1].error.message,
+      ] as string[],
+    })
+  );
+
+  return Promise.reject(res && res.filter((a) => a?.isErr).map((a) => a.error));
+});


### PR DESCRIPTION
The continuous reducer file was too big (>1k lines), so I moved the thunks to their own files, also moved selectors to a single `selectors.ts` file.
