### PR TITLE
Stop Disk cleaner when storage bucket is not defined

### DIFF
--- a/pkg/ingester/retention.go
+++ b/pkg/ingester/retention.go
@@ -153,7 +153,7 @@ func (dc *diskCleaner) DeleteUploadedBlocks(ctx context.Context) int {
 		}
 
 		for _, block := range blocks {
-			if !dc.isBlockDeletable(block, true) {
+			if !block.Uploaded || !dc.isExpired(block) {
 				continue
 			}
 
@@ -233,7 +233,7 @@ func (dc *diskCleaner) CleanupBlocksWhenHighDiskUtilization(ctx context.Context)
 	prevVolumeStats := &diskutil.VolumeStats{}
 	filesDeleted := 0
 	for _, block := range blocks {
-		if !dc.isBlockDeletable(block, false) {
+		if !dc.isExpired(block) {
 			continue
 		}
 
@@ -289,19 +289,12 @@ func (dc *diskCleaner) CleanupBlocksWhenHighDiskUtilization(ctx context.Context)
 }
 
 // isBlockDeletable returns true if this block can be deleted.
-func (dc *diskCleaner) isBlockDeletable(block *tenantBlock, deleteOnlyUploaded bool) bool {
+func (dc *diskCleaner) isExpired(block *tenantBlock) bool {
 	// TODO(kolesnikovae):
 	//  Expiry defaults to -querier.query-store-after which should be deprecated,
 	//  blocks-storage.bucket-store.ignore-blocks-within can be used instead.
 	expiryTs := time.Now().Add(-dc.policy.Expiry)
-
-	isExpired := ulid.Time(block.ID.Time()).Before(expiryTs)
-
-	if deleteOnlyUploaded {
-		return block.Uploaded && isExpired
-	}
-
-	return isExpired
+	return ulid.Time(block.ID.Time()).Before(expiryTs)
 }
 
 // blocksByUploadAndAge implements sorting tenantBlock by uploaded then by age

--- a/pkg/ingester/retention_test.go
+++ b/pkg/ingester/retention_test.go
@@ -323,7 +323,7 @@ func TestDiskCleaner_EnforceHighDiskUtilization(t *testing.T) {
 	})
 }
 
-func TestDiskCleaner_isBlockDeletable(t *testing.T) {
+func TestDiskCleaner_isBlockDeletableForUploadedBlocks(t *testing.T) {
 	tests := []struct {
 		Name   string
 		Expiry time.Duration
@@ -376,7 +376,7 @@ func TestDiskCleaner_isBlockDeletable(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			dc.policy.Expiry = tt.Expiry
 
-			got := dc.isBlockDeletable(tt.Block, true)
+			got := tt.Block.Uploaded && dc.isExpired(tt.Block)
 			require.Equal(t, tt.Want, got)
 		})
 	}


### PR DESCRIPTION
Fixes #2974 

As per issue, we have to activate disk cleaner when only storage is defined, otherwise we are getting error of `shipper.json`, does not exist, as shipper only runs when storage bucket is defined, as per code `pkg/ingester/instance.go:53`