### PR TITLE
fix: make table rows only take one line

### DIFF
--- a/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
+++ b/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
@@ -233,7 +233,9 @@ function Table({
       {...tableSortProps}
       tableBodyRef={tableBodyRef}
       table={table}
-      className={cl('flamegraph-table', { 'flamegraph-table-doubles': isDoubles })}
+      className={cl('flamegraph-table', {
+        'flamegraph-table-doubles': isDoubles,
+      })}
     />
   );
 }

--- a/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
+++ b/packages/pyroscope-flamegraph/src/ProfilerTable.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, RefObject, CSSProperties } from 'react';
 import type Color from 'color';
+import cl from 'classnames';
 import type { Maybe } from 'true-myth';
 import { doubleFF, singleFF, Flamebearer } from '@pyroscope/models/src';
 // until ui is moved to its own package this should do it
@@ -232,7 +233,7 @@ function Table({
       {...tableSortProps}
       tableBodyRef={tableBodyRef}
       table={table}
-      className="flamegraph-table"
+      className={cl('flamegraph-table', { 'flamegraph-table-doubles': isDoubles })}
     />
   );
 }

--- a/webapp/sass/common.scss
+++ b/webapp/sass/common.scss
@@ -90,6 +90,12 @@ tt {
     width: 130px;
     min-width: 130px;
     max-width: 130px;
+
+    &:first-child {
+      width: auto;
+      min-width: auto;
+      max-width: auto;
+    }
   }
 
   .symbol-name {

--- a/webapp/sass/common.scss
+++ b/webapp/sass/common.scss
@@ -85,6 +85,13 @@ tt {
     }
   }
 
+  &.flamegraph-table-doubles th,
+  &.flamegraph-table-doubles td {
+    width: 130px;
+    min-width: 130px;
+    max-width: 130px;
+  }
+
   .symbol-name {
     font-size: 14px;
     font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;

--- a/webapp/sass/common.scss
+++ b/webapp/sass/common.scss
@@ -57,9 +57,9 @@ tt {
 
     border-left: 1px solid var(--ps-ui-border);
     border-bottom: 1px solid var(--ps-ui-border);
-    width: 130px;
-    min-width: 130px;
-    max-width: 130px;
+    width: 150px;
+    min-width: 150px;
+    max-width: 150px;
 
     span {
       text-shadow: 0 0 1px var(--ps-table-row-text-shadow);


### PR DESCRIPTION
## Brief 
- https://github.com/pyroscope-io/pyroscope/issues/1764

## Changes
- increase width of profile table columns


https://user-images.githubusercontent.com/47758224/204250123-288dbb04-2a31-4cbb-a369-6024b9600aea.mov

