### PR TITLE
chore: add file service discovery example

### DIFF
--- a/examples/golang-pull/file/Dockerfile
+++ b/examples/golang-pull/file/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.18.3
+
+WORKDIR /go/src/app
+
+COPY main.go ./main.go
+
+RUN go mod init github.com/pyroscope-io/pyroscope/examples/golang-pull/static
+RUN go get -d ./
+RUN go build -o main .
+
+RUN adduser --disabled-password --gecos --quiet pyroscope
+USER pyroscope
+
+CMD ["./main"]

--- a/examples/golang-pull/file/README.md
+++ b/examples/golang-pull/file/README.md
@@ -1,0 +1,71 @@
+# Pyroscope pull with static targets
+
+This example demonstrates how Pyroscope can be used to scrape pprof profiles from remote targets discovered via file-based service discovery mechanism.
+
+When using Pyroscope' file-based service discovery mechanism, the Prometheus instance will listen for changes to the file and automatically update the scrape target list, without requiring an instance restart.
+
+### 1. Run Pyroscope server and demo applications in docker containers
+
+```shell
+docker-compose up -d
+```
+
+As a sample application we use slightly modified Jaeger [Hot R.O.D.](https://github.com/jaegertracing/jaeger/tree/master/examples/hotrod) demo –
+the only difference is that we enabled built-in Go `pprof` HTTP endpoints. You can find the modified code in the [hotrod-goland](https://github.com/pyroscope-io/hotrod-golang) repository.
+
+Note that we apply configuration defined in `server.yml`:
+
+<details>
+    <summary>server.yml</summary>
+
+```yaml
+---
+log-level: debug
+scrape-configs:
+  - job-name: testing
+    enabled-profiles: [cpu, mem, goroutines, mutex, block]
+    file-sd-configs:
+      - refresh-interval: 10s
+        files:
+          - '/targets.json'
+```
+
+</details>
+
+The file contains a list of remote target the Pyroscope server will pull profiling data from:
+
+<details>
+    <summary>targets.json</summary>
+
+```json
+[
+  {
+    "application": "hotrod",
+    "spy-name": "gospy",
+    "labels": {
+      "env": "dev"
+    },
+    "targets": [
+      "hotrod:6060"
+    ]
+  },
+  {
+    "application": "my-app",
+    "spy-name": "gospy",
+    "labels": {
+      "env": "dev"
+    },
+    "targets": [
+      "app:6060"
+    ]
+  }
+]
+```
+
+</details>
+
+### 2. Observe profiling data
+
+Profiling is more fun when the application does some work. Let's order some rides [in our Hot R.O.D. app](http://localhost:8080).
+
+Now that everything is set up, you can browse profiling data via [Pyroscope UI](http://localhost:4040).

--- a/examples/golang-pull/file/docker-compose.yml
+++ b/examples/golang-pull/file/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.9'
+services:
+  pyroscope:
+    image: 'pyroscope/pyroscope:latest'
+    ports:
+      - 4040:4040
+    command:
+      - server
+    volumes:
+      - ./server.yml:/etc/pyroscope/server.yml
+      - ./targets.json:/targets.json
+
+  hotrod:
+    image: 'public.ecr.aws/pyroscope/hotrod-golang:latest'
+    ports:
+      - 8080:8080
+      - 6060:6060
+    environment:
+      JAEGER_AGENT_HOST: jaeger
+      JAEGER_AGENT_PORT: '6831'
+    command:
+      - all
+
+  # Required for hotrod.
+  jaeger:
+    image: 'jaegertracing/all-in-one:1.11'
+    ports:
+      - '6831:6831/udp'
+      - '16686:16686'
+
+  app:
+    build: .
+    ports:
+      - 6061:6060

--- a/examples/golang-pull/file/main.go
+++ b/examples/golang-pull/file/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"sync"
+
+	"github.com/pyroscope-io/client/pyroscope"
+)
+
+//go:noinline
+func work(n int) {
+	// revive:disable:empty-block this is fine because this is a example app, not real production code
+	for i := 0; i < n; i++ {
+	}
+	// revive:enable:empty-block
+}
+
+var m *sync.Mutex
+
+func init() {
+	m = &sync.Mutex{}
+	runtime.SetMutexProfileFraction(5)
+	runtime.SetBlockProfileRate(5)
+}
+
+func fastFunction(c context.Context, wg *sync.WaitGroup) {
+	m.Lock()
+	defer m.Unlock()
+	pyroscope.TagWrapper(c, pyroscope.Labels("function", "fast"), func(c context.Context) {
+		work(20000000)
+	})
+	wg.Done()
+}
+
+func slowFunction(c context.Context, wg *sync.WaitGroup) {
+	m.Lock()
+	defer m.Unlock()
+	// standard pprof.Do wrappers work as well
+	pprof.Do(c, pprof.Labels("function", "slow"), func(c context.Context) {
+		work(80000000)
+	})
+	wg.Done()
+}
+
+func main() {
+	go func() {
+		log.Println(http.ListenAndServe(":6060", nil))
+	}()
+	serverAddress := os.Getenv("PYROSCOPE_SERVER_ADDRESS")
+	if serverAddress == "" {
+		serverAddress = "http://localhost:4040"
+	}
+	pyroscope.TagWrapper(context.Background(), pyroscope.Labels("foo", "bar"), func(c context.Context) {
+		for {
+			wg := sync.WaitGroup{}
+			wg.Add(6)
+			go fastFunction(c, &wg)
+			go fastFunction(c, &wg)
+			go fastFunction(c, &wg)
+			go slowFunction(c, &wg)
+			go slowFunction(c, &wg)
+			go slowFunction(c, &wg)
+			wg.Wait()
+		}
+	})
+}

--- a/examples/golang-pull/file/server.yml
+++ b/examples/golang-pull/file/server.yml
@@ -1,0 +1,9 @@
+---
+log-level: debug
+scrape-configs:
+  - job-name: testing
+    enabled-profiles: [cpu, mem, goroutines, mutex, block]
+    file-sd-configs:
+      - refresh-interval: 10s
+        files:
+          - '/targets.json'

--- a/examples/golang-pull/file/targets.json
+++ b/examples/golang-pull/file/targets.json
@@ -1,0 +1,22 @@
+[
+  {
+    "application": "hotrod",
+    "spy-name": "gospy",
+    "labels": {
+      "env": "dev"
+    },
+    "targets": [
+      "hotrod:6060"
+    ]
+  },
+  {
+    "application": "last-app",
+    "spy-name": "gospy",
+    "labels": {
+      "env": "dev"
+    },
+    "targets": [
+      "app:6060"
+    ]
+  }
+]


### PR DESCRIPTION
The PR adds an example configuration of the [file service discovery mechanism](https://github.com/pyroscope-io/pyroscope/pull/662) which was implemented almost a year ago but has not been documented