### PR TITLE
fix(pprof parsing): initialize function to zero values before parsing

### DIFF
--- a/pkg/convert/pprof/streaming/vt_function.go
+++ b/pkg/convert/pprof/streaming/vt_function.go
@@ -8,6 +8,9 @@ import (
 
 // revive:disable-next-line:cognitive-complexity,cyclomatic necessary complexity
 func (m *function) UnmarshalVT(dAtA []byte) error {
+	m.id = 0
+	m.name = 0
+	m.filename = 0
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {


### PR DESCRIPTION
before this change, when the parser is pooled if a function message has no some field it would reuse some garbage from previous pool usage