### PR TITLE
feat(profilecli): Add --max-nodes flag to query profile command

### DIFF
--- a/cmd/profilecli/query.go
+++ b/cmd/profilecli/query.go
@@ -94,6 +94,7 @@ type queryProfileParams struct {
 	*queryParams
 	ProfileType        string
 	StacktraceSelector []string
+	MaxNodes           int64
 }
 
 func addQueryProfileParams(queryCmd commander) *queryProfileParams {
@@ -101,6 +102,7 @@ func addQueryProfileParams(queryCmd commander) *queryProfileParams {
 	params.queryParams = addQueryParams(queryCmd)
 	queryCmd.Flag("profile-type", "Profile type to query.").Default("process_cpu:cpu:nanoseconds:cpu:nanoseconds").StringVar(&params.ProfileType)
 	queryCmd.Flag("stacktrace-selector", "Only query locations with those symbols. Provide multiple times starting with the root").StringsVar(&params.StacktraceSelector)
+	queryCmd.Flag("max-nodes", "Maximum number of nodes to return in the profile").Int64Var(&params.MaxNodes)
 	return params
 }
 
@@ -116,6 +118,10 @@ func queryProfile(ctx context.Context, params *queryProfileParams, outputFlag st
 		Start:         from.UnixMilli(),
 		End:           to.UnixMilli(),
 		LabelSelector: params.Query,
+	}
+
+	if params.MaxNodes > 0 {
+		req.MaxNodes = &params.MaxNodes
 	}
 
 	if len(params.StacktraceSelector) > 0 {


### PR DESCRIPTION
## Summary
- Added support for the `--max-nodes` flag in profilecli's `query profile` command
- This flag allows limiting the number of nodes returned in profile queries, matching the functionality available in buf curl

## Context
The `--max-nodes` parameter was already available in the underlying protobuf API (`SelectMergeProfileRequest`) but was missing from the profilecli command-line interface. This addition enables users to achieve similar performance optimizations without needing to use buf curl directly.

Reference: https://github.com/grafana/pyroscope-squad/issues/568#issuecomment-3281485494

🤖 Generated with [Claude Code](https://claude.ai/code)