### PR TITLE
chore(webapp): add table pagination

### DIFF
--- a/stories/Table.stories.tsx
+++ b/stories/Table.stories.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import Table, {
+  useTableSort,
+  BodyRow,
+  TableBodyType,
+} from '../webapp/javascript/ui/Table';
+import { randomId } from '../webapp/javascript/util/randomId';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import '../webapp/sass/profile.scss';
+
+const Template: ComponentStory<typeof Table> = (args) => <Table {...args} />;
+
+export default {
+  title: 'Components/Table',
+  component: Table,
+} as ComponentMeta<typeof Table>;
+
+const items = Array.from({ length: 20 }).map(() => {
+  return {
+    id: randomId(),
+    value: Math.random(),
+  };
+});
+
+export const MyTable = () => {
+  const headRow = [
+    { name: '', label: 'Id', sortable: 0 },
+    { name: '', label: 'Value', sortable: 0 },
+  ];
+
+  const bodyRows = items.map((a) => {
+    return {
+      onClick: () => alert(`clicked on ${JSON.stringify(a)}`),
+      cells: [{ value: a.id }, { value: a.value }],
+    };
+  });
+
+  return (
+    <Table
+      table={{
+        type: 'filled',
+        headRow,
+        bodyRows,
+      }}
+    />
+  );
+};

--- a/stories/Table.stories.tsx
+++ b/stories/Table.stories.tsx
@@ -1,32 +1,26 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import Table, {
-  useTableSort,
-  BodyRow,
-  TableBodyType,
-} from '../webapp/javascript/ui/Table';
+import Table from '../webapp/javascript/ui/Table';
 import { randomId } from '../webapp/javascript/util/randomId';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import '../webapp/sass/profile.scss';
-
-const Template: ComponentStory<typeof Table> = (args) => <Table {...args} />;
 
 export default {
   title: 'Components/Table',
   component: Table,
 } as ComponentMeta<typeof Table>;
 
