### PR TITLE
[MINOR] Fix order of table header for API Keys

### DIFF
--- a/webapp/javascript/components/Settings/APIKeys/index.tsx
+++ b/webapp/javascript/components/Settings/APIKeys/index.tsx
@@ -34,8 +34,8 @@ const getBodyRows = (
   return keys.reduce((acc, k) => {
     acc.push({
       cells: [
-        { value: k.name },
         { value: k.id },
+        { value: k.name },
         { value: k.role },
         { value: formatRelative(k.createdAt, now) },
         {
@@ -64,11 +64,11 @@ const getBodyRows = (
 };
 
 const headRow = [
+  { name: '', label: 'Id', sortable: 0 },
   { name: '', label: 'Name', sortable: 0 },
   { name: '', label: 'Role', sortable: 0 },
   { name: '', label: 'Creation date', sortable: 0 },
   { name: '', label: 'Expiration date', sortable: 0 },
-  { name: '', label: 'Role', 'aria-label': 'Actions', sortable: 0 },
 ];
 
 const ApiKeys = () => {


### PR DESCRIPTION
Making a minor fix to the `HeadRow` of Api Keys table to ensure that headings match the actual content


### Before
<img width="1124" alt="Screenshot 2023-01-03 at 11 36 12 PM" src="https://user-images.githubusercontent.com/408863/210417032-c5e79912-a7c1-4980-afb5-b9f311f88fbb.png">

### After
<img width="1136" alt="Screenshot 2023-01-03 at 11 33 19 PM" src="https://user-images.githubusercontent.com/408863/210417022-182c3021-f7af-4ac8-9599-1c659f0515e0.png">