### PR TITLE
chore: add scrape config for  delta profiles

### DIFF
--- a/pkg/scrape/config/config.go
+++ b/pkg/scrape/config/config.go
@@ -75,6 +75,26 @@ func DefaultConfig() *Config {
 					},
 				},
 			},
+			"pyroscope_mem": {
+				Path:   "/debug/pprof/pyroscope_heap",
+				Params: nil,
+				SampleTypes: map[string]*profile.SampleTypeConfig{
+					"inuse_objects": {
+						Units:       metadata.ObjectsUnits,
+						Aggregation: metadata.AverageAggregationType,
+					},
+					"alloc_objects": {
+						Units: metadata.ObjectsUnits,
+					},
+					"inuse_space": {
+						Units:       metadata.BytesUnits,
+						Aggregation: metadata.AverageAggregationType,
+					},
+					"alloc_space": {
+						Units: metadata.BytesUnits,
+					},
+				},
+			},
 			"goroutines": {
 				Path:   "/debug/pprof/goroutine",
 				Params: nil,
@@ -102,6 +122,20 @@ func DefaultConfig() *Config {
 					},
 				},
 			},
+			"pyroscope_mutex": {
+				Path:   "/debug/pprof/pyroscope_mutex",
+				Params: nil,
+				SampleTypes: map[string]*profile.SampleTypeConfig{
+					"contentions": {
+						DisplayName: "mutex_count",
+						Units:       metadata.LockSamplesUnits,
+					},
+					"delay": {
+						DisplayName: "mutex_duration",
+						Units:       metadata.LockNanosecondsUnits,
+					},
+				},
+			},
 			"block": {
 				Path:   "/debug/pprof/block",
 				Params: nil,
@@ -115,6 +149,20 @@ func DefaultConfig() *Config {
 						DisplayName: "block_duration",
 						Units:       metadata.LockNanosecondsUnits,
 						Cumulative:  true,
+					},
+				},
+			},
+			"pyroscope_block": {
+				Path:   "/debug/pprof/pyroscope_block",
+				Params: nil,
+				SampleTypes: map[string]*profile.SampleTypeConfig{
+					"contentions": {
+						DisplayName: "block_count",
+						Units:       metadata.LockSamplesUnits,
+					},
+					"delay": {
+						DisplayName: "block_duration",
+						Units:       metadata.LockNanosecondsUnits,
 					},
 				},
 			},

--- a/pkg/scrape/config/config.go
+++ b/pkg/scrape/config/config.go
@@ -33,6 +33,57 @@ import (
 
 // revive:disable:max-public-structs complex domain
 
+var (
+	profileDeltaMem = &Profile{
+		Path:   "/debug/pprof/delta_heap",
+		Params: nil,
+		SampleTypes: map[string]*profile.SampleTypeConfig{
+			"inuse_objects": {
+				Units:       metadata.ObjectsUnits,
+				Aggregation: metadata.AverageAggregationType,
+			},
+			"alloc_objects": {
+				Units: metadata.ObjectsUnits,
+			},
+			"inuse_space": {
+				Units:       metadata.BytesUnits,
+				Aggregation: metadata.AverageAggregationType,
+			},
+			"alloc_space": {
+				Units: metadata.BytesUnits,
+			},
+		},
+	}
+	profileDeltaMutex = &Profile{
+		Path:   "/debug/pprof/delta_mutex",
+		Params: nil,
+		SampleTypes: map[string]*profile.SampleTypeConfig{
+			"contentions": {
+				DisplayName: "mutex_count",
+				Units:       metadata.LockSamplesUnits,
+			},
+			"delay": {
+				DisplayName: "mutex_duration",
+				Units:       metadata.LockNanosecondsUnits,
+			},
+		},
+	}
+	profileDeltaBlock = &Profile{
+		Path:   "/debug/pprof/delta_block",
+		Params: nil,
+		SampleTypes: map[string]*profile.SampleTypeConfig{
+			"contentions": {
+				DisplayName: "block_count",
+				Units:       metadata.LockSamplesUnits,
+			},
+			"delay": {
+				DisplayName: "block_duration",
+				Units:       metadata.LockNanosecondsUnits,
+			},
+		},
+	}
+)
+
 // DefaultConfig returns the default scrape configuration.
 func DefaultConfig() *Config {
 	return &Config{
@@ -75,26 +126,6 @@ func DefaultConfig() *Config {
 					},
 				},
 			},
-			"pyroscope_mem": {
-				Path:   "/debug/pprof/pyroscope_heap",
-				Params: nil,
-				SampleTypes: map[string]*profile.SampleTypeConfig{
-					"inuse_objects": {
-						Units:       metadata.ObjectsUnits,
-						Aggregation: metadata.AverageAggregationType,
-					},
-					"alloc_objects": {
-						Units: metadata.ObjectsUnits,
-					},
-					"inuse_space": {
-						Units:       metadata.BytesUnits,
-						Aggregation: metadata.AverageAggregationType,
-					},
-					"alloc_space": {
-						Units: metadata.BytesUnits,
-					},
-				},
-			},
 			"goroutines": {
 				Path:   "/debug/pprof/goroutine",
 				Params: nil,
@@ -122,20 +153,6 @@ func DefaultConfig() *Config {
 					},
 				},
 			},
