### PR TITLE
chore: remove duplicated expectFormats check

### DIFF
--- a/pkg/server/render.go
+++ b/pkg/server/render.go
@@ -105,11 +105,6 @@ func (rh *RenderHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := expectFormats(p.format); err != nil {
-		rh.httpUtils.WriteInvalidParameterError(r, w, errUnknownFormat)
-		return
-	}
-
 	out, err := rh.storage.Get(r.Context(), p.gi)
 	var appName string
 	if p.gi.Key != nil {


### PR DESCRIPTION
`expectFormats` check is already done inside `renderParametersFromRequest` at [pkg/server/render.go#L264](https://github.com/pyroscope-io/pyroscope/blob/main/pkg/server/render.go#L264).