### PR TITLE
feat(webapp): add annotations rendering to all timelines

### DIFF
--- a/webapp/javascript/components/TimelineChart/TimelineChartWrapper.tsx
+++ b/webapp/javascript/components/TimelineChart/TimelineChartWrapper.tsx
@@ -5,6 +5,7 @@ import React, { ReactNode } from 'react';
 import Color from 'color';
 import type { Group } from '@pyroscope/models/src';
 import type { Timeline } from '@webapp/models/timeline';
+import { Annotation } from '@webapp/models/annotation';
 import Legend from '@webapp/pages/tagExplorer/components/Legend';
 import type { TooltipCallbackProps } from '@webapp/components/TimelineChart/Tooltip.plugin';
 import type { ITooltipWrapperProps } from './TooltipWrapper';
@@ -86,7 +87,7 @@ type TimelineChartWrapperProps = TimelineDataProps & {
   onHoverDisplayTooltip?: React.FC<TooltipCallbackProps>;
 
   /** list of annotations timestamp, to be rendered as markings */
-  annotations?: { timestamp: number; content: string }[];
+  annotations?: Annotation[];
 
   /** What element to render when clicking */
   ContextMenu?: (props: ContextMenuProps) => React.ReactNode;
@@ -290,6 +291,7 @@ class TimelineChartWrapper extends React.Component<
       onHoverDisplayTooltip,
       ContextMenu: this.props.ContextMenu,
       xaxis: { ...flotOptions.xaxis, autoscaleMargin: null, timezone },
+      wrapperId: this.props.id,
     };
 
     const centeredTimelineGroups = timelineGroups.map(

--- a/webapp/javascript/pages/ContinuousComparisonView.tsx
+++ b/webapp/javascript/pages/ContinuousComparisonView.tsx
@@ -12,6 +12,7 @@ import {
   fetchTagValues,
   selectQueries,
   selectTimelineSides,
+  selectAnnotationsOrDefault,
 } from '@webapp/redux/reducers/continuous';
 import SideTimelineComparator from '@webapp/components/SideTimelineComparator';
 import TimelineChartWrapper from '@webapp/components/TimelineChart/TimelineChartWrapper';
@@ -62,6 +63,9 @@ function ComparisonApp() {
   const { leftTags, rightTags } = useTags();
   const { leftTimeline, rightTimeline } = useTimelines();
   const sharedQuery = useFlamegraphSharedQuery();
+  const annotations = useAppSelector(
+    selectAnnotationsOrDefault('comparisonView')
+  );
 
   const timelines = useAppSelector(selectTimelineSides);
   const isLoading = isLoadingOrReloading([
@@ -182,6 +186,7 @@ function ComparisonApp() {
               id="timeline-chart-double"
               format="lines"
               height="125px"
+              annotations={annotations}
               timelineA={leftTimeline}
               timelineB={rightTimeline}
               onSelect={handleSelectMain}

--- a/webapp/javascript/pages/ContinuousDiffView.tsx
+++ b/webapp/javascript/pages/ContinuousDiffView.tsx
@@ -8,6 +8,7 @@ import {
   fetchTagValues,
   selectQueries,
   selectTimelineSides,
+  selectAnnotationsOrDefault,
 } from '@webapp/redux/reducers/continuous';
 import { FlamegraphRenderer } from '@pyroscope/flamegraph/src/FlamegraphRenderer';
 import usePopulateLeftRightQuery from '@webapp/hooks/populateLeftRightQuery.hook';
@@ -45,6 +46,7 @@ function ComparisonDiffApp() {
     rightUntil,
   } = useAppSelector(selectContinuousState);
   const { leftQuery, rightQuery } = useAppSelector(selectQueries);
+  const annotations = useAppSelector(selectAnnotationsOrDefault('diffView'));
 
   usePopulateLeftRightQuery();
   const { leftTags, rightTags } = useTags();
@@ -119,6 +121,7 @@ function ComparisonDiffApp() {
               id="timeline-chart-diff"
               format="lines"
               height="125px"
+              annotations={annotations}
               timelineA={leftTimeline}
               timelineB={rightTimeline}
               onSelect={(from, until) => {

--- a/webapp/javascript/pages/ContinuousSingleView.tsx
+++ b/webapp/javascript/pages/ContinuousSingleView.tsx
@@ -54,7 +54,7 @@ function ContinuousSingleView() {
   );
 
   const { singleView } = useAppSelector((state) => state.continuous);
-  const annotations = useAppSelector(selectAnnotationsOrDefault);
+  const annotations = useAppSelector(selectAnnotationsOrDefault('singleView'));
 
   useEffect(() => {
     if (from && until && query && maxNodes) {

--- a/webapp/javascript/pages/TagExplorerView.tsx
+++ b/webapp/javascript/pages/TagExplorerView.tsx
@@ -32,6 +32,7 @@ import {
   fetchTagExplorerViewProfile,
   ALL_TAGS,
   setQuery,
+  selectAnnotationsOrDefault,
 } from '@webapp/redux/reducers/continuous';
 import { queryToAppName } from '@webapp/models/query';
 import PageTitle from '@webapp/components/PageTitle';
@@ -172,6 +173,10 @@ function TagExplorerView() {
   const { query } = useAppSelector(selectQueries);
   const tags = useAppSelector(selectAppTags(query));
   const appName = queryToAppName(query);
+
+  const annotations = useAppSelector(
+    selectAnnotationsOrDefault('tagExplorerView')
+  );
 
   useEffect(() => {
     if (query) {
@@ -352,6 +357,7 @@ function TagExplorerView() {
                 timezone={offset === 0 ? 'utc' : 'browser'}
                 data-testid="timeline-explore-page"
                 id="timeline-chart-explore-page"
+                annotations={annotations}
                 timelineGroups={groups}
                 // to not "dim" timelines when "All" option is selected
                 activeGroup={

--- a/webapp/javascript/redux/reducers/continuous.ts
+++ b/webapp/javascript/redux/reducers/continuous.ts
@@ -43,6 +43,7 @@ const initialState: ContinuousState = {
     groupsLoadingType: 'pristine',
     activeTagProfileLoadingType: 'pristine',
     groups: {},
+    annotations: [],
   },
   newAnnotation: { type: 'pristine' },
 

--- a/webapp/javascript/redux/reducers/continuous.ts
+++ b/webapp/javascript/redux/reducers/continuous.ts
@@ -281,11 +281,13 @@ export const continuousSlice = createSlice({
     builder.addCase(fetchSideTimelines.fulfilled, (state, action) => {
       state.leftTimeline = {
         type: 'loaded',
-        timeline: action.payload.left,
+        timeline: action.payload.left.timeline,
+        annotations: action.payload.left.annotations,
       };
       state.rightTimeline = {
         type: 'loaded',
-        timeline: action.payload.right,
+        timeline: action.payload.right.timeline,
+        annotations: action.payload.right.annotations,
       };
     });
 

--- a/webapp/javascript/redux/reducers/continuous/selectors.ts
+++ b/webapp/javascript/redux/reducers/continuous/selectors.ts
@@ -1,6 +1,6 @@
 import { brandQuery, Query, queryToAppName } from '@webapp/models/query';
 import type { RootState } from '@webapp/redux/store';
-import { TagsState } from './state';
+import { ContinuousState, TagsState } from './state';
 
 export const selectContinuousState = (state: RootState) => state.continuous;
 export const selectApplicationName = (state: RootState) => {
@@ -57,13 +57,42 @@ export const selectQueries = (state: RootState) => {
   };
 };
 
-// TODO: accept a side (continuous / leftside)
-export const selectAnnotationsOrDefault = (state: RootState) => {
-  if ('annotations' in state.continuous.singleView) {
-    return state.continuous.singleView.annotations;
-  }
-  return [];
-};
+type ViewStates = Extract<keyof ContinuousState, `${string}View`>;
+export const selectAnnotationsOrDefault =
+  (view: ViewStates) => (state: RootState) => {
+    switch (view) {
+      case 'singleView': {
+        if ('annotations' in state.continuous.singleView) {
+          return state.continuous.singleView.annotations;
+        }
+        return [];
+      }
+
+      case 'tagExplorerView': {
+        return state.continuous.tagExplorerView.annotations;
+      }
+
+      // Merge data from both sides into a single annotation
+      // Which is fine, since this extra data won't be used if outside the time range
+      // NOTE: this assumes the left and right timelines belong to the same application
+      case 'diffView':
+      case 'comparisonView': {
+        const left =
+          'annotations' in state.continuous.leftTimeline
+            ? state.continuous.leftTimeline.annotations
+            : [];
+        const right =
+          'annotations' in state.continuous.rightTimeline
+            ? state.continuous.rightTimeline.annotations
+            : [];
+        return [...left, ...right];
+      }
+
+      default:
+        const exhaustiveCheck: never = view;
+        throw new Error(`Unhandled case: ${exhaustiveCheck}`);
+    }
+  };
 
 export const selectRanges = (rootState: RootState) => {
   const state = rootState.continuous;

--- a/webapp/javascript/redux/reducers/continuous/state.ts
+++ b/webapp/javascript/redux/reducers/continuous/state.ts
@@ -25,7 +25,11 @@ type SingleView =
       annotations: Annotation[];
     };
 
-type TagExplorerView = GroupByType & GroupsLoadingType & ActiveProfileType;
+type TagExplorerView = GroupByType &
+  GroupsLoadingType &
+  ActiveProfileType & {
+    annotations: Annotation[];
+  };
 
 type GroupByType = {
   groupByTag: string;
@@ -98,7 +102,7 @@ type TimelineState =
   | { type: 'pristine'; timeline: Timeline }
   | { type: 'loading'; timeline: Timeline }
   | { type: 'reloading'; timeline: Timeline }
-  | { type: 'loaded'; timeline: Timeline };
+  | { type: 'loaded'; timeline: Timeline; annotations: Annotation[] };
 
 type TagsData =
   | { type: 'pristine' }

--- a/webapp/javascript/redux/reducers/continuous/timelines.thunks.ts
+++ b/webapp/javascript/redux/reducers/continuous/timelines.thunks.ts
@@ -1,5 +1,4 @@
-import { renderSingle } from '@webapp/services/render';
-import type { Timeline } from '@webapp/models/timeline';
+import { RenderOutput, renderSingle } from '@webapp/services/render';
 import { RequestAbortedError } from '@webapp/services/base';
 import { addNotification } from '../notifications';
 import { createAsyncThunk } from '../../async-thunk';
@@ -8,7 +7,7 @@ import { ContinuousState } from './state';
 let sideTimelinesAbortController: AbortController | undefined;
 
 export const fetchSideTimelines = createAsyncThunk<
-  { left: Timeline; right: Timeline },
+  { left: RenderOutput; right: RenderOutput },
   null,
   { state: { continuous: ContinuousState } }
 >('continuous/fetchSideTimelines', async (_, thunkAPI) => {
@@ -54,8 +53,8 @@ export const fetchSideTimelines = createAsyncThunk<
 
   if (res?.[0].isOk && res?.[1].isOk) {
     return Promise.resolve({
-      left: res[0].value.timeline,
-      right: res[1].value.timeline,
+      left: res[0].value,
+      right: res[1].value,
     });
   }
 


### PR DESCRIPTION
Originally raised by @korniltsev 
Render annotations in the timeline for all pages, including TagExplorer:

![image](https://user-images.githubusercontent.com/6951209/212097348-be59043e-2d27-4ab9-8463-5ff444f70b37.png)

Keep in mind this is only about RENDERING annotations. For creation it's still only possible in Single View.