### PR TITLE
examples/ebpf-otel: Fix collector tag

### DIFF
--- a/examples/grafana-alloy-auto-instrumentation/ebpf-otel/docker/docker-compose.yml
+++ b/examples/grafana-alloy-auto-instrumentation/ebpf-otel/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   otel-collector:
     # fixed versions for pyroscope, otel-collector, otel-profiler due to protocol changes
-    image: otel/opentelemetry-collector-contrib:0.129.0 
+    image: otel/opentelemetry-collector-contrib:0.129.1
     command: ["--config=/etc/otel-collector-config.yaml", "--feature-gates=service.profilesSupport"]
     volumes:
       - ./config/otel-collector-config.yaml:/etc/otel-collector-config.yaml


### PR DESCRIPTION
Tag  otel/opentelemetry-collector-contrib:0.129.0 doesn't exist:

```bash
$ docker-compose up --build
Pulling otel-collector (otel/opentelemetry-collector-contrib:0.129.0)...
ERROR: manifest for otel/opentelemetry-collector-contrib:0.129.0 not found: manifest unknown: manifest unknown
```

Switch to the nearest tag that works.

---

https://github.com/open-telemetry/opentelemetry-collector-releases/pkgs/container/opentelemetry-collector-releases%2Fopentelemetry-collector-contrib states that the tags aren't stable, but given that this is an example I think it's fine to continue to use tags.