### PR TITLE
refactor(flamegraph): Hide ExportData and ChangeView dividers when it necessary

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -538,7 +538,7 @@ class FlameGraphRenderer extends Component<
           {toolbarVisible && (
             <Toolbar
               sharedQuery={this.props.sharedQuery}
-              disableChangingDisplay={!!this.props.onlyDisplay}
+              enableChangingDisplay={!this.props.onlyDisplay}
               flamegraphType={this.state.flamebearer.format}
               view={this.state.view}
               viewDiff={this.state.viewDiff}

--- a/packages/pyroscope-flamegraph/src/Toolbar.tsx
+++ b/packages/pyroscope-flamegraph/src/Toolbar.tsx
@@ -88,8 +88,7 @@ export interface ProfileHeaderProps {
   sharedQuery?: FlamegraphRendererProps['sharedQuery'];
 }
 
-const Divider = ({ visible = true }: { visible?: boolean }) =>
-  visible ? <div className={styles.divider} /> : null;
+const Divider = () => <div className={styles.divider} />;
 
 const Toolbar = React.memo(
   ({
@@ -141,15 +140,17 @@ const Toolbar = React.memo(
             selectedNode={selectedNode}
             onFocusOnSubtree={onFocusOnSubtree}
           />
-          <Divider visible={!disableChangingDisplay} />
-          {!disableChangingDisplay && (
-            <ViewSection
-              flamegraphType={flamegraphType}
-              showMode={showMode}
-              view={view}
-              updateView={updateView}
-            />
-          )}
+          {!disableChangingDisplay ? (
+            <>
+              <Divider />
+              <ViewSection
+                flamegraphType={flamegraphType}
+                showMode={showMode}
+                view={view}
+                updateView={updateView}
+              />
+            </>
+          ) : null}
           {isValidElement(ExportData) ? (
             <>
               <Divider />

--- a/packages/pyroscope-flamegraph/src/Toolbar.tsx
+++ b/packages/pyroscope-flamegraph/src/Toolbar.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, isValidElement } from 'react';
 import classNames from 'classnames/bind';
 import { faAlignLeft } from '@fortawesome/free-solid-svg-icons/faAlignLeft';
 import { faBars } from '@fortawesome/free-solid-svg-icons/faBars';
@@ -88,7 +88,8 @@ export interface ProfileHeaderProps {
   sharedQuery?: FlamegraphRendererProps['sharedQuery'];
 }
 
-const Divider = () => <div className={styles.divider} />;
+const Divider = ({ visible = true }: { visible?: boolean }) =>
+  visible ? <div className={styles.divider} /> : null;
 
 const Toolbar = React.memo(
   ({
@@ -107,7 +108,7 @@ const Toolbar = React.memo(
     flamegraphType,
     disableChangingDisplay = false,
     sharedQuery,
-    ExportData = <></>,
+    ExportData,
   }: ProfileHeaderProps) => {
     const toolbarRef = React.useRef<HTMLDivElement>(null);
     const showMode = useSizeMode(toolbarRef);
@@ -140,7 +141,7 @@ const Toolbar = React.memo(
             selectedNode={selectedNode}
             onFocusOnSubtree={onFocusOnSubtree}
           />
-          <Divider />
+          <Divider visible={!disableChangingDisplay} />
           {!disableChangingDisplay && (
             <ViewSection
               flamegraphType={flamegraphType}
@@ -149,8 +150,12 @@ const Toolbar = React.memo(
               updateView={updateView}
             />
           )}
-          <Divider />
-          {ExportData}
+          {isValidElement(ExportData) ? (
+            <>
+              <Divider />
+              {ExportData}
+            </>
+          ) : null}
         </div>
       </div>
     );

--- a/packages/pyroscope-flamegraph/src/Toolbar.tsx
+++ b/packages/pyroscope-flamegraph/src/Toolbar.tsx
@@ -64,7 +64,7 @@ export const useSizeMode = (target: React.RefObject<HTMLDivElement>) => {
 
 export interface ProfileHeaderProps {
   view: ViewTypes;
-  disableChangingDisplay?: boolean;
+  enableChangingDisplay?: boolean;
   flamegraphType: 'single' | 'double';
   viewDiff: 'diff' | 'total' | 'self';
   handleSearchChange: (s: string) => void;
@@ -105,7 +105,7 @@ const Toolbar = React.memo(
     selectedNode,
     onFocusOnSubtree,
     flamegraphType,
-    disableChangingDisplay = false,
+    enableChangingDisplay = true,
     sharedQuery,
     ExportData,
   }: ProfileHeaderProps) => {
@@ -140,7 +140,7 @@ const Toolbar = React.memo(
             selectedNode={selectedNode}
             onFocusOnSubtree={onFocusOnSubtree}
           />
-          {!disableChangingDisplay ? (
+          {enableChangingDisplay ? (
             <>
               <Divider />
               <ViewSection

--- a/packages/pyroscope-flamegraph/src/__snapshots__/Toolbar.spec.tsx.snap
+++ b/packages/pyroscope-flamegraph/src/__snapshots__/Toolbar.spec.tsx.snap
@@ -239,9 +239,6 @@ exports[`ProfileHeader shifts between visualization modes 1`] = `
           </svg>
         </button>
       </div>
-      <div
-        class="divider"
-      />
     </div>
   </div>
 </DocumentFragment>
@@ -374,9 +371,6 @@ exports[`ProfileHeader shifts between visualization modes 2`] = `
           />
         </div>
       </div>
-      <div
-        class="divider"
-      />
     </div>
   </div>
 </DocumentFragment>


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1710

## Changes
- DEMO: https://pr-1728.pyroscope.io/
- display only flamegraph + **NO** ExportData
![image](https://user-images.githubusercontent.com/7372044/202405263-3db57ecb-36af-4ce2-be8a-ff375bcc8d00.png)

- display only flamegraph + ExportData
![image](https://user-images.githubusercontent.com/7372044/202405522-0eb8b4da-a180-497e-b5a0-ceeeef2e7b5e.png)

- "display only" disabled + ExportData
![image](https://user-images.githubusercontent.com/7372044/202405752-85cd03b3-3956-488b-81c9-52d6ae880317.png)
