### PR TITLE
chore: include rule id in pyroscope_metrics_exporter_series_sent_total

### DIFF
--- a/pkg/model/recording_rule.go
+++ b/pkg/model/recording_rule.go
@@ -20,11 +20,11 @@ type RecordingRule struct {
 
 const (
 	metricNamePrefix = "profiles_recorded_"
-	ruleIdLabel      = "profiles_rule_id"
+	RuleIDLabel      = "profiles_rule_id"
 )
 
 var uniqueLabels = map[string]bool{
-	ruleIdLabel:                     true,
+	RuleIDLabel:                     true,
 	prometheusmodel.MetricNameLabel: true,
 }
 
@@ -77,7 +77,7 @@ func newRecordingRuleWithBuilder(rule *settingsv1.RecordingRule, sb *labels.Scra
 	// trust rule.MetricName
 	sb.Add(prometheusmodel.MetricNameLabel, rule.MetricName)
 	// Inject recording rule Id
-	sb.Add(ruleIdLabel, rule.Id)
+	sb.Add(RuleIDLabel, rule.Id)
 
 	sb.Sort()
 


### PR DESCRIPTION
The idea is to easily find rules that contribute the most to an eventual alert on tenants hitting cardinality limits. 

We can make this more efficient in a previous layer of the code, but I avoided changing interfaces too much, while this code runs in a separate thread I think we can deal with it