### PR TITLE
feat: make tag explorer modal adapt to content

### DIFF
--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
@@ -1,42 +1,44 @@
-.title {
-  display: inline-block;
-  text-transform: uppercase;
-  padding: 5px;
-  color: var(--ps-select-modal-title);
-  font-weight: 700;
-}
+.tagSelector {
+  width: auto;
 
-.tags {
-  padding: 0;
-  list-style: none;
-  margin: 0;
-  text-align: left;
-  min-height: 150px;
-  max-height: 440px;
+  .title {
+    display: inline-block;
+    text-transform: uppercase;
+    padding: 5px;
+    color: var(--ps-select-modal-title);
+    font-weight: 700;
+  }
 
-  li {
-    padding: 10px 30px;
+  .tags {
+    padding: 0;
+    list-style: none;
+    margin: 0;
+    text-align: left;
+    min-height: 150px;
+    max-height: 440px;
 
-    &.selected {
-      background-color: var(--ps-blue-highlight);
-    }
+    li {
+      &.selected {
+        background-color: var(--ps-blue-highlight);
+      }
 
-    input {
-      padding: 0;
-      border: none;
-      width: 100%;
-      text-align: left;
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
+      input {
+        border: none;
+        padding: 10px 30px;
+        width: 100%;
+        text-align: left;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
   }
-}
 
-.compareButton {
-  background-color: var(--ps-blue-highlight);
-  border: var(--ps-blue-highlight);
-  padding: 8px;
-  cursor: pointer;
-  border-radius: 4px;
+  .compareButton {
+    background-color: var(--ps-blue-highlight);
+    border: var(--ps-blue-highlight);
+    padding: 8px;
+    cursor: pointer;
+    border-radius: 4px;
+  }
 }

--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
@@ -1,45 +1,45 @@
 .tagsSelector {
   width: auto;
+}
 
-  .title {
-    display: inline-block;
-    text-transform: uppercase;
-    padding: 5px;
-    color: var(--ps-select-modal-title);
-    font-weight: 700;
-  }
+.title {
+  display: inline-block;
+  text-transform: uppercase;
+  padding: 5px;
+  color: var(--ps-select-modal-title);
+  font-weight: 700;
+}
 
-  .tags {
-    max-width: 500px;
-    padding: 0;
-    list-style: none;
-    margin: 0;
-    text-align: left;
-    min-height: 150px;
-    max-height: 440px;
+.tags {
+  max-width: 500px;
+  padding: 0;
+  list-style: none;
+  margin: 0;
+  text-align: left;
+  min-height: 150px;
+  max-height: 440px;
 
-    li {
-      &.selected {
-        background-color: var(--ps-blue-highlight);
-      }
+  li {
+    &.selected {
+      background-color: var(--ps-blue-highlight);
+    }
 
-      input {
-        border: none;
-        padding: 10px 30px;
-        width: 100%;
-        text-align: left;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
+    input {
+      border: none;
+      padding: 10px 30px;
+      width: 100%;
+      text-align: left;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
+}
 
-  .compareButton {
-    background-color: var(--ps-blue-highlight);
-    border: var(--ps-blue-highlight);
-    padding: 8px;
-    cursor: pointer;
-    border-radius: 4px;
-  }
+.compareButton {
+  background-color: var(--ps-blue-highlight);
+  border: var(--ps-blue-highlight);
+  padding: 8px;
+  cursor: pointer;
+  border-radius: 4px;
 }

--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
@@ -10,6 +10,7 @@
   }
 
   .tags {
+    max-width: 500px;
     padding: 0;
     list-style: none;
     margin: 0;

--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
@@ -1,4 +1,4 @@
-.tagSelector {
+.tagsSelector {
   width: auto;
 
   .title {

--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.module.scss
@@ -15,13 +15,15 @@
   max-height: 440px;
 
   li {
+    padding: 10px 30px;
+
     &.selected {
       background-color: var(--ps-blue-highlight);
     }
 
     input {
+      padding: 0;
       border: none;
-      padding: 10px 30px;
       width: 100%;
       text-align: left;
       white-space: nowrap;

--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.tsx
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.tsx
@@ -7,6 +7,7 @@ import { appendLabelToQuery } from '@webapp/util/query';
 import { brandQuery } from '@webapp/models/query';
 import { PAGES } from '@webapp/pages/constants';
 import ModalWithToggle from '@webapp/ui/Modals/ModalWithToggle';
+import { Tooltip } from '@webapp/ui/Tooltip';
 import styles from './TagsSelector.module.scss';
 
 const emptyTagsTag = 'No tags available';
@@ -85,19 +86,21 @@ function TagSelector({
       <ul className={styles.tags}>
         {tags.map((tag) => (
           <li className={sideTag === tag ? styles.selected : ''} key={tag}>
-            <input
-              type="button"
-              onClick={
-                tag !== emptyTagsTag
-                  ? () =>
-                      setSelectedTags((currState) => ({
-                        ...currState,
-                        [tagsSideName]: tag,
-                      }))
-                  : undefined
-              }
-              value={tag}
-            />
+            <Tooltip placement="top" title={tag}>
+              <input
+                type="button"
+                onClick={
+                  tag !== emptyTagsTag
+                    ? () =>
+                        setSelectedTags((currState) => ({
+                          ...currState,
+                          [tagsSideName]: tag,
+                        }))
+                    : undefined
+                }
+                value={tag}
+              />
+            </Tooltip>
           </li>
         ))}
       </ul>

--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.tsx
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Redirect, useLocation } from 'react-router-dom';
+import cl from 'classnames';
 
 import { useAppDispatch } from '@webapp/redux/hooks';
 import { actions } from '@webapp/redux/reducers/continuous';
@@ -86,7 +87,7 @@ function TagSelector({
         {tags.map((tag) => (
           <li
             title={tag}
-            className={sideTag === tag ? styles.selected : ''}
+            className={cl({ [styles.selected]: sideTag === tag })}
             key={tag}
           >
             <input

--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.tsx
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.tsx
@@ -120,7 +120,7 @@ function TagSelector({
 
   return (
     <ModalWithToggle
-      modalClassName={styles.tagSelector}
+      modalClassName={styles.tagsSelector}
       isModalOpen={isModalOpen}
       setModalOpenStatus={setModalOpenStatus}
       customHandleOutsideClick={handleOutsideClick}

--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.tsx
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.tsx
@@ -84,7 +84,11 @@ function TagSelector({
       </span>
       <ul className={styles.tags}>
         {tags.map((tag) => (
-          <li className={sideTag === tag ? styles.selected : ''} key={tag}>
+          <li
+            title={tag}
+            className={sideTag === tag ? styles.selected : ''}
+            key={tag}
+          >
             <input
               type="button"
               onClick={

--- a/webapp/javascript/pages/tagExplorer/components/TagsSelector.tsx
+++ b/webapp/javascript/pages/tagExplorer/components/TagsSelector.tsx
@@ -7,7 +7,6 @@ import { appendLabelToQuery } from '@webapp/util/query';
 import { brandQuery } from '@webapp/models/query';
 import { PAGES } from '@webapp/pages/constants';
 import ModalWithToggle from '@webapp/ui/Modals/ModalWithToggle';
-import { Tooltip } from '@webapp/ui/Tooltip';
 import styles from './TagsSelector.module.scss';
 
 const emptyTagsTag = 'No tags available';
@@ -86,21 +85,19 @@ function TagSelector({
       <ul className={styles.tags}>
         {tags.map((tag) => (
           <li className={sideTag === tag ? styles.selected : ''} key={tag}>
-            <Tooltip placement="top" title={tag}>
-              <input
-                type="button"
-                onClick={
-                  tag !== emptyTagsTag
-                    ? () =>
-                        setSelectedTags((currState) => ({
-                          ...currState,
-                          [tagsSideName]: tag,
-                        }))
-                    : undefined
-                }
-                value={tag}
-              />
-            </Tooltip>
+            <input
+              type="button"
+              onClick={
+                tag !== emptyTagsTag
+                  ? () =>
+                      setSelectedTags((currState) => ({
+                        ...currState,
+                        [tagsSideName]: tag,
+                      }))
+                  : undefined
+              }
+              value={tag}
+            />
           </li>
         ))}
       </ul>
@@ -123,6 +120,7 @@ function TagSelector({
 
   return (
     <ModalWithToggle
+      modalClassName={styles.tagSelector}
       isModalOpen={isModalOpen}
       setModalOpenStatus={setModalOpenStatus}
       customHandleOutsideClick={handleOutsideClick}


### PR DESCRIPTION
## Brief 
- https://github.com/pyroscope-io/pyroscope/issues/1517

## Changes
- remove fixed width

<img width="324" alt="Screenshot 2022-11-17 at 16 00 52" src="https://user-images.githubusercontent.com/47758224/202481362-0bf175a3-9383-49a8-9761-85de1e0cc920.png">
<img width="733" alt="Screenshot 2022-11-17 at 16 01 21" src="https://user-images.githubusercontent.com/47758224/202481370-44dc1922-216e-4077-bf1a-a7d17890c622.png">
