### PR TITLE
chore(webapp): color mode for timeline [Single View]

### DIFF
--- a/webapp/javascript/hooks/colorMode.hook.ts
+++ b/webapp/javascript/hooks/colorMode.hook.ts
@@ -5,18 +5,49 @@ import { setColorMode, selectAppColorMode } from '@webapp/redux/reducers/ui';
 const useColorMode = () => {
   const dispatch = useAppDispatch();
   const colorMode = useAppSelector(selectAppColorMode);
+  const { body } = document;
+
+  const changeColorMode = (newColorMode: 'light' | 'dark') =>
+    dispatch(setColorMode(newColorMode));
 
   useEffect(() => {
-    // sync color mode from redux with DOM body attr
-    if (document.body.dataset.theme !== colorMode) {
-      document.body.dataset.theme = colorMode;
+    // sync data-theme attr with redux value
+    const observer = new MutationObserver((mutationsList) => {
+      const mutation = mutationsList[0];
+
+      if (mutation.type === 'attributes' && body.dataset.theme !== colorMode) {
+        changeColorMode(
+          body.dataset.theme === 'light' || body.dataset.theme === 'dark'
+            ? body.dataset.theme
+            : 'dark'
+        );
+      }
+    });
+
+    if (body) {
+      observer.observe(body, {
+        attributes: true,
+        attributeFilter: ['data-theme'],
+        childList: false,
+        subtree: false,
+      });
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    // sync redux value with DOM body attr
+    if (body.dataset.theme !== colorMode) {
+      body.dataset.theme = colorMode;
     }
   }, [colorMode]);
 
   return {
     colorMode,
-    changeColorMode: (newColorMode: 'light' | 'dark') =>
-      dispatch(setColorMode(newColorMode)),
+    changeColorMode,
   };
 };
 

--- a/webapp/javascript/pages/ContinuousSingleView.tsx
+++ b/webapp/javascript/pages/ContinuousSingleView.tsx
@@ -114,6 +114,7 @@ function ContinuousSingleView() {
       case 'reloading': {
         return {
           data: singleView.timeline,
+          color: colorMode === 'light' ? '#3b78e7' : undefined,
         };
       }
 


### PR DESCRIPTION
## Brief
- https://github.com/pyroscope-io/pyroscope/issues/1788

## Changes
- added color for Single View timeline chart on light mode (I set primary color for light mode as bars color, but it can be changed after review)
![image](https://user-images.githubusercontent.com/7372044/205648580-cdd36209-0d63-4a75-9f86-bda4037ed370.png)

- added logic which tracks changing color mode for `<body data-theme="light | dark">`. There are 2 source where we set current color mode - redux store (`ui.colorMode`) and `<body data-theme="light | dark">`. I extended `useColorMode` logic to have synced both these source. When some logic changes color mode in `data-theme` there is react-side handler which updates UI according to new theme.

- DEMO: https://pr-1790.pyroscope.io/