### PR TITLE
chore: Handle EOF as part of bidi streaming

### DIFF
--- a/pkg/phlaredb/phlaredb_test.go
+++ b/pkg/phlaredb/phlaredb_test.go
@@ -2,6 +2,7 @@ package phlaredb
 
 import (
 	"context"
+	"io"
 	"math"
 	"net/http"
 	"os"
@@ -247,7 +248,15 @@ func TestMergeProfilesStacktraces(t *testing.T) {
 	t.Run("empty request fails", func(t *testing.T) {
 		bidi := client.MergeProfilesStacktraces(ctx)
 
-		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesStacktracesRequest{}))
+		// It is possible that the error returned by server side of the
+		// stream closes the net.Conn before bidi.Send has finished. The
+		// short timing for that to happen with real HTTP servers makes this
+		// unlikely, but it does happen with the synchronous in memory
+		// net.Pipe() that is used here.
+		// See https://github.com/grafana/pyroscope/issues/3549 for more details.
+		if err := bidi.Send(&ingestv1.MergeProfilesStacktracesRequest{}); !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
 
 		_, err := bidi.Receive()
 		require.EqualError(t, err, "invalid_argument: missing initial select request")
@@ -408,7 +417,15 @@ func TestMergeProfilesPprof(t *testing.T) {
 	t.Run("empty request fails", func(t *testing.T) {
 		bidi := client.MergeProfilesPprof(ctx)
 
-		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesPprofRequest{}))
+		// It is possible that the error returned by server side of the
+		// stream closes the net.Conn before bidi.Send has finished. The
+		// short timing for that to happen with real HTTP servers makes this
+		// unlikely, but it does happen with the synchronous in memory
+		// net.Pipe() that is used here.
+		// See https://github.com/grafana/pyroscope/issues/3549 for more details.
+		if err := bidi.Send(&ingestv1.MergeProfilesPprofRequest{}); !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
 
 		_, err := bidi.Receive()
 		require.EqualError(t, err, "invalid_argument: missing initial select request")

--- a/pkg/segmentwriter/memdb/head_test.go
+++ b/pkg/segmentwriter/memdb/head_test.go
@@ -3,7 +3,9 @@ package memdb
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"sync"
 	"testing"
@@ -409,7 +411,15 @@ func TestMergeProfilesStacktraces(t *testing.T) {
 	t.Run("empty request fails", func(t *testing.T) {
 		bidi := client.MergeProfilesStacktraces(context.Background())
 
-		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesStacktracesRequest{}))
+		// It is possible that the error returned by server side of the
+		// stream closes the net.Conn before bidi.Send has finished. The
+		// short timing for that to happen with real HTTP servers makes this
+		// unlikely, but it does happen with the synchronous in memory
+		// net.Pipe() that is used here.
+		// See https://github.com/grafana/pyroscope/issues/3549 for more details.
+		if err := bidi.Send(&ingestv1.MergeProfilesStacktracesRequest{}); !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
 
 		_, err := bidi.Receive()
 		require.EqualError(t, err, "invalid_argument: missing initial select request")
@@ -603,7 +613,15 @@ func TestMergeProfilesPprof(t *testing.T) {
 	t.Run("empty request fails", func(t *testing.T) {
 		bidi := client.MergeProfilesPprof(context.Background())
 
-		require.NoError(t, bidi.Send(&ingestv1.MergeProfilesPprofRequest{}))
+		// It is possible that the error returned by server side of the
+		// stream closes the net.Conn before bidi.Send has finished. The
+		// short timing for that to happen with real HTTP servers makes this
+		// unlikely, but it does happen with the synchronous in memory
+		// net.Pipe() that is used here.
+		// See https://github.com/grafana/pyroscope/issues/3549 for more details.
+		if err := bidi.Send(&ingestv1.MergeProfilesPprofRequest{}); !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
 
 		_, err := bidi.Receive()
 		require.EqualError(t, err, "invalid_argument: missing initial select request")


### PR DESCRIPTION
It is possible that the error returned by server side of the stream closes the net.Conn before bidi.Send has finished `Send`. This manifests in an error: `"write envelope: EOF"`

The short timing for that to happen with real HTTP servers makes this unlikely, but it does happen with the synchronous in memory net.Pipe() that is used in tests.

Relates to #3549

The error itself occurs here: https://github.com/connectrpc/connect-go/blob/46c8b00cab4b55c06a7c8f76fdcd6ca8d20e8629/envelope.go#L86 and then gets rewritten by this bit into an io.EOF https://github.com/connectrpc/connect-go/blob/46c8b00cab4b55c06a7c8f76fdcd6ca8d20e8629/duplex_http_call.go#L120.

I have spent a bit of time to reproduce this cleanly for a report in connect-go, still haven't managed to reproduce it consistently.

In our code base the easiest why to reproduce is through running tests (only get it on Linux not on Darwin)

```
go test -failfast ./pkg/segmentwriter/memdb  -test.run TestMergeProfilesPprof/empty -test.count 100000
```
