### PR TITLE
fix: GetTenantStats reports wrong stats

### DIFF
--- a/pkg/metastore/index/index.go
+++ b/pkg/metastore/index/index.go
@@ -204,18 +204,16 @@ func (i *Index) GetTenantStats(tx *bbolt.Tx, tenant string) *metastorev1.TenantS
 			// Partition not found.
 			continue
 		}
-		if q.Shards(tenant) == nil {
-			// No shards for this tenant in this partition.
-			continue
-		}
-		oldest := p.StartTime().UnixMilli()
-		newest := p.EndTime().UnixMilli()
-		stats.DataIngested = true
-		if oldest < stats.OldestProfileTime {
-			stats.OldestProfileTime = oldest
-		}
-		if newest > stats.NewestProfileTime {
-			stats.NewestProfileTime = newest
+		for shard := range q.Shards(tenant) {
+			stats.DataIngested = true
+			oldest := shard.ShardIndex.MinTime
+			newest := shard.ShardIndex.MaxTime
+			if oldest < stats.OldestProfileTime {
+				stats.OldestProfileTime = oldest
+			}
+			if newest > stats.NewestProfileTime {
+				stats.NewestProfileTime = newest
+			}
 		}
 	}
 	if !stats.DataIngested {


### PR DESCRIPTION
We had a bug where GetTenantStats would report data was sent for a new tenant.

This fixes this, also improves the accuracy of the data window.

It comes at a cost see benchmark:

```
❯ benchstat before.txt after.txt
name                                       old time/op  new time/op  delta
Index_GetTenantStats/ExistingTenant-12      394µs ± 1%   694µs ± 0%  +75.83%  (p=0.000 n=9+8)
Index_GetTenantStats/MidTenant-12           395µs ± 1%   686µs ± 0%  +73.88%  (p=0.000 n=9+8)
Index_GetTenantStats/LastTenant-12          405µs ± 5%   693µs ± 1%  +71.25%  (p=0.000 n=10+10)
Index_GetTenantStats/NonExistentTenant-12   359µs ± 3%   360µs ± 0%     ~     (p=0.968 n=10+9)
```
