### PR TITLE
chore(tests): improve pkg/server test

### DIFF
--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -462,6 +462,10 @@ func (ctrl *Controller) getHandler() (http.Handler, error) {
 }
 
 func (ctrl *Controller) Start() error {
+	return ctrl.StartSync(nil)
+}
+
+func (ctrl *Controller) StartSync(serveSync chan struct{}) error {
 	logger := logrus.New()
 	w := logger.Writer()
 	defer w.Close()
@@ -481,6 +485,10 @@ func (ctrl *Controller) Start() error {
 	}
 
 	updates.StartVersionUpdateLoop()
+
+	if serveSync != nil {
+		serveSync <- struct{}{}
+	}
 
 	if ctrl.config.TLSCertificateFile != "" && ctrl.config.TLSKeyFile != "" {
 		err = ctrl.httpServer.ListenAndServeTLS(ctrl.config.TLSCertificateFile, ctrl.config.TLSKeyFile)

--- a/pkg/server/controller.go
+++ b/pkg/server/controller.go
@@ -462,10 +462,10 @@ func (ctrl *Controller) getHandler() (http.Handler, error) {
 }
 
 func (ctrl *Controller) Start() error {
-	return ctrl.StartSync(nil)
+	return ctrl.startSync(nil)
 }
 
-func (ctrl *Controller) StartSync(serveSync chan struct{}) error {
+func (ctrl *Controller) startSync(serveSync chan struct{}) error {
 	logger := logrus.New()
 	w := logger.Writer()
 	defer w.Close()

--- a/pkg/server/controller_admin_test.go
+++ b/pkg/server/controller_admin_test.go
@@ -86,6 +86,7 @@ var _ = Describe("server", func() {
 			Notifier:                mockNotifier{},
 			DB:                      sql.DB(),
 		})
+		c.dir = http.Dir("testdata")
 		startController(c, "http", ":4040")
 		defer c.Stop()
 

--- a/pkg/server/controller_admin_test.go
+++ b/pkg/server/controller_admin_test.go
@@ -86,7 +86,7 @@ var _ = Describe("server", func() {
 			Notifier:                mockNotifier{},
 			DB:                      sql.DB(),
 		})
-		startController(c, ":4040")
+		startController(c, "http", ":4040")
 		defer c.Stop()
 
 		k := service.NewAPIKeyService(sql.DB())

--- a/pkg/server/controller_admin_test.go
+++ b/pkg/server/controller_admin_test.go
@@ -86,12 +86,9 @@ var _ = Describe("server", func() {
 			Notifier:                mockNotifier{},
 			DB:                      sql.DB(),
 		})
-
-		go c.Start()
+		startController(c, ":4040")
 		defer c.Stop()
 
-		// TODO: Wait for start .There's possibly a better way of doing this
-		time.Sleep(50 * time.Millisecond)
 		k := service.NewAPIKeyService(sql.DB())
 		cb(testServices{s, k})
 	}

--- a/pkg/server/controller_https_test.go
+++ b/pkg/server/controller_https_test.go
@@ -125,7 +125,7 @@ func startController(c *Controller, protocol string, addr string) {
 	startSync := make(chan struct{})
 	go func() {
 		defer GinkgoRecover()
-		err := c.StartSync(startSync)
+		err := c.startSync(startSync)
 		Expect(err).ToNot(HaveOccurred())
 	}()
 	<-startSync

--- a/pkg/server/controller_https_test.go
+++ b/pkg/server/controller_https_test.go
@@ -55,9 +55,8 @@ var _ = Describe("server", func() {
 					})
 					c.dir = http.Dir(testDataDir)
 
-					go c.Start()
-					// TODO: Wait for start .There's possibly a better way of doing this
-					time.Sleep(50 * time.Millisecond)
+					startController(c, addr)
+
 					tr := &http.Transport{
 						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 					}
@@ -101,8 +100,8 @@ var _ = Describe("server", func() {
 					})
 					c.dir = http.Dir(testDataDir)
 
-					go c.Start()
-					time.Sleep(50 * time.Millisecond)
+					startController(c, addr)
+
 					tr := &http.Transport{
 						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 					}
@@ -121,3 +120,26 @@ var _ = Describe("server", func() {
 		})
 	})
 })