-			"pyroscope_mutex": {
-				Path:   "/debug/pprof/pyroscope_mutex",
-				Params: nil,
-				SampleTypes: map[string]*profile.SampleTypeConfig{
-					"contentions": {
-						DisplayName: "mutex_count",
-						Units:       metadata.LockSamplesUnits,
-					},
-					"delay": {
-						DisplayName: "mutex_duration",
-						Units:       metadata.LockNanosecondsUnits,
-					},
-				},
-			},
 			"block": {
 				Path:   "/debug/pprof/block",
 				Params: nil,
@@ -149,20 +166,6 @@ func DefaultConfig() *Config {
 						DisplayName: "block_duration",
 						Units:       metadata.LockNanosecondsUnits,
 						Cumulative:  true,
-					},
-				},
-			},
-			"pyroscope_block": {
-				Path:   "/debug/pprof/pyroscope_block",
-				Params: nil,
-				SampleTypes: map[string]*profile.SampleTypeConfig{
-					"contentions": {
-						DisplayName: "block_count",
-						Units:       metadata.LockSamplesUnits,
-					},
-					"delay": {
-						DisplayName: "block_duration",
-						Units:       metadata.LockNanosecondsUnits,
 					},
 				},
 			},
@@ -201,6 +204,7 @@ type Config struct {
 	// Profiles parameters.
 	Profiles map[string]*Profile `yaml:"profiles,omitempty"`
 
+	UseDeltaProfiles bool `yaml:"use-delta-profiles,omitempty"`
 	// TODO(kolesnikovae): Implement.
 	// List of profiles relabel configurations.
 	// ProfilesRelabelConfigs []*relabel.Config `yaml:"profiles-relabel-configs,omitempty"`
@@ -266,7 +270,27 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 	}
 
+	if c.UseDeltaProfiles {
+		enableDeltaProfiles(c.Profiles)
+	}
+
 	return nil
+}
+
+func enableDeltaProfiles(profiles map[string]*Profile) {
+	var ok bool
+	_, ok = profiles["mem"]
+	if ok {
+		profiles["mem"] = profileDeltaMem
+	}
+	_, ok = profiles["block"]
+	if ok {
+		profiles["block"] = profileDeltaBlock
+	}
+	_, ok = profiles["mutex"]
+	if ok {
+		profiles["mutex"] = profileDeltaMutex
+	}
 }
 
 func checkStaticTargets(configs discovery.Configs) error {


### PR DESCRIPTION
introduce an option `use-delta-profiles` which will enable new delta profiles and make scraper go to new delta endpoints https://github.com/pyroscope-io/client/pull/28/files#diff-0373c4cce76bc8bd39c8c6b636420424b74140f3e3da03a10612373a32f9c348R21-R23

```
    enabled-profiles: [cpu, mem, block, mutex]
    use-delta-profiles: true # << 
```
