### PR TITLE
feat: Allow to optionally enforce maxNodes on SelectMergeProfile through limits

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -579,6 +579,8 @@ Usage of ./pyroscope:
     	Maximum number of flame graph nodes by default. 0 to disable. (default 8192)
   -querier.max-flamegraph-nodes-max int
     	Maximum number of flame graph nodes allowed. 0 to disable. (default 1048576)
+  -querier.max-flamegraph-nodes-on-select-merge-profile
+    	Enforce the max nodes limits and defaults on SelectMergeProfile API. Historically this limit was not enforced to enable to gather full pprof profiles without truncation.
   -querier.max-query-length duration
     	The limit to length of queries. 0 to disable. (default 1d)
   -querier.max-query-lookback duration

--- a/pkg/frontend/frontend_diff_test.go
+++ b/pkg/frontend/frontend_diff_test.go
@@ -51,6 +51,10 @@ func (m *mockLimits) MaxFlameGraphNodesMax(_ string) int {
 	return 100_000
 }
 
+func (m *mockLimits) MaxFlameGraphNodesOnSelectMergeProfile(_ string) bool {
+	return true
+}
+
 func (m *mockLimits) SymbolizerEnabled(s string) bool { return true }
 
 type mockRoundTripper struct {

--- a/pkg/test/mocks/mockfrontend/mock_limits.go
+++ b/pkg/test/mocks/mockfrontend/mock_limits.go
@@ -113,6 +113,52 @@ func (_c *MockLimits_MaxFlameGraphNodesMax_Call) RunAndReturn(run func(string) i
 	return _c
 }
 
+// MaxFlameGraphNodesOnSelectMergeProfile provides a mock function with given fields: _a0
+func (_m *MockLimits) MaxFlameGraphNodesOnSelectMergeProfile(_a0 string) bool {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MaxFlameGraphNodesOnSelectMergeProfile")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockLimits_MaxFlameGraphNodesOnSelectMergeProfile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MaxFlameGraphNodesOnSelectMergeProfile'
+type MockLimits_MaxFlameGraphNodesOnSelectMergeProfile_Call struct {
+	*mock.Call
+}
+
+// MaxFlameGraphNodesOnSelectMergeProfile is a helper method to define mock.On call
+//   - _a0 string
+func (_e *MockLimits_Expecter) MaxFlameGraphNodesOnSelectMergeProfile(_a0 interface{}) *MockLimits_MaxFlameGraphNodesOnSelectMergeProfile_Call {
+	return &MockLimits_MaxFlameGraphNodesOnSelectMergeProfile_Call{Call: _e.mock.On("MaxFlameGraphNodesOnSelectMergeProfile", _a0)}
+}
+
+func (_c *MockLimits_MaxFlameGraphNodesOnSelectMergeProfile_Call) Run(run func(_a0 string)) *MockLimits_MaxFlameGraphNodesOnSelectMergeProfile_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockLimits_MaxFlameGraphNodesOnSelectMergeProfile_Call) Return(_a0 bool) *MockLimits_MaxFlameGraphNodesOnSelectMergeProfile_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockLimits_MaxFlameGraphNodesOnSelectMergeProfile_Call) RunAndReturn(run func(string) bool) *MockLimits_MaxFlameGraphNodesOnSelectMergeProfile_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MaxQueryLength provides a mock function with given fields: tenantID
 func (_m *MockLimits) MaxQueryLength(tenantID string) time.Duration {
 	ret := _m.Called(tenantID)
@@ -297,6 +343,52 @@ func (_c *MockLimits_QueryAnalysisEnabled_Call) RunAndReturn(run func(string) bo
 	return _c
 }
 
+// QuerySanitizeOnMerge provides a mock function with given fields: _a0
+func (_m *MockLimits) QuerySanitizeOnMerge(_a0 string) bool {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QuerySanitizeOnMerge")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockLimits_QuerySanitizeOnMerge_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'QuerySanitizeOnMerge'
+type MockLimits_QuerySanitizeOnMerge_Call struct {
+	*mock.Call
+}
+
+// QuerySanitizeOnMerge is a helper method to define mock.On call
+//   - _a0 string
+func (_e *MockLimits_Expecter) QuerySanitizeOnMerge(_a0 interface{}) *MockLimits_QuerySanitizeOnMerge_Call {
+	return &MockLimits_QuerySanitizeOnMerge_Call{Call: _e.mock.On("QuerySanitizeOnMerge", _a0)}
+}
+
+func (_c *MockLimits_QuerySanitizeOnMerge_Call) Run(run func(_a0 string)) *MockLimits_QuerySanitizeOnMerge_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockLimits_QuerySanitizeOnMerge_Call) Return(_a0 bool) *MockLimits_QuerySanitizeOnMerge_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockLimits_QuerySanitizeOnMerge_Call) RunAndReturn(run func(string) bool) *MockLimits_QuerySanitizeOnMerge_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // QuerySplitDuration provides a mock function with given fields: _a0
 func (_m *MockLimits) QuerySplitDuration(_a0 string) time.Duration {
 	ret := _m.Called(_a0)
@@ -349,23 +441,6 @@ func (_m *MockLimits) SymbolizerEnabled(_a0 string) bool {
 
 	if len(ret) == 0 {
 		panic("no return value specified for SymbolizerEnabled")
-	}
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = rf(_a0)
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-func (_m *MockLimits) QuerySanitizeOnMerge(_a0 string) bool {
-	ret := _m.Called(_a0)
-
-	if len(ret) == 0 {
-		panic("no return value specified for QuerySanitizeOnMerge")
 	}
 
 	var r0 bool

--- a/pkg/test/mocks/mockobjstore/mock_bucket.go
+++ b/pkg/test/mocks/mockobjstore/mock_bucket.go
@@ -766,17 +766,24 @@ func (_c *MockBucket_SupportedIterOptions_Call) RunAndReturn(run func() []objsto
 	return _c
 }
 
-// Upload provides a mock function with given fields: ctx, name, r
+// Upload provides a mock function with given fields: ctx, name, r, opts
 func (_m *MockBucket) Upload(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption) error {
-	ret := _m.Called(ctx, name, r)
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, name, r)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Upload")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, io.Reader) error); ok {
-		r0 = rf(ctx, name, r)
+	if rf, ok := ret.Get(0).(func(context.Context, string, io.Reader, ...objstore.ObjectUploadOption) error); ok {
+		r0 = rf(ctx, name, r, opts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -793,13 +800,21 @@ type MockBucket_Upload_Call struct {
 //   - ctx context.Context
 //   - name string
 //   - r io.Reader
-func (_e *MockBucket_Expecter) Upload(ctx interface{}, name interface{}, r interface{}) *MockBucket_Upload_Call {
-	return &MockBucket_Upload_Call{Call: _e.mock.On("Upload", ctx, name, r)}
+//   - opts ...objstore.ObjectUploadOption
+func (_e *MockBucket_Expecter) Upload(ctx interface{}, name interface{}, r interface{}, opts ...interface{}) *MockBucket_Upload_Call {
+	return &MockBucket_Upload_Call{Call: _e.mock.On("Upload",
+		append([]interface{}{ctx, name, r}, opts...)...)}
 }
 
-func (_c *MockBucket_Upload_Call) Run(run func(ctx context.Context, name string, r io.Reader)) *MockBucket_Upload_Call {
+func (_c *MockBucket_Upload_Call) Run(run func(ctx context.Context, name string, r io.Reader, opts ...objstore.ObjectUploadOption)) *MockBucket_Upload_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(io.Reader))
+		variadicArgs := make([]objstore.ObjectUploadOption, len(args)-3)
+		for i, a := range args[3:] {
+			if a != nil {
+				variadicArgs[i] = a.(objstore.ObjectUploadOption)
+			}
+		}
+		run(args[0].(context.Context), args[1].(string), args[2].(io.Reader), variadicArgs...)
 	})
 	return _c
 }
@@ -809,7 +824,7 @@ func (_c *MockBucket_Upload_Call) Return(_a0 error) *MockBucket_Upload_Call {
 	return _c
 }
 
-func (_c *MockBucket_Upload_Call) RunAndReturn(run func(context.Context, string, io.Reader) error) *MockBucket_Upload_Call {
+func (_c *MockBucket_Upload_Call) RunAndReturn(run func(context.Context, string, io.Reader, ...objstore.ObjectUploadOption) error) *MockBucket_Upload_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -87,9 +87,9 @@ type Limits struct {
 	QueryAnalysisSeriesEnabled bool           `yaml:"query_analysis_series_enabled" json:"query_analysis_series_enabled"`
 
 	// Flame graph enforced limits.
-	MaxFlameGraphNodesDefault int `yaml:"max_flamegraph_nodes_default" json:"max_flamegraph_nodes_default"`
-	MaxFlameGraphNodesMax     int `yaml:"max_flamegraph_nodes_max" json:"max_flamegraph_nodes_max"`
-
+	MaxFlameGraphNodesDefault              int  `yaml:"max_flamegraph_nodes_default" json:"max_flamegraph_nodes_default"`
+	MaxFlameGraphNodesMax                  int  `yaml:"max_flamegraph_nodes_max" json:"max_flamegraph_nodes_max"`
+	MaxFlameGraphNodesOnSelectMergeProfile bool `yaml:"max_flamegraph_nodes_on_select_merge_profile" json:"max_flamegraph_nodes_on_select_merge_profile" category:"advanced" doc:"hidden"`
 	// Store-gateway.
 	StoreGatewayTenantShardSize int `yaml:"store_gateway_tenant_shard_size" json:"store_gateway_tenant_shard_size"`
 
@@ -186,6 +186,7 @@ func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 
 	f.IntVar(&l.MaxFlameGraphNodesDefault, "querier.max-flamegraph-nodes-default", 8<<10, "Maximum number of flame graph nodes by default. 0 to disable.")
 	f.IntVar(&l.MaxFlameGraphNodesMax, "querier.max-flamegraph-nodes-max", 1<<20, "Maximum number of flame graph nodes allowed. 0 to disable.")
+	f.BoolVar(&l.MaxFlameGraphNodesOnSelectMergeProfile, "querier.max-flamegraph-nodes-on-select-merge-profile", false, "Enforce the max nodes limits and defaults on SelectMergeProfile API. Historically this limit was not enforced to enable to gather full pprof profiles without truncation.")
 
 	f.Var(&l.DistributorAggregationWindow, "distributor.aggregation-window", "Duration of the distributor aggregation window. Requires aggregation period to be specified. 0 to disable.")
 	f.Var(&l.DistributorAggregationPeriod, "distributor.aggregation-period", "Duration of the distributor aggregation period. Requires aggregation window to be specified. 0 to disable.")
@@ -426,6 +427,11 @@ func (o *Overrides) MaxFlameGraphNodesDefault(tenantID string) int {
 // MaxFlameGraphNodesMax returns the max flame graph nodes allowed.
 func (o *Overrides) MaxFlameGraphNodesMax(tenantID string) int {
 	return o.getOverridesForTenant(tenantID).MaxFlameGraphNodesMax
+}
+
+// MaxFlameGraphNodesOnSelectMergeProfiles returns if the max flame graph nodes should be enforced for the SelectMergeProfile API.
+func (o *Overrides) MaxFlameGraphNodesOnSelectMergeProfile(tenantID string) bool {
+	return o.getOverridesForTenant(tenantID).MaxFlameGraphNodesOnSelectMergeProfile
 }
 
 // StoreGatewayTenantShardSize returns the store-gateway shard size for a given user.

--- a/pkg/validation/testutil.go
+++ b/pkg/validation/testutil.go
@@ -16,8 +16,9 @@ type MockLimits struct {
 	MaxLabelValueLengthValue        int
 	MaxLabelNamesPerSeriesValue     int
 
-	MaxFlameGraphNodesDefaultValue int
-	MaxFlameGraphNodesMaxValue     int
+	MaxFlameGraphNodesDefaultValue              int
+	MaxFlameGraphNodesMaxValue                  int
+	MaxFlameGraphNodesOnSelectMergeProfileValue bool
 
 	DistributorAggregationWindowValue time.Duration
 	DistributorAggregationPeriodValue time.Duration
@@ -51,6 +52,9 @@ func (m MockLimits) QuerySanitizeOnMerge(tenantID string) bool {
 }
 func (m MockLimits) MaxFlameGraphNodesDefault(string) int { return m.MaxFlameGraphNodesDefaultValue }
 func (m MockLimits) MaxFlameGraphNodesMax(string) int     { return m.MaxFlameGraphNodesMaxValue }
+func (m MockLimits) MaxFlameGraphNodesOnSelectMergeProfile(string) bool {
+	return m.MaxFlameGraphNodesOnSelectMergeProfileValue
+}
 
 func (m MockLimits) MaxLabelNameLength(userID string) int     { return m.MaxLabelNameLengthValue }
 func (m MockLimits) MaxLabelValueLength(userID string) int    { return m.MaxLabelValueLengthValue }

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -517,6 +517,7 @@ func SanitizeTimeRange(limits RangeRequestLimits, tenant []string, start, end *i
 type FlameGraphLimits interface {
 	MaxFlameGraphNodesDefault(string) int
 	MaxFlameGraphNodesMax(string) int
+	MaxFlameGraphNodesOnSelectMergeProfile(string) bool
 }
 
 func ValidateMaxNodes(l FlameGraphLimits, tenantIDs []string, n int64) (int64, error) {


### PR DESCRIPTION
Historically we didn't default and enforce the maxNodes limit on SelectMergeProfiles. I think we should start doing that.