-const items = Array.from({ length: 20 }).map(() => {
+const items = Array.from({ length: 20 }).map((a, i) => {
   return {
-    id: randomId(),
-    value: Math.random(),
+    id: i,
+    value: randomId(),
   };
 });
 
 export const MyTable = () => {
   const headRow = [
-    { name: '', label: 'Id', sortable: 0 },
-    { name: '', label: 'Value', sortable: 0 },
+    { name: '', label: 'Id', sortable: 1 },
+    { name: '', label: 'Value', sortable: 1 },
   ];
 
   const bodyRows = items.map((a) => {
@@ -38,6 +32,7 @@ export const MyTable = () => {
 
   return (
     <Table
+      itemsPerPage={5}
       table={{
         type: 'filled',
         headRow,

--- a/webapp/javascript/ui/Table.module.scss
+++ b/webapp/javascript/ui/Table.module.scss
@@ -75,3 +75,8 @@
   text-align: center;
   margin-top: 50px;
 }
+
+.pagination {
+  display: flex;
+  justify-content: flex-end;
+}

--- a/webapp/javascript/ui/Table.spec.tsx
+++ b/webapp/javascript/ui/Table.spec.tsx
@@ -1,6 +1,7 @@
+import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
-
-import { useTableSort } from './Table';
+import { render, within, screen } from '@testing-library/react';
+import Table, { useTableSort } from './Table';
 
 const mockHeadRow = [
   { name: 'self', label: 'test col2', sortable: 1 },
@@ -59,5 +60,42 @@ describe('Hook: useTableSort', () => {
       sortBy: 'name',
       sortByDirection: 'asc',
     });
+  });
+});
+
+describe.only('pagination', () => {
+  const header = [{ name: 'id', label: 'Id' }];
+  const rows = Array.from({ length: 10 }).map((item, index) => {
+    return {
+      cells: [{ value: index }],
+    };
+  });
+
+  it('does not paginate by default', async () => {
+    render(
+      <Table table={{ type: 'filled', headRow: header, bodyRows: rows }} />
+    );
+
+    const tbody = document.getElementsByTagName('tbody')[0];
+    const items = await within(tbody).findAllByRole('row');
+    expect(items).toHaveLength(10);
+  });
+
+  it('paginates', async () => {
+    render(
+      <Table
+        itemsPerPage={1}
+        table={{
+          type: 'filled',
+          headRow: header,
+          bodyRows: rows,
+        }}
+      />
+    );
+
+    const tbody = document.getElementsByTagName('tbody')[0];
+    const items = await within(tbody).findAllByRole('row');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveTextContent('0');
   });
 });

--- a/webapp/javascript/ui/Table.spec.tsx
+++ b/webapp/javascript/ui/Table.spec.tsx
@@ -63,13 +63,13 @@ describe('Hook: useTableSort', () => {
   });
 });
 
-describe.only('pagination', () => {
+describe('pagination', () => {
   const header = [{ name: 'id', label: 'Id' }];
-  const rows = Array.from({ length: 10 }).map((item, index) => {
-    return {
-      cells: [{ value: index }],
-    };
-  });
+  const rows = [
+    { cells: [{ value: 1 }] },
+    { cells: [{ value: 2 }] },
+    { cells: [{ value: 3 }] },
+  ];
 
   it('does not paginate by default', async () => {
     render(
@@ -78,7 +78,7 @@ describe.only('pagination', () => {
 
     const tbody = document.getElementsByTagName('tbody')[0];
     const items = await within(tbody).findAllByRole('row');
-    expect(items).toHaveLength(10);
+    expect(items).toHaveLength(rows.length);
   });
 
   it('paginates', async () => {
@@ -94,8 +94,28 @@ describe.only('pagination', () => {
     );
 
     const tbody = document.getElementsByTagName('tbody')[0];
-    const items = await within(tbody).findAllByRole('row');
+
+    // First page
+    expect(screen.getByLabelText('Previous Page')).toBeDisabled();
+    expect(screen.getByLabelText('Next Page')).toBeEnabled();
+    let items = await within(tbody).findAllByRole('row');
     expect(items).toHaveLength(1);
-    expect(items[0]).toHaveTextContent('0');
+    expect(items[0]).toHaveTextContent('1');
+
+    // Second page
+    screen.getByLabelText('Next Page').click();
+    expect(screen.getByLabelText('Previous Page')).toBeEnabled();
+    expect(screen.getByLabelText('Next Page')).toBeEnabled();
+    items = await within(tbody).findAllByRole('row');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveTextContent('2');
+
+    // Third page
+    screen.getByLabelText('Next Page').click();
+    expect(screen.getByLabelText('Previous Page')).toBeEnabled();
+    expect(screen.getByLabelText('Next Page')).toBeDisabled();
+    items = await within(tbody).findAllByRole('row');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveTextContent('3');
   });
 });

--- a/webapp/javascript/ui/Table.tsx
+++ b/webapp/javascript/ui/Table.tsx
@@ -230,7 +230,7 @@ function PaginationNavigation({
     : false;
 
   return (
-    <nav>
+    <nav className={styles.pagination}>
       <Button
         aria-label="Previous Page"
         disabled={!isTherePreviousPage}

--- a/webapp/javascript/ui/Table.tsx
+++ b/webapp/javascript/ui/Table.tsx
@@ -84,6 +84,8 @@ interface TableProps {
   tableBodyRef?: RefObject<HTMLTableSectionElement>;
   className?: string;
   isLoading?: boolean;
+  /* enables pagination */
+  itemsPerPage?: number;
 }
 
 function Table({
@@ -94,8 +96,11 @@ function Table({
   tableBodyRef,
   className,
   isLoading,
+  itemsPerPage,
 }: TableProps) {
   const hasSort = sortByDirection && sortBy && updateSortParams;
+  const [currPage, setCurrPage] = useState(0);
+
   return isLoading ? (
     <div className={styles.loadingSpinner}>
       <LoadingSpinner />
@@ -141,7 +146,7 @@ function Table({
             <td colSpan={table.headRow.length}>{table.value}</td>
           </tr>
         ) : (
-          table.bodyRows?.map(
+          paginate(table.bodyRows, currPage, itemsPerPage).map(
             ({ cells, isRowSelected, isRowDisabled, className, ...rest }) => {
               // The problem is that when you switch apps or time-range and the function
               // names stay the same it leads to an issue where rows don't get re-rendered
@@ -174,6 +179,18 @@ function Table({
       </tbody>
     </table>
   );
+}
+
+function paginate(
+  bodyRows: Extract<Table, { type: 'filled' }>['bodyRows'],
+  currPage: number,
+  itemsPerPage?: TableProps['itemsPerPage']
+) {
+  if (!itemsPerPage) {
+    return bodyRows;
+  }
+
+  return bodyRows.slice(currPage * itemsPerPage, itemsPerPage * (currPage + 1));
 }
 
 export default Table;


### PR DESCRIPTION
* Adds very simple frontend pagination to the `Table` component:
![image](https://user-images.githubusercontent.com/6951209/211596576-bbd9ad00-acee-4be5-bb3f-4ca96eceddfa.png)
(sorry, having trouble generating gifs right now)

The use case is for some internal visualization code I am writing which has a large number of items.

To have it enabled, just pass an `itemsPerPage` prop.

* Also add tests for this pagination, and a storybook example.
* Left only previous/next page button, so that implementing api pagination is easier (specially when using cursors, as opposed to offsets).

