### PR TITLE
feat: enable "reset view" button when table item is highlighted

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -258,6 +258,7 @@ class FlameGraphRenderer extends Component<
         ...this.state.flamegraphConfigs,
         ...this.initialFlamegraphState,
       },
+      selectedItem: Maybe.nothing(),
     });
   };
 
@@ -310,15 +311,16 @@ class FlameGraphRenderer extends Component<
 
   setActiveItem = (item: { name: string }) => {
     const { name } = item;
+    this.setState({ isFlamegraphDirty: true });
 
     // if clicking on the same item, undo the search
     if (this.state.selectedItem.isJust) {
       if (name === this.state.selectedItem.value) {
         this.setState({
           selectedItem: Maybe.nothing(),
+          isFlamegraphDirty: true,
         });
         return;
-        //        name = '';
       }
     }
 

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -318,7 +318,6 @@ class FlameGraphRenderer extends Component<
       if (name === this.state.selectedItem.value) {
         this.setState({
           selectedItem: Maybe.nothing(),
-          isFlamegraphDirty: true,
         });
         return;
       }


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1699

## Changes
- set `isFlamegraphDirty` when clicking on table 
- reset table selected item when clicking _reset_ button 
demo link:  https://pr-1703.pyroscope.io/?query=


https://user-images.githubusercontent.com/47758224/201331118-eabc3998-2232-4642-8a04-945a9933aebb.mov



## Concerns
- nope