### PR TITLE
fix: integration test data of partially symbolized profile

### DIFF
--- a/pkg/test/integration/symbolization_test.go
+++ b/pkg/test/integration/symbolization_test.go
@@ -196,6 +196,9 @@ Mappings
 						Value:    []int64{3},
 					},
 				}
+				p.Function = []*profile.Function{
+					f1,
+				}
 
 				return p
 			},
@@ -207,10 +210,10 @@ cpu/nanoseconds[dflt]
           3: 1 2 
         100: 1 
 Locations
-     1: 0x1500 M=1 symbolized_func src.c:239:0 s=0()
-     2: 0x3c5a M=1 atoll_b :0:0 s=0()
+     1: 0x0 M=1 symbolized_func src.c:239:0 s=0()
+     2: 0x0 M=1 atoll_b :0:0 s=0()
 Mappings
-1: 0x0/0x1000000/0x0 libfoo.so 2fa2055ef20fabc972d5751147e093275514b142 [FN]
+1: 0x0/0x0/0x0 libfoo.so 2fa2055ef20fabc972d5751147e093275514b142 [FN]
 `,
 			skip: true, // TODO fix the testdata or symbolization
 		},


### PR DESCRIPTION
This PR fixes a problem in the testdata.

The test is still skipped and broken.

```
    symbolization_test.go:274: 
        	Error Trace:	/home/korniltsev/pyroscope/pkg/test/integration/symbolization_test.go:274
        	            				/home/korniltsev/sdk/go1.25.0/src/runtime/asm_amd64.s:1693
        	Error:      	Not equal: 
        	            	expected: "PeriodType: cpu nanoseconds\nPeriod: 1000000000\nSamples:\ncpu/nanoseconds[dflt]\n        200: 2 \n          3: 1 2 \n        100: 1 \nLocations\n     1: 0x0 M=1 symbolized_func src.c:239:0 s=0()\n     2: 0x0 M=1 atoll_b :0:0 s=0()\nMappings\n1: 0x0/0x0/0x0 libfoo.so 2fa2055ef20fabc972d5751147e093275514b142 [FN]\n"
        	            	actual  : "PeriodType: cpu nanoseconds\nPeriod: 1000000000\nSamples:\ncpu/nanoseconds[dflt]\n        200: 2 \n          3: 1 2 \n        100: 1 \nLocations\n     1: 0x0 M=1 symbolized_func src.c:239:0 s=0()\n     2: 0x0 M=1 \nMappings\n1: 0x0/0x0/0x0 libfoo.so 2fa2055ef20fabc972d5751147e093275514b142 [FN]\n"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -9,3 +9,3 @@
        	            	      1: 0x0 M=1 symbolized_func src.c:239:0 s=0()
        	            	-     2: 0x0 M=1 atoll_b :0:0 s=0()
        	            	+     2: 0x0 M=1 
```