### PR TITLE
fix(flamegraph): fix styling when in light mode

### DIFF
--- a/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlameGraph/FlameGraphRenderer.tsx
@@ -86,7 +86,6 @@ export interface FlamegraphRendererProps {
   showPyroscopeLogo?: boolean;
   showCredit?: boolean;
   ExportData?: ProfileHeaderProps['ExportData'];
-  colorMode?: 'light' | 'dark';
 
   /** @deprecated  prefer Profile */
   flamebearer?: Flamebearer;
@@ -554,7 +553,7 @@ class FlameGraphRenderer extends Component<
     );
 
     return (
-      <div data-flamegraph-color-mode={this.props.colorMode || 'dark'}>
+      <div>
         <div>
           {toolbarVisible && (
             <Toolbar

--- a/packages/pyroscope-flamegraph/src/FlamegraphRenderer.tsx
+++ b/packages/pyroscope-flamegraph/src/FlamegraphRenderer.tsx
@@ -26,12 +26,17 @@ declare global {
 }
 
 // TODO: type props
-export const FlamegraphRenderer = (props: FlamegraphRendererProps) => {
+export const FlamegraphRenderer = (
+  props: FlamegraphRendererProps & { colorMode?: 'light' | 'dark' }
+) => {
   // Although 'flamegraph' is not a valid HTML element
   // It's used to scope css without affecting specificity
   // For more info see flamegraph.scss
   return (
-    <pyro-flamegraph is="span">
+    <pyro-flamegraph
+      is="span"
+      data-flamegraph-color-mode={props.colorMode || 'dark'}
+    >
       {/* eslint-disable-next-line react/jsx-props-no-spreading */}
       <FlameGraphRenderer {...props} {...overrideProps} />
     </pyro-flamegraph>

--- a/webapp/javascript/pages/exemplars/ExemplarsSingleView.tsx
+++ b/webapp/javascript/pages/exemplars/ExemplarsSingleView.tsx
@@ -31,10 +31,7 @@ import ChartTitle from '@webapp/components/ChartTitle';
 /* eslint-disable css-modules/no-undef-class */
 import ChartTitleStyles from '@webapp/components/ChartTitle.module.scss';
 import { DEFAULT_HEATMAP_PARAMS } from '@webapp/components/Heatmap/constants';
-import {
-  FlamegraphRenderer,
-  FlamegraphRendererProps,
-} from '@pyroscope/flamegraph/src/FlamegraphRenderer';
+import { FlamegraphRenderer } from '@pyroscope/flamegraph/src/FlamegraphRenderer';
 import type { Profile } from '@pyroscope/models/src';
 import { diffTwoProfiles } from '@pyroscope/flamegraph/src/convert/diffTwoProfiles';
 import { subtract } from '@pyroscope/flamegraph/src/convert/subtract';
@@ -205,7 +202,7 @@ function ExemplarsSingleView() {
 export default ExemplarsSingleView;
 
 interface TabProps {
-  colorMode: FlamegraphRendererProps['colorMode'];
+  colorMode: ReturnType<typeof useColorMode>['colorMode'];
   type: LoadingType;
   selectionProfile: Profile;
 }


### PR DESCRIPTION
A tricky one raised by @Rperry2174 

In light mode, the title (which i highlighted with red) is white.
<img width="906" alt="image" src="https://user-images.githubusercontent.com/6951209/224350255-8d72083c-e1bc-40d3-86df-42b7e8bb979f.png">

The reason is that it inherits the color from the topmost component with has an explicit color set, in this case `pyro-flamegraph`. However, the css variables for light mode were only available in a div UNDER `pyro-flamegraph`. 
To put in other terms, title used whatever color `pyro-flamegraph` had, but `pyro-flamegraph` didn't have any color set!

Solution here is to move the theme attribute (`data-`) to be defined in the `pyro-flamegraph` component.