### PR TITLE
fix: heatmap y-axis value with "<"

### DIFF
--- a/webapp/javascript/components/Heatmap/Heatmap.module.scss
+++ b/webapp/javascript/components/Heatmap/Heatmap.module.scss
@@ -38,7 +38,18 @@ $svg-side-margin: 40px;
     .tickValues {
       margin: -10px 0px;
       width: 30px;
-      word-break: initial;
+
+      .tickValue {
+        position: relative;
+        height: 20px;
+
+        span {
+          position: absolute;
+          display: block;
+          width: 40px;
+          right: 0;
+        }
+      }
     }
 
     .ticksContainer {


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1667

## Changes
- fix y-axis values

demo link:  https://pr-1694.pyroscope.io/exemplars/single?query=rideshare-app-golang.cpu%7B%7D&from=now-30d

1st ss is before fix, 2nd is after fix
<img width="325" alt="Screenshot 2022-11-10 at 11 18 53" src="https://user-images.githubusercontent.com/47758224/201064985-eeca001f-061b-4310-a09a-17c95e1a59ad.png">

<img width="918" alt="Screenshot 2022-11-09 at 17 11 31" src="https://user-images.githubusercontent.com/47758224/200881832-9a965cdb-5243-4757-b0b6-cd1afbc481d5.png">

## Concerns
-