### PR TITLE
chore: Allow to configure subPaths for metastore and shared

### DIFF
--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -71,6 +71,8 @@
 | pyroscope.persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
 | pyroscope.persistence.annotations | object | `{}` |  |
 | pyroscope.persistence.enabled | bool | `false` |  |
+| pyroscope.persistence.metastore.subPath | string | `".metastore"` |  |
+| pyroscope.persistence.shared.subPath | string | `".shared"` |  |
 | pyroscope.persistence.size | string | `"10Gi"` |  |
 | pyroscope.podAnnotations."profiles.grafana.com/cpu.port_name" | string | `"http2"` |  |
 | pyroscope.podAnnotations."profiles.grafana.com/cpu.scrape" | string | `"true"` |  |

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -214,12 +214,12 @@ spec:
             {{- if $hasV2 }}
             - name: data
               mountPath: /data-shared
-              subPath: .shared
+              subPath: {{ $values.persistence.shared.subPath }}
             {{- end }}
             {{- if $isMetastore }}
             - name: data
               mountPath: /data-metastore
-              subPath: .metastore
+              subPath: {{ $values.persistence.metastore.subPath }}
             {{- end }}
             {{- with $values.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -144,6 +144,14 @@ pyroscope:
     # subPath: ""
     # existingClaim:
 
+    metastore:
+      # subPath to use of the data volume for the metastore persistence.
+      subPath: .metastore
+
+    shared:
+      # subPath to use of the data volume for the shared storage used as bucket replacement.
+      subPath: .shared
+
   extraVolumes:
     []
     # - name: backup-volume

--- a/operations/pyroscope/jsonnet/values.json
+++ b/operations/pyroscope/jsonnet/values.json
@@ -414,6 +414,12 @@
       ],
       "annotations": {},
       "enabled": false,
+      "metastore": {
+        "subPath": ".metastore"
+      },
+      "shared": {
+        "subPath": ".shared"
+      },
       "size": "10Gi"
     },
     "podAnnotations": {


### PR DESCRIPTION
This allows to adapt those variables, without fullly patching them out.

That's used GL internal, as we started of with a subPath of "metastore".
