### PR TITLE
fix: make reset view available in sandwich mode context menu

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/index.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/index.tsx
@@ -265,19 +265,11 @@ export default function FlameGraphComponent(props: FlamegraphProps) {
         );
       };
 
-      const ResetItem = () => {
-        const isResetDisabled = selectedItem.isNothing && !dirty;
-
-        return (
-          <MenuItem key="reset" disabled={isResetDisabled} onClick={onReset}>
-            <FontAwesomeIcon icon={faRedo} />
-            Reset View
-          </MenuItem>
-        );
-      };
-
       return [
-        ResetItem(),
+        <MenuItem key="reset" disabled={!dirty} onClick={onReset}>
+          <FontAwesomeIcon icon={faRedo} />
+          Reset View
+        </MenuItem>,
         CollapseItem(),
         CopyItem(),
         HighlightSimilarNodesItem(),

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/index.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/index.tsx
@@ -265,11 +265,20 @@ export default function FlameGraphComponent(props: FlamegraphProps) {
         );
       };
 
+      const ResetItem = () => {
+        const isResetDisabled =
+          !(selectedItem.isJust && selectedItem.value) && !dirty;
+
+        return (
+          <MenuItem key="reset" disabled={isResetDisabled} onClick={onReset}>
+            <FontAwesomeIcon icon={faRedo} />
+            Reset View
+          </MenuItem>
+        );
+      };
+
       return [
-        <MenuItem key="reset" disabled={!dirty} onClick={onReset}>
-          <FontAwesomeIcon icon={faRedo} />
-          Reset View
-        </MenuItem>,
+        ResetItem(),
         CollapseItem(),
         CopyItem(),
         HighlightSimilarNodesItem(),

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/index.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphComponent/index.tsx
@@ -266,8 +266,7 @@ export default function FlameGraphComponent(props: FlamegraphProps) {
       };
 
       const ResetItem = () => {
-        const isResetDisabled =
-          !(selectedItem.isJust && selectedItem.value) && !dirty;
+        const isResetDisabled = selectedItem.isNothing && !dirty;
 
         return (
           <MenuItem key="reset" disabled={isResetDisabled} onClick={onReset}>

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -311,7 +311,6 @@ class FlameGraphRenderer extends Component<
 
   setActiveItem = (item: { name: string }) => {
     const { name } = item;
-    this.setState({ isFlamegraphDirty: true });
 
     // if clicking on the same item, undo the search
     if (this.state.selectedItem.isJust) {

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -376,7 +376,7 @@ class FlameGraphRenderer extends Component<
   // so that the flamegraph doesn't rerender unnecessarily
   isDirty = () => {
     return (
-      !this.state.selectedItem.isNothing ||
+      this.state.selectedItem.isJust ||
       JSON.stringify(this.initialFlamegraphState) !==
         JSON.stringify(this.state.flamegraphConfigs)
     );

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -377,8 +377,9 @@ class FlameGraphRenderer extends Component<
   // so that the flamegraph doesn't rerender unnecessarily
   isDirty = () => {
     return (
+      !this.state.selectedItem.isNothing ||
       JSON.stringify(this.initialFlamegraphState) !==
-      JSON.stringify(this.state.flamegraphConfigs)
+        JSON.stringify(this.state.flamegraphConfigs)
     );
   };
 

--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -548,7 +548,7 @@ class FlameGraphRenderer extends Component<
               updateViewDiff={this.updateViewDiff}
               updateFitMode={this.updateFitMode}
               fitMode={this.state.fitMode}
-              isFlamegraphDirty={this.state.isFlamegraphDirty}
+              isFlamegraphDirty={this.isDirty()}
               selectedNode={this.state.flamegraphConfigs.zoom}
               highlightQuery={this.state.searchQuery}
               onFocusOnSubtree={this.onFocusOnNode}


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1727

## Changes
- fix ability to reset flamegraph from ContextMenu components

https://user-images.githubusercontent.com/47758224/202425277-b60efba4-ee6a-4501-aa8d-8bfc72f5a63e.mov


## Concerns
- 