### PR TITLE
feat: Add block list/inspect to profilecli

### DIFF
--- a/cmd/profilecli/bucket.go
+++ b/cmd/profilecli/bucket.go
@@ -3,65 +3,115 @@ package main
 import (
 	"context"
 	"embed"
+	"flag"
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/grafana/dskit/server"
+	"github.com/oklog/ulid/v2"
+	"github.com/olekukonko/tablewriter"
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/model"
+	"github.com/thanos-io/objstore"
 
+	"github.com/grafana/pyroscope/pkg/block"
+	"github.com/grafana/pyroscope/pkg/block/metadata"
 	phlareobj "github.com/grafana/pyroscope/pkg/objstore"
 	objstoreclient "github.com/grafana/pyroscope/pkg/objstore/client"
-	"github.com/grafana/pyroscope/pkg/objstore/providers/gcs"
 	"github.com/grafana/pyroscope/pkg/operations"
 )
 
+type bucketParams struct {
+	objectStoreCfg objstoreclient.Config
+}
+
+func (b *bucketParams) initClient(ctx context.Context) (phlareobj.Bucket, error) {
+	return objstoreclient.NewBucket(
+		ctx,
+		b.objectStoreCfg,
+		"storage",
+	)
+}
+
 type bucketWebToolParams struct {
-	httpListenPort  int
-	objectStoreType string
-	bucketName      string
+	*bucketParams
+	httpListenPort int
+}
+
+func addBucketParams(cmd commander) *bucketParams {
+	var (
+		params = &bucketParams{}
+	)
+	// keep in sync with objstoreclient.RegisterFlags
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+	params.objectStoreCfg.RegisterFlagsWithPrefix("storage.", fs)
+	fs.VisitAll(func(f *flag.Flag) {
+		switch f.Name {
+		case "storage.backend":
+			cmd.Flag(f.Name, f.Usage).Default("filesystem").StringVar(&params.objectStoreCfg.Backend)
+		case "storage.prefix":
+			cmd.Flag(f.Name, f.Usage).Default(f.DefValue).StringVar(&params.objectStoreCfg.Prefix)
+		case "storage.filesystem.dir":
+			cmd.Flag(f.Name, f.Usage).Default(f.DefValue).StringVar(&params.objectStoreCfg.Filesystem.Directory)
+		case "storage.gcs.bucket-name":
+			cmd.Flag(f.Name, f.Usage).Default(f.DefValue).StringVar(&params.objectStoreCfg.GCS.BucketName)
+		case "storage.s3.bucket-name":
+			cmd.Flag(f.Name, f.Usage).Default(f.DefValue).StringVar(&params.objectStoreCfg.S3.BucketName)
+		case "storage.s3.endpoint":
+			cmd.Flag(f.Name, f.Usage).Default(f.DefValue).StringVar(&params.objectStoreCfg.S3.Endpoint)
+		case "storage.s3.region":
+			cmd.Flag(f.Name, f.Usage).Default(f.DefValue).StringVar(&params.objectStoreCfg.S3.Region)
+		case "storage.azure.container-name":
+			cmd.Flag(f.Name, f.Usage).Default(f.DefValue).StringVar(&params.objectStoreCfg.Azure.ContainerName)
+		case "storage.azure.account-name":
+			cmd.Flag(f.Name, f.Usage).Default(f.DefValue).StringVar(&params.objectStoreCfg.Azure.StorageAccountName)
+		default:
+			break
+		}
+	})
+	return params
 }
 
 //go:embed static
 var staticFiles embed.FS
 
