### PR TITLE
build: make @pyroscope/nodejs an optional dependency since it's only used to profile ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
   "devDependencies": {
     "@babel/core": "7.8.4",
     "@fortawesome/fontawesome-common-types": "~0.2.36",
-    "@pyroscope/nodejs": "^0.2.5",
     "@size-limit/file": "^6.0.3",
     "@size-limit/time": "^6.0.3",
     "@storybook/addon-actions": "~6.5.0",
@@ -283,5 +282,8 @@
     "jquery": "3.6.0",
     "d3-graphviz": "5.0.2",
     "d3-selection": "3.0.0"
+  },
+  "optionalDependencies": {
+    "@pyroscope/nodejs": "^0.2.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5489,9 +5489,9 @@
   integrity sha512-PfeQhvcMR4cPFVuYfBN4ifG7p9c+Dlh3yUZR6k+5yQK7wX3gDgVxBly4/WkBRs9x4dmcy1TVl08SY67wwtEvmA==
 
 "@types/node@>=13.7.0":
-  version "18.11.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.18.tgz#8dfb97f0da23c2293e554c5a50d61ef134d7697f"
-  integrity sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==
+  version "18.14.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.2.tgz#c076ed1d7b6095078ad3cf21dfeea951842778b1"
+  integrity sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==
 
 "@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0":
   version "16.11.49"


### PR DESCRIPTION
Closes https://github.com/pyroscope-io/pyroscope/issues/1879

From the Docs (https://classic.yarnpkg.com/lang/en/docs/dependency-types/):

> optionalDependencies
> Optional dependencies are just that: optional. If they fail to install, Yarn will still say the install process was successful.
> This is useful for dependencies that won’t necessarily work on every machine and you have a fallback plan in case they are not installed (e.g. Watchman).