### PR TITLE
fix(pprof parsing): decrease number of allocations during stack hash

### DIFF
--- a/pkg/convert/pprof/streaming/structs.go
+++ b/pkg/convert/pprof/streaming/structs.go
@@ -5,7 +5,6 @@ import (
 	"github.com/pyroscope-io/pyroscope/pkg/util/arenahelper"
 )
 
-
 var (
 	profileIDLabel = []byte(segment.ProfileIDLabelName)
 )
@@ -43,6 +42,7 @@ type sample struct {
 	//type labelPacked uint64
 	tmpLabels   []uint64
 	tmpStack    [][]byte
+	stackHashes []uint64
 	tmpStackLoc []uint64
 	//todo rename - remove tmp prefix
 }


### PR DESCRIPTION
There was an attempt to do the whole hashing on the stack
```
	var hashes [64 + 32]uint64
	s := hashes[:]
```
unfortunately it should have been 
```
	s := hashes[:0]
```

also 

with this code 
```
	sh.Data = uintptr(unsafe.Pointer(&s[0]))
```

hashes escapes to heap
and with this does not escape
```
ps := uintptr(unsafe.Pointer(&s[0]))
sh.Data = ps
```
which is weird


I rewrote to just hash on a single preallocated  heap/arena slice 