-func addBucketWebToolParams(bucketWebToolCmd commander) *bucketWebToolParams {
+func addBucketWebToolParams(cmd commander) *bucketWebToolParams {
 	var (
 		params = &bucketWebToolParams{}
 	)
-	bucketWebToolCmd.Flag("object-store-type", "The type of the object storage (e.g., gcs).").Default("gcs").StringVar(&params.objectStoreType)
-	bucketWebToolCmd.Flag("bucket-name", "The name of the object storage bucket.").StringVar(&params.bucketName)
-	bucketWebToolCmd.Flag("http-listen-port", "The port to run the HTTP server on.").Default("4201").IntVar(&params.httpListenPort)
+	params.bucketParams = addBucketParams(cmd)
+	cmd.Flag("http-listen-port", "The port to run the HTTP server on.").Default("4201").IntVar(&params.httpListenPort)
 	return params
 }
 
 type bucketWebTool struct {
 	params *bucketWebToolParams
-	server *server.Server
 }
 
 func newBucketWebTool(params *bucketWebToolParams) *bucketWebTool {
-	var (
-		serverCfg = server.Config{
-			HTTPListenPort: params.httpListenPort,
-			Log:            logger,
-		}
-	)
-
-	s, err := server.New(serverCfg)
-	if err != nil {
-		log.Fatal(err)
-		return nil
-	}
-
-	b, err := initObjectStoreBucket(params)
-	if err != nil {
-		log.Fatal(err)
-		return nil
-	}
-
-	tool := &bucketWebTool{
+	return &bucketWebTool{
 		params: params,
-		server: s,
+	}
+}
+
+func (t *bucketWebTool) run(ctx context.Context) error {
+	s, err := server.New(server.Config{
+		HTTPListenPort: t.params.httpListenPort,
+		Log:            logger,
+	})
+	if err != nil {
+		return err
+	}
+
+	b, err := t.params.initClient(ctx)
+	if err != nil {
+		log.Fatal(err)
+		return err
 	}
 
 	handlers := operations.Handlers{
@@ -74,34 +124,214 @@ func newBucketWebTool(params *bucketWebToolParams) *bucketWebTool {
 	s.HTTP.Path("/ops/object-store/tenants/{tenant}/blocks").HandlerFunc(handlers.CreateBlocksHandler())
 	s.HTTP.Path("/ops/object-store/tenants/{tenant}/blocks/{block}").HandlerFunc(handlers.CreateBlockDetailsHandler())
 
-	return tool
-}
-
-func initObjectStoreBucket(params *bucketWebToolParams) (phlareobj.Bucket, error) {
-	objectStoreConfig := objstoreclient.Config{
-		Prefix: "",
-		StorageBackendConfig: objstoreclient.StorageBackendConfig{
-			Backend: params.objectStoreType,
-			GCS: gcs.Config{
-				BucketName: params.bucketName,
-			},
-		},
-	}
-	return objstoreclient.NewBucket(
-		context.Background(),
-		objectStoreConfig,
-		"storage",
-	)
-}
-
-func (t *bucketWebTool) run(ctx context.Context) error {
 	out := output(ctx)
 
 	fmt.Fprintf(out, "The bucket web tool is available at http://localhost:%d/ops/object-store/tenants\n", t.params.httpListenPort)
 
-	if err := t.server.Run(); err != nil {
+	if err := s.Run(); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func labelStrings(v []int32, s []string, sb *strings.Builder) {
+	pairs := metadata.LabelPairs(v)
+	for pairs.Next() {
+		p := pairs.At()
+		first := true
+		for len(p) > 0 {
+			if first {
+				first = false
+				_, _ = sb.WriteString("- ")
+			} else {
+				_, _ = sb.WriteString("  ")
+			}
+			_, _ = sb.WriteString(s[p[0]])
+			_, _ = sb.WriteString(`="`)
+			_, _ = sb.WriteString(s[p[1]])
+			_, _ = sb.WriteString(`"`)
+			_, _ = sb.WriteString("\n")
+			p = p[2:]
+		}
+	}
+}
+
+func bucketInspectV2(ctx context.Context, params *bucketParams, paths []string) error {
+	b, err := params.initClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	lst := bucketList{}
+
+	for _, path := range paths {
+		obj, err := block.NewObjectFromPath(ctx, b, path)
+		if err != nil {
+			return err
+		}
+
+		e, err := bucketListElemFromPath(path)
+		if err != nil {
+			return err
+		}
+
+		meta := obj.Metadata()
+		stringTable := meta.GetStringTable()
+		e.Size = meta.GetSize()
+		e.CompactionLevel = meta.GetCompactionLevel()
+
+		lst.lst = lst.lst[:0]
+		lst.lst = append(lst.lst, *e)
+		lst.renderInspectTable(ctx)
+
+		sb := new(strings.Builder)
+		tbl := tablewriter.NewWriter(output(ctx))
+		tbl.SetAutoWrapText(false)
+		tbl.SetHeader([]string{"Tenant", "Dataset Name", "From", "Duration", "Size", "Labels"})
+
+		for _, ds := range meta.Datasets {
+			sb.Reset()
+			labelStrings(ds.Labels, stringTable, sb)
+			tbl.Append([]string{
+				stringTable[ds.Tenant],
+				stringTable[ds.Name],
+				model.Time(ds.MinTime).Time().Format(time.RFC3339),
+				(time.Duration(ds.MaxTime-ds.MinTime) * time.Millisecond).String(),
+				humanize.Bytes(ds.Size),
+				strings.TrimRight(sb.String(), "\n"),
+			})
+		}
+		tbl.Render()
+
+	}
+
+	return nil
+}
+
+type bucketList struct {
+	lst []bucketListElem
+	tbl *tablewriter.Table
+}
+
+func (b bucketList) renderInspectTable(ctx context.Context) {
+	if b.tbl == nil {
+		b.tbl = tablewriter.NewWriter(output(ctx))
+	} else {
+		b.tbl.ClearRows()
+	}
+	b.tbl.SetHeader([]string{"Block ID", "Time", "Type", "Shard", "Tenant", "Compaction Level", "Size", "Path"})
+	for _, e := range b.lst {
+		b.tbl.Append([]string{
+			e.ID.String(),
+			e.ID.Timestamp().Format(time.RFC3339),
+			e.Type,
+			strconv.Itoa(e.Shard),
+			e.Tenant,
+			strconv.Itoa(int(e.CompactionLevel)),
+			humanize.Bytes(e.Size),
+			e.Path,
+		})
+
+	}
+	b.tbl.Render()
+}
+
+func (b bucketList) renderListTable(ctx context.Context) {
+	if b.tbl == nil {
+		b.tbl = tablewriter.NewWriter(output(ctx))
+	} else {
+		b.tbl.ClearRows()
+	}
+	b.tbl.SetHeader([]string{"Block ID", "Time", "Type", "Shard", "Tenant", "Path"})
+	for _, e := range b.lst {
+		b.tbl.Append([]string{
+			e.ID.String(),
+			e.ID.Timestamp().Format(time.RFC3339),
+			e.Type,
+			strconv.Itoa(e.Shard),
+			e.Tenant,
+			e.Path,
+		})
+
+	}
+	b.tbl.Render()
+}
+
+type bucketListElem struct {
+	ID              ulid.ULID
+	Type            string
+	Shard           int
+	Tenant          string
+	Path            string
+	CompactionLevel uint32
+	Size            uint64
+}
+
+var errUnexpectedPath = errors.New("unexpected path")
+
+func bucketListElemFromPath(s string) (*bucketListElem, error) {
+	parts := strings.Split(s, "/")
+	if parts[len(parts)-1] != "block.bin" {
+		return nil, errUnexpectedPath
+	}
+
+	id, err := ulid.Parse(parts[len(parts)-2])
+	if err != nil {
+		return nil, err
+	}
+	shard, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	tenant := parts[2]
+	if parts[0] == "segments" {
+		tenant = "various"
+	}
+
+	return &bucketListElem{
+		ID:     id,
+		Type:   parts[0],
+		Shard:  shard,
+		Tenant: tenant,
+		Path:   s,
+	}, nil
+}
+
+func bucketListV2(ctx context.Context, params *bucketParams) error {
+	b, err := params.initClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	lst := bucketList{}
+	limit := 40 // might be depending on the size of the terminal
+
+	addBlock := func(name string) error {
+		e, err := bucketListElemFromPath(name)
+		if err != nil {
+			if err == errUnexpectedPath {
+				return nil
+			}
+			return err
+		}
+
+		lst.lst = append(lst.lst, *e)
+		if len(lst.lst) > limit {
+			lst.renderListTable(ctx)
+			lst.lst = lst.lst[:0]
+		}
+
+		return nil
+	}
+
+	if err := b.Iter(ctx, "segments", addBlock, objstore.WithRecursiveIter()); err != nil {
+		return err
+	}
+	if err := b.Iter(ctx, "blocks", addBlock, objstore.WithRecursiveIter()); err != nil {
+		return err
+	}
+	lst.renderListTable(ctx)
 	return nil
 }

--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -95,6 +95,13 @@ func main() {
 	bucketWebCmd := bucketCmd.Command("web", "Run the web tool for visualizing blocks in object-store buckets.")
 	bucketWebParams := addBucketWebToolParams(bucketWebCmd)
 
+	bucketListV2Cmd := bucketCmd.Command("list-v2-blocks", "List Pyroscope v2 segments and blocks in object-store buckets.")
+	bucketListV2Params := addBucketParams(bucketListV2Cmd)
+
+	bucketInspectV2Cmd := bucketCmd.Command("inspect-v2-blocks", "Inspect Pyroscope v2 segments and blocks in object-store buckets.")
+	bucketInspectV2Params := addBucketParams(bucketInspectV2Cmd)
+	bucketInspectV2Paths := bucketInspectV2Cmd.Arg("path", "block paths").Required().Strings()
+
 	readyCmd := app.Command("ready", "Check Pyroscope health.")
 	readyParams := addReadyParams(readyCmd)
 
@@ -171,6 +178,14 @@ func main() {
 		}
 	case bucketWebCmd.FullCommand():
 		if err := newBucketWebTool(bucketWebParams).run(ctx); err != nil {
+			os.Exit(checkError(err))
+		}
+	case bucketListV2Cmd.FullCommand():
+		if err := bucketListV2(ctx, bucketListV2Params); err != nil {
+			os.Exit(checkError(err))
+		}
+	case bucketInspectV2Cmd.FullCommand():
+		if err := bucketInspectV2(ctx, bucketInspectV2Params, *bucketInspectV2Paths); err != nil {
 			os.Exit(checkError(err))
 		}
 	case blocksCompactCmd.FullCommand():


### PR DESCRIPTION
This adds sub commands to discover and inspect v2 blocks/segments in the bucket.

This works both locally and on buckets:

```
❯ go run ./cmd/profilecli/ admin bucket list-v2-blocks
+----------------------------+---------------------------+--------+-------+-----------+---------------------------------------------------------+
|          BLOCK ID          |           TIME            |  TYPE  | SHARD |  TENANT   |                          PATH                           |
+----------------------------+---------------------------+--------+-------+-----------+---------------------------------------------------------+
| 01K3QQ392EDW57ZB3YMHA9NKB3 | 2025-08-28T07:50:59+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3QQ392EDW57ZB3YMHA9NKB3/block.bin |
| 01K3QVDHCSVTGKBD6FAF7AGEMH | 2025-08-28T09:06:29+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3QVDHCSVTGKBD6FAF7AGEMH/block.bin |
| 01K3QZWNFK62B5Z3Z808GD34A2 | 2025-08-28T10:24:39+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3QZWNFK62B5Z3Z808GD34A2/block.bin |
| 01K3R48E5WJ9QRNVNVW3TPSN9G | 2025-08-28T11:40:59+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3R48E5WJ9QRNVNVW3TPSN9G/block.bin |
| 01K3R8Q8ERSRV2NGW41D7172K5 | 2025-08-28T12:58:59+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3R8Q8ERSRV2NGW41D7172K5/block.bin |
| 01K3RD5KMBSJMTQ2ZFKBF6W3Q1 | 2025-08-28T14:16:44+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3RD5KMBSJMTQ2ZFKBF6W3Q1/block.bin |
| 01K3RHHPJ0NYCSW1TEZKS3HZAP | 2025-08-28T15:33:14+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3RHHPJ0NYCSW1TEZKS3HZAP/block.bin |
| 01K3RP0Z2Q14J7R8MKVXQY3VAF | 2025-08-28T16:51:29+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3RP0Z2Q14J7R8MKVXQY3VAF/block.bin |
| 01K3RTMAW8SNE6CN9GNG0PFKR2 | 2025-08-28T18:11:58+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3RTMAW8SNE6CN9GNG0PFKR2/block.bin |
| 01K3RZAFK8298WEQNPTAG4C5P1 | 2025-08-28T19:33:58+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3RZAFK8298WEQNPTAG4C5P1/block.bin |
| 01K3S41H41VEBCE6MHRRAY6F31 | 2025-08-28T20:56:27+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3S41H41VEBCE6MHRRAY6F31/block.bin |
| 01K3TDADXA2Y2072JN219HEFY5 | 2025-08-29T08:57:50+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TDADXA2Y2072JN219HEFY5/block.bin |
| 01K3TTEQ93R4TX55DH09NHK48T | 2025-08-29T12:47:23+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TTEQ93R4TX55DH09NHK48T/block.bin |
| 01K3TTMP6J2ZFXHNANB9BN39CB | 2025-08-29T12:50:38+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TTMP6J2ZFXHNANB9BN39CB/block.bin |
| 01K3TTMP6JKADQK4540700D3AT | 2025-08-29T12:50:38+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TTMP6JKADQK4540700D3AT/block.bin |
| 01K3TTWGX9XH43MJVC1E1XT19H | 2025-08-29T12:54:55+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TTWGX9XH43MJVC1E1XT19H/block.bin |
| 01K3TTXXB62EZG4KYVWTC3MES7 | 2025-08-29T12:55:40+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TTXXB62EZG4KYVWTC3MES7/block.bin |
| 01K3TTZ99FR1T5SG5ZM9C6GZJA | 2025-08-29T12:56:25+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TTZ99FR1T5SG5ZM9C6GZJA/block.bin |
| 01K3TV3H8BQRQMVRTB08EX8462 | 2025-08-29T12:58:45+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TV3H8BQRQMVRTB08EX8462/block.bin |
| 01K3TV5TG51CWP74R7Q1EK0XS1 | 2025-08-29T13:00:00+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TV5TG51CWP74R7Q1EK0XS1/block.bin |
| 01K3TV69MGKPNHF7V0ZXBQ3YG0 | 2025-08-29T13:00:15+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TV69MGKPNHF7V0ZXBQ3YG0/block.bin |
| 01K3TXY2Z2VR2HB2EAQYSE4DPF | 2025-08-29T13:48:12+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TXY2Z2VR2HB2EAQYSE4DPF/block.bin |
| 01K3TY1F3KNAG31ZQ91836S15Y | 2025-08-29T13:50:02+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TY1F3KNAG31ZQ91836S15Y/block.bin |
| 01K3TY4VV7H3T1WPN6J7FTF9KG | 2025-08-29T13:51:54+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TY4VV7H3T1WPN6J7FTF9KG/block.bin |
| 01K3TY6PE74HRTXWBQSCPMYH3F | 2025-08-29T13:52:54+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TY6PE74HRTXWBQSCPMYH3F/block.bin |
| 01K3TY9HDMC3T1Z1HDKWA27F41 | 2025-08-29T13:54:27+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TY9HDMC3T1Z1HDKWA27F41/block.bin |
| 01K3TYAXBXP482HKKZ9FDD0SX2 | 2025-08-29T13:55:12+01:00 | blocks |     3 | anonymous | blocks/3/anonymous/01K3TYAXBXP482HKKZ9FDD0SX2/block.bin |
+----------------------------+---------------------------+--------+-------+-----------+---------------------------------------------------------+
```

```
❯ profilecli admin bucket inspect-v2-blocks segments/3/anonymous/01K3TYAXBX303FH7NCEJYD1K1P/block.bin segments/3/anonymous/01K3TYBC0N3MP0ZS01M4D8KE0T/block.bin
+----------------------------+---------------------------+----------+-------+---------+------------------+-------+-----------------------------------------------------------+
|          BLOCK ID          |           TIME            |   TYPE   | SHARD | TENANT  | COMPACTION LEVEL | SIZE  |                           PATH                            |
+----------------------------+---------------------------+----------+-------+---------+------------------+-------+-----------------------------------------------------------+
| 01K3TYAXBX303FH7NCEJYD1K1P | 2025-08-29T13:55:12+01:00 | segments |     3 | various |                0 | 50 kB | segments/3/anonymous/01K3TYAXBX303FH7NCEJYD1K1P/block.bin |
+----------------------------+---------------------------+----------+-------+---------+------------------+-------+-----------------------------------------------------------+
+-----------+--------------+---------------------------+----------+-------+-------------------------------------------------------------+
|  TENANT   | DATASET NAME |           FROM            | DURATION | SIZE  |                           LABELS                            |
+-----------+--------------+---------------------------+----------+-------+-------------------------------------------------------------+
| anonymous | pyroscope    | 2025-08-29T13:55:12+01:00 | 0s       | 50 kB | - service_name="pyroscope"                                  |
|           |              |                           |          |       |   __profile_type__="memory:alloc_objects:count:space:bytes" |
|           |              |                           |          |       | - service_name="pyroscope"                                  |
|           |              |                           |          |       |   __profile_type__="memory:alloc_space:bytes:space:bytes"   |
|           |              |                           |          |       | - service_name="pyroscope"                                  |
|           |              |                           |          |       |   __profile_type__="memory:inuse_objects:count:space:bytes" |
|           |              |                           |          |       | - service_name="pyroscope"                                  |
|           |              |                           |          |       |   __profile_type__="memory:inuse_space:bytes:space:bytes"   |
+-----------+--------------+---------------------------+----------+-------+-------------------------------------------------------------+
+----------------------------+---------------------------+----------+-------+---------+------------------+-------+-----------------------------------------------------------+
|          BLOCK ID          |           TIME            |   TYPE   | SHARD | TENANT  | COMPACTION LEVEL | SIZE  |                           PATH                            |
+----------------------------+---------------------------+----------+-------+---------+------------------+-------+-----------------------------------------------------------+
| 01K3TYBC0N3MP0ZS01M4D8KE0T | 2025-08-29T13:55:27+01:00 | segments |     3 | various |                0 | 94 kB | segments/3/anonymous/01K3TYBC0N3MP0ZS01M4D8KE0T/block.bin |
+----------------------------+---------------------------+----------+-------+---------+------------------+-------+-----------------------------------------------------------+
+-----------+--------------+---------------------------+----------+-------+------------------------------------------------------------------+
|  TENANT   | DATASET NAME |           FROM            | DURATION | SIZE  |                              LABELS                              |
+-----------+--------------+---------------------------+----------+-------+------------------------------------------------------------------+
| anonymous | pyroscope    | 2025-08-29T13:54:57+01:00 | 29.982s  | 94 kB | - service_name="pyroscope"                                       |
|           |              |                           |          |       |   __profile_type__="block:contentions:count:contentions:count"   |
|           |              |                           |          |       | - service_name="pyroscope"                                       |
|           |              |                           |          |       |   __profile_type__="block:delay:nanoseconds:contentions:count"   |
|           |              |                           |          |       | - service_name="pyroscope"                                       |
|           |              |                           |          |       |   __profile_type__="goroutines:goroutine:count:goroutine:count"  |
|           |              |                           |          |       | - service_name="pyroscope"                                       |
|           |              |                           |          |       |   __profile_type__="memory:inuse_objects:count:space:bytes"      |
|           |              |                           |          |       | - service_name="pyroscope"                                       |
|           |              |                           |          |       |   __profile_type__="memory:inuse_space:bytes:space:bytes"        |
|           |              |                           |          |       | - service_name="pyroscope"                                       |
|           |              |                           |          |       |   __profile_type__="mutex:contentions:count:contentions:count"   |
|           |              |                           |          |       | - service_name="pyroscope"                                       |
|           |              |                           |          |       |   __profile_type__="mutex:delay:nanoseconds:contentions:count"   |
|           |              |                           |          |       | - service_name="pyroscope"                                       |
|           |              |                           |          |       |   __profile_type__="process_cpu:cpu:nanoseconds:cpu:nanoseconds" |
|           |              |                           |          |       | - service_name="pyroscope"                                       |
|           |              |                           |          |       |   __profile_type__="process_cpu:samples:count:cpu:nanoseconds"   |
+-----------+--------------+---------------------------+----------+-------+------------------------------------------------------------------+

```

To do this remotely:

```
❯ profilecli admin bucket inspect-v2-blocks --storage.backend=gcs --storage.gcs.bucket-name=dev-us-central-0-profiles-dev-001-data segments/11/anonymous/01K1BZQX7VMXDDVJV3VDE3H6S2/block.bin
```