### PR TITLE
ci: fixes homebrew formulas generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,4 +83,5 @@ jobs:
           cd ../homebrew-brew
           make generate-formulas && git add Formula && git commit -m "chore: update formulas" && git push origin main
         env:
-          GITHUB_TOKEN: ${{ steps.brew-token.outputs.token }}
+          HOMEBREW_GITHUB_TOKEN: ${{ steps.brew-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-goreleaser.outputs.token }}


### PR DESCRIPTION
Fixes a few issues:
* introduces two tokens, one for homebrew repo, one for pyroscope proper
* clones homebrew-brew to an adjacent directory, so that it's not in the same go workspace as pyroscope
* adds email / name for the commit

This PR consists of cherry picked commits from https://github.com/grafana/pyroscope/tree/release/v1.1
