### PR TITLE
fix: add structed validation for tag key and app name in case nil pointer panic

### DIFF
--- a/pkg/convert/pprof/parser.go
+++ b/pkg/convert/pprof/parser.go
@@ -111,7 +111,10 @@ func (p *Parser) Convert(ctx context.Context, startTime, endTime time.Time, prof
 			// TODO(petethepig): this conversion is questionable
 			pi.Units = metadata.Units(profile.StringTable[vt.Unit])
 		}
-		pi.Key = p.buildName(sampleType, profile.ResolveLabels(l))
+		pi.Key, err = p.buildName(sampleType, profile.ResolveLabels(l))
+		if err != nil {
+			return false, err
+		}
 		err = p.putter.Put(ctx, &pi)
 		return sampleTypeConfig.Cumulative, err
 	})
@@ -133,12 +136,17 @@ func sampleRate(p *tree.Profile) uint32 {
 	return uint32(time.Second / (sampleUnit * time.Duration(p.Period)))
 }
 
-func (p *Parser) buildName(sampleTypeName string, labels map[string]string) *segment.Key {
+func (p *Parser) buildName(sampleTypeName string, labels map[string]string) (*segment.Key, error) {
 	for k, v := range p.labels {
 		labels[k] = v
 	}
 	labels["__name__"] += "." + sampleTypeName
-	return segment.NewKey(labels)
+	key := segment.NewKey(labels)
+	err := segment.ValidateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return key, nil
 }
 
 func (p *Parser) load(sampleType int64, labels tree.Labels) (*tree.Tree, bool) {

--- a/pkg/storage/segment/key.go
+++ b/pkg/storage/segment/key.go
@@ -55,6 +55,21 @@ func ParseKey(name string) (*Key, error) {
 	return k, nil
 }
 
+func ValidateKey(k *Key) error {
+	for key, v := range k.labels {
+		if key == "__name__" {
+			if err := flameql.ValidateAppName(v); err != nil {
+				return err
+			}
+		} else {
+			if err := flameql.ValidateTagKey(key); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 type parser struct {
 	parserState ParserState
 	key         *bytes.Buffer


### PR DESCRIPTION
Hi, 
So sorry for my mistake, I want to revert my code so I click `sync fork`, never thought of that means GitHub will delete my old repo and close relevant [PR](https://github.com/pyroscope-io/pyroscope/pull/1854) automatically then create a new one

Just like the comments from my wrongly closed [PR](https://github.com/pyroscope-io/pyroscope/pull/1854) say, I add `segment.ValidateKey(k *Key)` function for both tag key and app name, add caller at where the key is assigned, so we can validate it from the start,  before it's used

after changing code, I ran some tests. now both client and server will report error about invalid characters:
![img_v2_32ede418-bf3a-47d6-bb67-b9f95e81cf4g](https://user-images.githubusercontent.com/65116642/219664624-bb87e266-7873-4556-86be-2a757dd6810f.jpg)
![img_v2_603d8ba7-3635-453e-87b0-8ba0a3a887dg](https://user-images.githubusercontent.com/65116642/219664640-776e5634-53d9-4aa7-9ce0-c6f3ceda741c.jpg)
