### PR TITLE
chore: ci profiling

### DIFF
--- a/.github/workflows/ci-profiling.yaml
+++ b/.github/workflows/ci-profiling.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: uninstall from gospy since profiler is already running
         run: rm pkg/agent/gospy/pyroscope_test.go
       - name: Run Go tests and upload
-        run: pyroscope-ci exec --apiKey=${{ secrets.PYROSCOPE_CLOUD_TOKEN }} make test
+        run: pyroscope-ci exec --logLevel=debug --apiKey=${{ secrets.PYROSCOPE_CLOUD_TOKEN }} make test
   js-tests:
     runs-on: ubuntu-latest
     # skip if user has not access to the token

--- a/.github/workflows/ci-profiling.yaml
+++ b/.github/workflows/ci-profiling.yaml
@@ -47,7 +47,13 @@ jobs:
       - name: uninstall from gospy since profiler is already running
         run: rm pkg/agent/gospy/pyroscope_test.go
       - name: Run Go tests and upload
-        run: pyroscope-ci exec --logLevel=debug --apiKey=${{ secrets.PYROSCOPE_CLOUD_TOKEN }} make test
+        run: pyroscope-ci exec --export --apiKey=${{ secrets.PYROSCOPE_CLOUD_TOKEN }} make test
+      - uses: pyroscope-io/flamegraph.com-github-action@main
+        with:
+          file: pyroscope-ci-output/*
+          postInPR: true
+          token: ${{ github.token }}
+          id: go-tests
   js-tests:
     runs-on: ubuntu-latest
     # skip if user has not access to the token

--- a/webapp/javascript/components/PageTitle.spec.tsx
+++ b/webapp/javascript/components/PageTitle.spec.tsx
@@ -2,12 +2,20 @@ import React from 'react';
 import PageTitle, { AppNameContext } from './PageTitle';
 import { render, screen, waitFor } from '@testing-library/react';
 
+// Default is 1000, try a few more times since it was failing in ci
+const waitForOpts = {
+  timeout: 5000,
+};
+
 describe('PageTitle', () => {
   describe("there's no app name in context", () => {
     it('defaults to Pyroscope', async () => {
       render(<PageTitle title={'mypage'} />);
 
-      await waitFor(() => expect(document.title).toEqual('mypage | Pyroscope'));
+      await waitFor(
+        () => expect(document.title).toEqual('mypage | Pyroscope'),
+        waitForOpts
+      );
     });
   });
 
@@ -19,7 +27,10 @@ describe('PageTitle', () => {
         </AppNameContext.Provider>
       );
 
-      await waitFor(() => expect(document.title).toEqual('mypage | myapp'));
+      await waitFor(
+        () => expect(document.title).toEqual('mypage | myapp'),
+        waitForOpts
+      );
     });
   });
 });


### PR DESCRIPTION
* Increase timeout for flaky frontend tests
* Export golang ci profiles to flamegraph.com