### PR TITLE
unset gzip header when scraping

### DIFF
--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -464,7 +464,6 @@ func (s *scraper) scrape(ctx context.Context, dst *bytes.Buffer) error {
 		if err != nil {
 			return err
 		}
-		req.Header.Add("Accept-Encoding", "gzip")
 		req.Header.Set("User-Agent", UserAgent)
 		s.req = req
 	}


### PR DESCRIPTION
Signed-off-by: Ben Ye <benye@amazon.com>

This pr unsets the `Accept-Encoding=gzip` header in scraper.

See more context from slack discussion https://pyroscope.slack.com/archives/C01FJRYENPQ/p1673835553042149.