### PR TITLE
feat: disable sandwich view for diff page

### DIFF
--- a/packages/pyroscope-flamegraph/src/Toolbar.tsx
+++ b/packages/pyroscope-flamegraph/src/Toolbar.tsx
@@ -409,7 +409,9 @@ function ViewSection({
       <option value="flamegraph">Flame</option>
       {flamegraphType === 'single' ? (
         <option value="sandwich">Sandwich</option>
-      ) : null}
+      ) : (
+        (null as ShamefulAny)
+      )}
     </Select>
   );
 

--- a/packages/pyroscope-flamegraph/src/Toolbar.tsx
+++ b/packages/pyroscope-flamegraph/src/Toolbar.tsx
@@ -144,6 +144,7 @@ const Toolbar = React.memo(
           />
           {!disableChangingDisplay && (
             <ViewSection
+              flamegraphType={flamegraphType}
               showMode={showMode}
               view={view}
               updateView={updateView}
@@ -387,10 +388,12 @@ function ViewSection({
   view,
   updateView,
   showMode,
+  flamegraphType,
 }: {
   showMode: ReturnType<typeof useSizeMode>;
   updateView: ProfileHeaderProps['updateView'];
   view: ProfileHeaderProps['view'];
+  flamegraphType: ProfileHeaderProps['flamegraphType'];
 }) {
   const ViewSelect = (
     <Select
@@ -404,7 +407,9 @@ function ViewSection({
       <option value="table">Table</option>
       <option value="both">Both</option>
       <option value="flamegraph">Flame</option>
-      <option value="sandwich">Sandwich</option>
+      {flamegraphType === 'single' ? (
+        <option value="sandwich">Sandwich</option>
+      ) : null}
     </Select>
   );
 
@@ -441,14 +446,16 @@ function ViewSection({
       >
         Flamegraph
       </Button>
-      <Button
-        grouped
-        kind={kindByState('sandwich')}
-        iconNode={<SandwichIcon />}
-        onClick={() => updateView('sandwich')}
-      >
-        Sandwich
-      </Button>
+      {flamegraphType === 'single' ? (
+        <Button
+          grouped
+          kind={kindByState('sandwich')}
+          iconNode={<SandwichIcon />}
+          onClick={() => updateView('sandwich')}
+        >
+          Sandwich
+        </Button>
+      ) : null}
     </>
   );
 


### PR DESCRIPTION
## Brief
- 

## Changes
- disable sandwich view for diff page 

demo link: https://pr-1693.pyroscope.io/?query=rideshare-app-golang.alloc_objects%7B%7D

https://user-images.githubusercontent.com/47758224/200874752-91d416e3-eac9-4f8c-8bdb-b33dc22d4890.mov


## Concerns
-