### PR TITLE
fix distributor sampling rule processing priority

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -347,7 +347,7 @@ func (l lazyUsageGroups) String() string {
 	groups := l()
 	result := make([]string, len(groups))
 	for pos := range groups {
-		result[pos] = groups[pos].ResolvedName
+		result[pos] = groups[pos].String()
 	}
 	return fmt.Sprintf("%v", result)
 }
@@ -1021,9 +1021,9 @@ func (d *Distributor) shouldSample(tenantID string, groupsInRequest []validation
 	samplingProbability := 1.0
 	var match *validation.UsageGroupMatchName
 	for _, group := range groupsInRequest {
-		probabilityCfg, found := l.UsageGroups[group.ConfiguredName]
+		probabilityCfg, found := l.UsageGroups[group.ResolvedName]
 		if !found {
-			probabilityCfg, found = l.UsageGroups[group.ResolvedName]
+			probabilityCfg, found = l.UsageGroups[group.ConfiguredName]
 		}
 		if !found {
 			continue


### PR DESCRIPTION
The improvement introduced in https://github.com/grafana/pyroscope/pull/4347 assumed that there will always be multiple usage groups configured, when there are multiple sampling rules defined. However, a common setup is to have a single usage group (e.g., `service/${labels.service_name}`) and multiple sampling rules targeting both the configured usage group (`service/${labels.service_name}`) and the resolved ones (e.g., `service/service_a`, `service/service_b`).

The current implementation doesn't handle this setup correctly, since we never take into account sampling rules that target resolved names. This PR fixes that and improves the tests around it.