### PR TITLE
chore: update icon colors

### DIFF
--- a/packages/pyroscope-flamegraph/src/Toolbar.module.scss
+++ b/packages/pyroscope-flamegraph/src/Toolbar.module.scss
@@ -23,7 +23,7 @@ $buttonHeight: 37px;
 }
 
 .navbar button {
-  color: var(--ps-neutral-2);
+  color: var(--ps-toolbar-icon-color);
 }
 
 .toggleViewButton {
@@ -115,6 +115,6 @@ $buttonHeight: 37px;
 .divider {
   width: 1px;
   height: 35px;
-  background-color: #646466;
+  background-color: var(--ps-ui-border);
   margin: 0 2px;
 }

--- a/webapp/sass/variables.css
+++ b/webapp/sass/variables.css
@@ -85,6 +85,7 @@
 
   --ps-fl-toolbar-bg: #2c2c30;
   --ps-fl-toolbar-btn-bg: #3c7150;
+  --ps-toolbar-icon-color: #ffffff;
 }
 
 [data-theme='light'],
@@ -135,4 +136,5 @@
 
   --ps-fl-toolbar-bg: #00000008;
   --ps-fl-toolbar-btn-bg: #3b78e7;
+  --ps-toolbar-icon-color: #5f6367;
 }


### PR DESCRIPTION
Light mode icon colors were a little too harsh:

before:
<img width="1727" alt="Screen Shot 2022-11-14 at 9 58 42 AM" src="https://user-images.githubusercontent.com/23323466/201692527-e30f1ec7-106d-483c-a98f-2827afe4f448.png">

after:
<img width="1700" alt="Screen Shot 2022-11-14 at 9 58 11 AM" src="https://user-images.githubusercontent.com/23323466/201692552-8c2b7d2c-4bfe-44d7-8418-64f816fa894b.png">

modeled after colors from google sheets
<img width="562" alt="Screen Shot 2022-11-14 at 9 37 14 AM" src="https://user-images.githubusercontent.com/23323466/201692603-2a7d6c76-b231-4b6c-ae0b-503a7f26d3dd.png">

also changed light mode prompt color:
<img width="1446" alt="image" src="https://user-images.githubusercontent.com/23323466/201694913-a9830d28-5591-4bdd-948a-c163dd4bdad0.png">


also made separator match border colors

