### PR TITLE
fix(webapp): Tag Explorer loading spinner consistent with other pages

### DIFF
--- a/webapp/javascript/redux/reducers/continuous/selectors.ts
+++ b/webapp/javascript/redux/reducers/continuous/selectors.ts
@@ -36,7 +36,9 @@ export const selectIsLoadingData = (state: RootState) => {
     loadingStates.includes(state.continuous.leftTimeline.type) ||
     loadingStates.includes(state.continuous.rightTimeline.type) ||
     // Exemplars
-    loadingStates.includes(state.tracing.exemplarsSingleView.type)
+    loadingStates.includes(state.tracing.exemplarsSingleView.type) ||
+    // Tag Explorer
+    loadingStates.includes(state.continuous.tagExplorerView.type)
   );
 };
 


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1376

## Changes
- DEMO: https://pr-1748.pyroscope.io/

https://user-images.githubusercontent.com/7372044/203017090-4fc5eee3-df03-46ed-a3b4-198110848f7f.mp4

