### PR TITLE
fix: table should not say unsupported when search filter doesn't find anything

### DIFF
--- a/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
+++ b/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
@@ -515,7 +515,7 @@ const getTableBody = ({
   return rows.length > 0
     ? { bodyRows: rows, type: 'filled' as const }
     : {
-        value: <div className="unsupported-format">Unsupported</div>,
+        value: <div className="unsupported-format">No items found</div>,
         type: 'not-filled' as const,
       };
 };


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1708

## Changes
- change text

<img width="546" alt="Screenshot 2022-11-17 at 11 47 17" src="https://user-images.githubusercontent.com/47758224/202426418-83cc741d-07b3-482e-91a1-057ea8d73214.png">

## Concerns
- i would remove search input outline
<img width="398" alt="Screenshot 2022-11-17 at 11 45 13" src="https://user-images.githubusercontent.com/47758224/202426308-ceb0d75d-2ffe-4ae5-a87a-71532fe27339.png">
