### PR TITLE
chore(webapp): fix type

### DIFF
--- a/webapp/javascript/ui/Menu.tsx
+++ b/webapp/javascript/ui/Menu.tsx
@@ -3,7 +3,7 @@ import {
   MenuItem,
   ControlledMenu,
   useMenuState,
-  ClickEvent,
 } from '@szhsin/react-menu';
+import type { ClickEvent } from '@szhsin/react-menu';
 
 export { ControlledMenu, Menu, MenuItem, useMenuState, ClickEvent };


### PR DESCRIPTION
When building an application that reuses the webapp code, I got;
```
export 'ClickEvent' (reexported as 'ClickEvent') was not found in '@szhsin/react-menu' (possible exports: ControlledMenu, FocusableItem, Menu, MenuButton, MenuDivider, MenuGroup, MenuHeader, MenuItem, MenuRadioGroup, SubMenu, useMenuState)
```

Don't know the exact cause, only that `import type` solves the issue.