+
+func startController(c *Controller, addr string) {
+	startSync := make(chan struct{})
+	go func() {
+		defer GinkgoRecover()
+		err := c.StartSync(startSync)
+		Expect(err).ToNot(HaveOccurred())
+	}()
+	<-startSync
+	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	httpClient := &http.Client{Transport: tr}
+	var err error
+	var res *http.Response
+	for i := 0; i < 100; i++ {
+		res, err = httpClient.Get(fmt.Sprintf("http://localhost%s", addr))
+		if err == nil && res.StatusCode == http.StatusOK {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	err = fmt.Errorf("failed to wait for server startup %v %v", err, res)
+	Expect(err).ToNot(HaveOccurred())
+}

--- a/pkg/server/controller_https_test.go
+++ b/pkg/server/controller_https_test.go
@@ -55,7 +55,7 @@ var _ = Describe("server", func() {
 					})
 					c.dir = http.Dir(testDataDir)
 
-					startController(c, addr)
+					startController(c, "https", addr)
 
 					tr := &http.Transport{
 						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -100,7 +100,7 @@ var _ = Describe("server", func() {
 					})
 					c.dir = http.Dir(testDataDir)
 
-					startController(c, addr)
+					startController(c, "http", addr)
 
 					tr := &http.Transport{
 						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -121,7 +121,7 @@ var _ = Describe("server", func() {
 	})
 })
 
-func startController(c *Controller, addr string) {
+func startController(c *Controller, protocol string, addr string) {
 	startSync := make(chan struct{})
 	go func() {
 		defer GinkgoRecover()
@@ -134,7 +134,7 @@ func startController(c *Controller, addr string) {
 	var err error
 	var res *http.Response
 	for i := 0; i < 100; i++ {
-		res, err = httpClient.Get(fmt.Sprintf("http://localhost%s", addr))
+		res, err = httpClient.Get(fmt.Sprintf("%s://localhost%s", protocol, addr))
 		if err == nil && res.StatusCode == http.StatusOK {
 			return
 		}


### PR DESCRIPTION
- tries to fix a data race 
<details>
==================
WARNING: DATA RACE
Read at 0x00c00021a530 by goroutine 11548:
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Stop()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:502 +0x9e
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.2()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:91 +0x39
  runtime.gopanic()
      /usr/local/go/src/runtime/panic.go:890 +0x261
  github.com/onsi/gomega/internal.(*Assertion).match()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:100 +0x302
  github.com/onsi/gomega/internal.(*Assertion).To()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:58 +0xe8
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:47 +0xb6a
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.5()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:105 +0xa9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:143 +0x62
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:96 +0xbf3
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea

Previous write at 0x00c00021a530 by goroutine 11659:
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Start()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:473 +0x7aa
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0x39

Goroutine 11548 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:593 +0x935
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:181 +0x2cb8
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:303 +0xc0c
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:304 +0xfa8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:83 +0x444
  github.com/onsi/ginkgo/v2.RunSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/core_dsl.go:280 +0x1084
  github.com/pyroscope-io/pyroscope/pkg/server_test.TestServer()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/server_suite_test.go:17 +0x2e5
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Goroutine 11659 (finished) created at:
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0xb71
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea
==================
==================
WARNING: DATA RACE
Write at 0x00c0011b0438 by goroutine 11548:
  sync/atomic.StoreInt32()
      /usr/local/go/src/runtime/race_amd64.s:231 +0xb
  sync/atomic.StoreInt32()
      <autogenerated>:1 +0x1a
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Stop()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:502 +0xb9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.2()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:91 +0x39
  runtime.gopanic()
      /usr/local/go/src/runtime/panic.go:890 +0x261
  github.com/onsi/gomega/internal.(*Assertion).match()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:100 +0x302
  github.com/onsi/gomega/internal.(*Assertion).To()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:58 +0xe8
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:47 +0xb6a
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.5()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:105 +0xa9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:143 +0x62
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:96 +0xbf3
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea

Previous write at 0x00c0011b0438 by goroutine 11659:
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Start()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:473 +0x589
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0x39

Goroutine 11548 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:593 +0x935
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:181 +0x2cb8
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:303 +0xc0c
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:304 +0xfa8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:83 +0x444
  github.com/onsi/ginkgo/v2.RunSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/core_dsl.go:280 +0x1084
  github.com/pyroscope-io/pyroscope/pkg/server_test.TestServer()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/server_suite_test.go:17 +0x2e5
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Goroutine 11659 (finished) created at:
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0xb71
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea
==================
==================
WARNING: DATA RACE
Write at 0x00c0011b0460 by goroutine 11548:
  sync/atomic.CompareAndSwapInt32()
      /usr/local/go/src/runtime/race_amd64.s:310 +0xb
  sync/atomic.CompareAndSwapInt32()
      <autogenerated>:1 +0x1e
  net/http.(*Server).Shutdown()
      /usr/local/go/src/net/http/server.go:2785 +0x90
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Stop()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:502 +0xb9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.2()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:91 +0x39
  runtime.gopanic()
      /usr/local/go/src/runtime/panic.go:890 +0x261
  github.com/onsi/gomega/internal.(*Assertion).match()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:100 +0x302
  github.com/onsi/gomega/internal.(*Assertion).To()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:58 +0xe8
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:47 +0xb6a
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.5()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:105 +0xa9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:143 +0x62
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:96 +0xbf3
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea

Previous write at 0x00c0011b0460 by goroutine 11659:
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Start()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:473 +0x589
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0x39

Goroutine 11548 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:593 +0x935
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:181 +0x2cb8
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:303 +0xc0c
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:304 +0xfa8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:83 +0x444
  github.com/onsi/ginkgo/v2.RunSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/core_dsl.go:280 +0x1084
  github.com/pyroscope-io/pyroscope/pkg/server_test.TestServer()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/server_suite_test.go:17 +0x2e5
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Goroutine 11659 (finished) created at:
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0xb71
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea
==================
==================
WARNING: DATA RACE
Read at 0x00c0011b0468 by goroutine 11548:
  net/http.(*Server).closeListenersLocked()
      /usr/local/go/src/net/http/server.go:2860 +0x53
  net/http.(*Server).Shutdown()
      /usr/local/go/src/net/http/server.go:2786 +0x9d
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Stop()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:502 +0xb9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.2()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:91 +0x39
  runtime.gopanic()
      /usr/local/go/src/runtime/panic.go:890 +0x261
  github.com/onsi/gomega/internal.(*Assertion).match()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:100 +0x302
  github.com/onsi/gomega/internal.(*Assertion).To()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:58 +0xe8
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:47 +0xb6a
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.5()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:105 +0xa9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:143 +0x62
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:96 +0xbf3
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea

Previous write at 0x00c0011b0468 by goroutine 11659:
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Start()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:473 +0x589
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0x39

Goroutine 11548 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:593 +0x935
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:181 +0x2cb8
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:303 +0xc0c
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:304 +0xfa8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:83 +0x444
  github.com/onsi/ginkgo/v2.RunSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/core_dsl.go:280 +0x1084
  github.com/pyroscope-io/pyroscope/pkg/server_test.TestServer()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/server_suite_test.go:17 +0x2e5
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Goroutine 11659 (finished) created at:
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0xb71
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea
==================
==================
WARNING: DATA RACE
Read at 0x00c0011b0478 by goroutine 11548:
  net/http.(*Server).getDoneChanLocked()
      /usr/local/go/src/net/http/server.go:2704 +0xce
  net/http.(*Server).closeDoneChanLocked()
      /usr/local/go/src/net/http/server.go:2711 +0xaf
  net/http.(*Server).Shutdown()
      /usr/local/go/src/net/http/server.go:2787 +0xae
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Stop()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:502 +0xb9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.2()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:91 +0x39
  runtime.gopanic()
      /usr/local/go/src/runtime/panic.go:890 +0x261
  github.com/onsi/gomega/internal.(*Assertion).match()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:100 +0x302
  github.com/onsi/gomega/internal.(*Assertion).To()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:58 +0xe8
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:47 +0xb6a
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.5()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:105 +0xa9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:143 +0x62
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:96 +0xbf3
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea

Previous write at 0x00c0011b0478 by goroutine 11659:
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Start()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:473 +0x589
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0x39

Goroutine 11548 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:593 +0x935
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:181 +0x2cb8
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:303 +0xc0c
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:304 +0xfa8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:83 +0x444
  github.com/onsi/ginkgo/v2.RunSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/core_dsl.go:280 +0x1084
  github.com/pyroscope-io/pyroscope/pkg/server_test.TestServer()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/server_suite_test.go:17 +0x2e5
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Goroutine 11659 (finished) created at:
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0xb71
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea
==================
==================
WARNING: DATA RACE
Read at 0x00c0011b0480 by goroutine 11548:
  net/http.(*Server).Shutdown()
      /usr/local/go/src/net/http/server.go:2788 +0x19b
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Stop()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:502 +0xb9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.2()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:91 +0x39
  runtime.gopanic()
      /usr/local/go/src/runtime/panic.go:890 +0x261
  github.com/onsi/gomega/internal.(*Assertion).match()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:100 +0x302
  github.com/onsi/gomega/internal.(*Assertion).To()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:58 +0xe8
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:47 +0xb6a
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.5()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:105 +0xa9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:143 +0x62
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:96 +0xbf3
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea

Previous write at 0x00c0011b0480 by goroutine 11659:
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Start()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:473 +0x589
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0x39

Goroutine 11548 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:593 +0x935
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:181 +0x2cb8
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:303 +0xc0c
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:304 +0xfa8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:83 +0x444
  github.com/onsi/ginkgo/v2.RunSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/core_dsl.go:280 +0x1084
  github.com/pyroscope-io/pyroscope/pkg/server_test.TestServer()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/server_suite_test.go:17 +0x2e5
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Goroutine 11659 (finished) created at:
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0xb71
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea
==================
==================
WARNING: DATA RACE
Read at 0x00c0011b0470 by goroutine 11548:
  net/http.(*Server).closeIdleConns()
      /usr/local/go/src/net/http/server.go:2838 +0xc7
  net/http.(*Server).Shutdown()
      /usr/local/go/src/net/http/server.go:2809 +0x313
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Stop()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:502 +0xb9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.2()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:91 +0x39
  runtime.gopanic()
      /usr/local/go/src/runtime/panic.go:890 +0x261
  github.com/onsi/gomega/internal.(*Assertion).match()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:100 +0x302
  github.com/onsi/gomega/internal.(*Assertion).To()
      /home/korniltsev/go/pkg/mod/github.com/onsi/gomega@v1.17.0/internal/assertion.go:58 +0xe8
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:47 +0xb6a
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.5()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:105 +0xa9
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:143 +0x62
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:96 +0xbf3
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea

Previous write at 0x00c0011b0470 by goroutine 11659:
  github.com/pyroscope-io/pyroscope/pkg/server.(*Controller).Start()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller.go:473 +0x589
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0x39

Goroutine 11548 (running) created at:
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:593 +0x935
  github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:181 +0x2cb8
  github.com/onsi/ginkgo/v2/internal.(*group).run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/group.go:303 +0xc0c
  github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:304 +0xfa8
  github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:83 +0x444
  github.com/onsi/ginkgo/v2.RunSpecs()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/core_dsl.go:280 +0x1084
  github.com/pyroscope-io/pyroscope/pkg/server_test.TestServer()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/server_suite_test.go:17 +0x2e5
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /usr/local/go/src/testing/testing.go:1493 +0x47

Goroutine 11659 (finished) created at:
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.3()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:90 +0xb71
  github.com/pyroscope-io/pyroscope/pkg/server.glob..func3.6.1.2.1()
      /home/korniltsev/pyroscope/pyroscope/pkg/server/controller_admin_test.go:142 +0x118
  github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func2()
      /home/korniltsev/go/pkg/mod/github.com/onsi/ginkgo/v2@v2.1.3/internal/suite.go:605 +0xea

</details>

- wait for a server to start before doing the tests

