### PR TITLE
fix(webapp): Timeline ticks overlapping

### DIFF
--- a/webapp/javascript/components/TimelineChart/TimelineChartWrapper.tsx
+++ b/webapp/javascript/components/TimelineChart/TimelineChartWrapper.tsx
@@ -167,6 +167,8 @@ class TimelineChartWrapper extends React.Component<
         mode: 'time',
         timezone: props.timezone,
         reserveSpace: false,
+        // according to https://github.com/flot/flot/blob/master/API.md#customizing-the-axes
+        minTickSize: [3, 'second'],
       },
     };
 


### PR DESCRIPTION
## Brief
- fixes https://github.com/pyroscope-io/pyroscope/issues/1604

# Changes
- added `minTickSize` option for timelines.

https://user-images.githubusercontent.com/7372044/205306728-c7a6e689-0c18-4747-a60c-e27c80ed5bd0.mp4

DEMO: https://pr-1786.pyroscope.io/

