### PR TITLE
WIP feat: Add request dump middleware and replay tool with PushRequest de…

### DIFF
--- a/pkg/pyroscope/pyroscope.go
+++ b/pkg/pyroscope/pyroscope.go
@@ -75,6 +75,7 @@ import (
 	"github.com/grafana/pyroscope/pkg/usagestats"
 	"github.com/grafana/pyroscope/pkg/util"
 	"github.com/grafana/pyroscope/pkg/util/cli"
+	"github.com/grafana/pyroscope/pkg/util/http/requestdump"
 	"github.com/grafana/pyroscope/pkg/validation"
 	"github.com/grafana/pyroscope/pkg/validation/exporter"
 )
@@ -119,6 +120,7 @@ type Config struct {
 	CompactionWorker  compactionworker.Config `yaml:"compaction_worker"  doc:"hidden"`
 	AdaptivePlacement placement.Config        `yaml:"adaptive_placement" doc:"hidden"`
 	Symbolizer        symbolizer.Config       `yaml:"symbolizer"         doc:"hidden"`
+	RequestDump       requestdump.Config      `yaml:"request_dump"`
 }
 
 func newDefaultConfig() *Config {
@@ -201,6 +203,7 @@ func (c *Config) RegisterFlagsWithContext(f *flag.FlagSet) {
 	c.API.RegisterFlags(f)
 	c.EmbeddedGrafana.RegisterFlags(f)
 	c.TenantSettings.RegisterFlags(f)
+	c.RequestDump.RegisterFlags(f)
 }
 
 // registerServerFlagsWithChangedDefaultValues registers *Config.Server flags, but overrides some defaults set by the dskit package.

--- a/pkg/util/http/requestdump/middleware.go
+++ b/pkg/util/http/requestdump/middleware.go
@@ -1,0 +1,156 @@
+package requestdump
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/middleware"
+
+	"github.com/grafana/pyroscope/pkg/objstore"
+	"github.com/grafana/pyroscope/pkg/tenant"
+)
+
+type Config struct {
+	Enabled       bool    `yaml:"enabled"`
+	SamplingRate  float64 `yaml:"sampling_rate"`
+	MaxConcurrency int    `yaml:"max_concurrency"`
+}
+
+func (c *Config) RegisterFlags(f *flag.FlagSet) {
+	f.BoolVar(&c.Enabled, "request-dump.enabled", false, "Enable dumping of HTTP requests to object storage")
+	f.Float64Var(&c.SamplingRate, "request-dump.sampling-rate", 1.0, "Sampling rate for request dumping (0.0-1.0, where 1.0 means 100% of requests)")
+	f.IntVar(&c.MaxConcurrency, "request-dump.max-concurrency", 2, "Maximum number of concurrent request dumps")
+}
+
+type Middleware struct {
+	cfg          Config
+	logger       log.Logger
+	bucket       objstore.Bucket
+	counter      uint64
+	inflightChan chan struct{}
+}
+
+func NewMiddleware(cfg Config, logger log.Logger, bucket objstore.Bucket) middleware.Interface {
+	return &Middleware{
+		cfg:          cfg,
+		logger:       logger,
+		bucket:       bucket,
+		inflightChan: make(chan struct{}, cfg.MaxConcurrency),
+	}
+}
+
+func (m *Middleware) Wrap(next http.Handler) http.Handler {
+	if !m.cfg.Enabled || m.bucket == nil {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if m.cfg.SamplingRate < 1.0 && rand.Float64() > m.cfg.SamplingRate {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if !writeRequest(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		var bodyBytes []byte
+		if r.Body != nil {
+			var err error
+			bodyBytes, err = io.ReadAll(r.Body)
+			if err != nil {
+				level.Warn(m.logger).Log("msg", "failed to read request body", "err", err, "url", r.URL.String())
+			}
+			r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
+
+		tenantID, err := tenant.ExtractTenantIDFromContext(r.Context())
+		if err != nil {
+			tenantID = "unknown"
+		}
+
+		select {
+		case m.inflightChan <- struct{}{}:
+			reqCopy := r.Clone(context.Background())
+			if len(bodyBytes) > 0 {
+				reqCopy.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			}
+			go m.dumpFullRequest(reqCopy, tenantID)
+		default:
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func writeRequest(r *http.Request) bool {
+	return r.URL.Path == "/ingest" ||
+		r.URL.Path == "/push.v1.PusherService/Push" ||
+		r.URL.Path == "/opentelemetry.proto.collector.profiles.v1development.ProfilesService/Export"
+}
+
+func (m *Middleware) dumpFullRequest(r *http.Request, tenantID string) {
+	defer func() {
+		<-m.inflightChan
+	}()
+
+	requestNum := atomic.AddUint64(&m.counter, 1)
+	timestamp := time.Now().UTC().Format("2006-01-02_15:04:05.000000000")
+
+	sanitizedPath := sanitizePath(r.URL.Path)
+	filename := fmt.Sprintf("%s_%d_%s.bin", timestamp, requestNum, sanitizedPath)
+
+	var buf bytes.Buffer
+	if err := r.Write(&buf); err != nil {
+		level.Warn(m.logger).Log("msg", "failed to serialize request", "err", err, "path", filename, "tenant", tenantID)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	prefixedBucket := objstore.NewPrefixedBucket(m.bucket, fmt.Sprintf("request-dump/%s/", tenantID))
+	defer prefixedBucket.Close()
+
+	if err := prefixedBucket.Upload(ctx, filename, bytes.NewReader(buf.Bytes())); err != nil {
+		level.Warn(m.logger).Log("msg", "failed to upload request dump", "path", filename, "err", err, "tenant", tenantID)
+	}
+}
+
+var sanitizeRegex = regexp.MustCompile(`[^a-zA-Z0-9.-]+`)
+
+func sanitizePath(path string) string {
+	parsedURL, err := url.Parse(path)
+	if err != nil {
+		path = "invalid"
+	} else {
+		path = parsedURL.Path
+	}
+
+	if path == "" || path == "/" {
+		return "root"
+	}
+
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
+
+	sanitized := sanitizeRegex.ReplaceAllString(path, "_")
+
+	if len(sanitized) > 100 {
+		sanitized = sanitized[:100]
+	}
+
+	return sanitized
+}

--- a/pkg/util/http/requestdump/replay/main.go
+++ b/pkg/util/http/requestdump/replay/main.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	gprofile "github.com/google/pprof/profile"
+	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
+)
+
+type Config struct {
+	targetURL string
+	dryRun    bool
+}
+
+func main() {
+	var cfg Config
+	flag.StringVar(&cfg.targetURL, "url", "http://localhost:4040", "Target URL to send requests to")
+	flag.BoolVar(&cfg.dryRun, "dry-run", false, "Do not send requests, just print them")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: at least one file or directory path is required\n")
+		fmt.Fprintf(os.Stderr, "Usage: %s [flags] <path1> [path2] ...\n", os.Args[0])
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	targetURL, err := url.Parse(cfg.targetURL)
+	if err != nil {
+		log.Fatalf("Invalid target URL: %v", err)
+	}
+
+	var allFiles []string
+	for _, path := range args {
+		files, err := getRequestFiles(path)
+		if err != nil {
+			log.Fatalf("Error getting request files from %s: %v", path, err)
+		}
+		allFiles = append(allFiles, files...)
+	}
+
+	if len(allFiles) == 0 {
+		log.Fatal("No request files found")
+	}
+
+	allFiles = removeDuplicates(allFiles)
+
+	fmt.Printf("Found %d request files to replay\n", len(allFiles))
+	fmt.Printf("Target URL: %s\n", cfg.targetURL)
+
+	replayer := &Replayer{
+		targetURL: targetURL,
+		dryRun:    cfg.dryRun,
+	}
+
+	if err := replayer.ReplayFiles(allFiles); err != nil {
+		log.Fatalf("Error replaying requests: %v", err)
+	}
+	fmt.Println(cfg.dryRun)
+}
+
+func removeDuplicates(files []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, file := range files {
+		absPath, err := filepath.Abs(file)
+		if err != nil {
+			absPath = file
+		}
+		if !seen[absPath] {
+			seen[absPath] = true
+			result = append(result, file)
+		}
+	}
+	return result
+}
+
+func getRequestFiles(path string) ([]string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var files []string
+	if info.IsDir() {
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".bin") {
+				files = append(files, filepath.Join(path, entry.Name()))
+			}
+		}
+	} else {
+		files = []string{path}
+	}
+
+	return files, nil
+}
+
+type Replayer struct {
+	targetURL *url.URL
+	dryRun    bool
+}
+
+func (r *Replayer) ReplayFiles(files []string) error {
+	startTime := time.Now()
+	successCount := 0
+	failCount := 0
+
+	for _, file := range files {
+		if err := r.replayFile(file); err != nil {
+			failCount++
+			log.Printf("Error replaying %s: %v", file, err)
+		} else {
+			successCount++
+			log.Printf("Successfully replayed %s", file)
+		}
+	}
+
+	duration := time.Since(startTime)
+	fmt.Printf("\nReplay completed in %s\n", duration)
+	fmt.Printf("Success: %d, Failed: %d\n", successCount, failCount)
+
+	return nil
+}
+
+func (r *Replayer) replayFile(filePath string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("opening file: %w", err)
+	}
+	defer file.Close()
+
+	req, err := http.ReadRequest(bufio.NewReader(file))
+	if err != nil {
+		return fmt.Errorf("reading request: %w", err)
+	}
+
+	newURL := *r.targetURL
+	newURL.Path = req.URL.Path
+	newURL.RawQuery = req.URL.RawQuery
+
+	newReq, err := http.NewRequest(req.Method, newURL.String(), req.Body)
+	if err != nil {
+		return fmt.Errorf("creating new request: %w", err)
+	}
+
+	for key, values := range req.Header {
+		if key == "Host" {
+			continue
+		}
+		for _, value := range values {
+			newReq.Header.Add(key, value)
+		}
+	}
+
+	if r.dryRun {
+		body, _ := io.ReadAll(req.Body)
+
+		if req.URL.Path == "/push.v1.PusherService/Push" {
+			var pushReq pushv1.PushRequest
+			if err := proto.Unmarshal(body, &pushReq); err != nil {
+				fmt.Printf("[%s] %s %s %d bytes (failed to deserialize: %v)\n",
+					filepath.Base(filePath), req.Method, req.URL.Path, len(body), err)
+			} else {
+				fmt.Printf("[%s] %s %s %d bytes\n",
+					filepath.Base(filePath), req.Method, req.URL.Path, len(body))
+				fmt.Printf("  Series count: %d\n", len(pushReq.Series))
+				for i, series := range pushReq.Series {
+					fmt.Printf("  Series[%d]: %d labels, %d samples\n",
+						i, len(series.Labels), len(series.Samples))
+					if len(series.Labels) > 0 {
+						fmt.Printf("    Labels: ")
+						for j, label := range series.Labels {
+							if j > 0 {
+								fmt.Printf(", ")
+							}
+							fmt.Printf("%s=%s", label.Name, label.Value)
+						}
+						fmt.Printf("\n")
+					}
+					for _, s := range series.Samples {
+						p, err := gprofile.ParseData(s.RawProfile)
+						if err != nil {
+							fmt.Printf("    Sample[%d]: %d bytes (failed to deserialize: %v)\n",
+								i, len(s.RawProfile), err)
+						} else {
+							fmt.Println(p.String())
+						}
+					}
+				}
+			}
+		} else {
+			fmt.Printf("[%s] %s %s %d bytes\n", filepath.Base(filePath), req.Method, req.URL.Path, len(body))
+		}
+		return nil
+	}
+	fmt.Println("=================")
+	resp, err := http.DefaultClient.Do(newReq)
+	if err != nil {
+		return fmt.Errorf("sending request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	io.Copy(io.Discard, resp.Body)
+
+	fmt.Printf("[%s] %s %s -> %d\n", filepath.Base(filePath), req.Method, req.URL.Path, resp.StatusCode)
+
+	return nil
+}


### PR DESCRIPTION
…serialization

Implemented request dumping middleware to capture HTTP requests to object storage and a replay tool that can deserialize and display pushv1.PushRequest messages. The replay tool now properly deserializes protobuf messages for the /push.v1.PusherService/Push endpoint and displays detailed information about the series, labels, and pprof profiles.

🤖 Generated with [Claude Code](https://claude.ai/code)

Refers to https://github.com/grafana/pyroscope-squad/issues/373