### PR TITLE
feat(webapp): Pie chart doesn't display labels correctly when they are too large

### DIFF
--- a/webapp/javascript/pages/tagExplorer/components/TotalSamplesChart/PieChart/index.tsx
+++ b/webapp/javascript/pages/tagExplorer/components/TotalSamplesChart/PieChart/index.tsx
@@ -62,8 +62,9 @@ const PieChart = ({
         label: {
           show: true,
           radius: 0.7,
-          threshold: 0.17,
-          formatter: (label: string) => label,
+          threshold: 0.05,
+          formatter: (_: string, data: { percent: number }) =>
+            `${data.percent.toFixed(2)}%`,
         },
       },
     },


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1516

## Changes
- according to Slack discussion, render chart slice percentage instead of tag name
![image](https://user-images.githubusercontent.com/7372044/202189015-8b5801fa-f99e-45f0-b93b-0a48f76e6396.png)
