### PR TITLE
Fix panic in query pprof path

### DIFF
--- a/pkg/phlaredb/symdb/resolver.go
+++ b/pkg/phlaredb/symdb/resolver.go
@@ -273,7 +273,11 @@ func (r *Resolver) Pprof() (*googlev1.Profile, error) {
 			return nil, err
 		}
 		if p == nil { // for consistency with the return value when using the merge path
-			return nil, nil
+			return &googlev1.Profile{
+				SampleType:  []*googlev1.ValueType{new(googlev1.ValueType)},
+				PeriodType:  new(googlev1.ValueType),
+				StringTable: []string{""},
+			}, nil
 		}
 		return p, nil
 	}


### PR DESCRIPTION
Testing a fix for the panic observed in the integration tests running on https://github.com/grafana/pyroscope/pull/4428. I cannot reproduce this locally (darwin, ubuntu arm64/amd64). 

Also, even if this fixes the panic I expect the related test to still fail in a different way, unless the issue is elsewhere.

Edit: this does seem to fix the issue in the limited attempts I did here. 