### PR TITLE
feat: add health check/warmup to segmentwriter to reduce first-write latency

### DIFF
--- a/pkg/segmentwriter/service.go
+++ b/pkg/segmentwriter/service.go
@@ -193,7 +193,7 @@ func (i *SegmentWriterService) starting(ctx context.Context) error {
 	// Perform bucket health check before ring registration to warm up the connection
 	// and avoid slow first requests affecting p99 latency
 	// On error, will emit a warning but continue startup
-	i.performBucketHealthCheck(ctx)
+	_ = i.performBucketHealthCheck(ctx)
 
 	if err := services.StartManagerAndAwaitHealthy(ctx, i.subservices); err != nil {
 		return err


### PR DESCRIPTION
* Adds dual-purpose check that:
  * Establishes connection to object store before reporting ready to reduce latency
  * Logs a warning if there is an issue with credentials