### PR TITLE
draft: change StacktraceTree implementation to fast Insert

### DIFF
--- a/pkg/model/stacktrace_tree_indexed.go
+++ b/pkg/model/stacktrace_tree_indexed.go
@@ -1,0 +1,284 @@
+package model
+
+import (
+	"fmt"
+
+	"github.com/grafana/pyroscope/pkg/util/minheap"
+)
+
+type AVLTree struct {
+	root       *AVLNode
+	totalNodes int32
+}
+
+func (t *AVLTree) Insert(locations []int32, value int64) {
+	var inserted *AVLNode
+	var insertedNodes int
+	tree := t
+	for i := len(locations) - 1; i >= 0; i-- {
+		location := locations[i]
+		inserted, tree.root, insertedNodes = tree.root.insert(location, value, i == 0)
+		tree = inserted.children
+		t.totalNodes += int32(insertedNodes)
+	}
+}
+
+func (t *AVLTree) Len() int32 {
+	return t.totalNodes
+}
+
+func (t *AVLTree) ToString() string {
+	return t.root.ToString()
+}
+
+func (t *AVLNode) ToString() string {
+	if t == nil {
+		return ""
+	}
+	return t.left.ToString() + fmt.Sprintf("[%d %d %d]", t.Location, t.Value, t.Total) + t.children.ToString() + t.right.ToString()
+}
+
+func (t *AVLTree) Print(level int32) {
+	t.root.Print(level)
+}
+
+func (t *AVLNode) Print(level int32) {
+	if t == nil {
+		return
+	}
+	t.left.Print(level)
+	fmt.Printf("%d %d %d %d\n", level, t.Location, t.Value, t.Total)
+	t.children.Print(level + 1)
+	t.right.Print(level)
+}
+
+type AVLNode struct {
+	Location int32
+	Value    int64
+	Total    int64
+	left     *AVLNode
+	right    *AVLNode
+	height   int32
+	children *AVLTree
+}
+
+func (n *AVLNode) updateHeight() {
+	left, right := int32(-1), int32(-1)
+	if n.left != nil {
+		left = n.left.height
+	}
+	if n.right != nil {
+		right = n.right.height
+	}
+	n.height = 1 + max(left, right)
+}
+
+func (n *AVLNode) rightRotation() *AVLNode {
+	x := n.left
+	n.left = x.right
+	x.right = n
+	n.updateHeight()
+	x.updateHeight()
+	return x
+}
+
+func (n *AVLNode) leftRotation() *AVLNode {
+	x := n.right
+	n.right = x.left
+	x.left = n
+	n.updateHeight()
+	x.updateHeight()
+	return x
+}
+
+func (n *AVLNode) balanceFactor() int32 {
+	left, right := int32(-1), int32(-1)
+	if n.left != nil {
+		left = n.left.height
+	}
+	if n.right != nil {
+		right = n.right.height
+	}
+	return left - right
+}
+
+// return the new root
+
+func (n *AVLNode) rebalance() *AVLNode {
+	bf := n.balanceFactor()
+	if bf > 1 {
+		// LR
+		if n.left != nil && n.left.balanceFactor() < 0 {
+			n.left = n.left.leftRotation()
+		}
+		// LL
+		n = n.rightRotation()
+	} else if bf < -1 {
+		// RL
+		if n.right != nil && n.right.balanceFactor() > 0 {
+			n.right = n.right.rightRotation()
+		}
+		// RR
+		n = n.leftRotation()
+	}
+	return n
+}
+
+func NewAVLNode(key int32, val int64, total int64) *AVLNode {
+	return &AVLNode{
+		Location: key,
+		Value:    val,
+		Total:    total,
+		left:     nil,
+		right:    nil,
+		height:   0,
+		children: &AVLTree{},
+	}
+}
+
+func (n *AVLNode) insert(location int32, value int64, isFinal bool) (*AVLNode, *AVLNode, int) {
+	var inserted *AVLNode
+	if n == nil {
+		total := value
+		if !isFinal {
+			value = 0
+		}
+		inserted = NewAVLNode(location, value, total)
+		return inserted, inserted, 1
+	}
+	insertedNodes := 0
+	if location < n.Location {
+		inserted, n.left, insertedNodes = n.left.insert(location, value, isFinal)
+	} else if location > n.Location {
+		inserted, n.right, insertedNodes = n.right.insert(location, value, isFinal)
+	} else {
+		inserted = n
+		if isFinal {
+			n.Value += value
+		}
+		n.Total += value
+	}
+	n.updateHeight()
+	return inserted, n.rebalance(), insertedNodes
+}
+
+func (t *AVLTree) MinValue(maxNodes int64) int64 {
+	if maxNodes < 1 || maxNodes >= int64(t.totalNodes) {
+		return 0
+	}
+	h := make([]int64, 0, maxNodes)
+	for i := NewAVLIterator(*t); i.Next(); {
+		curr := i.At()
+		if len(h) >= int(maxNodes) {
+			if curr.Total > h[0] {
+				h = minheap.Pop(h)
+			} else {
+				continue
+			}
+		}
+		h = minheap.Push(h, curr.Total)
+	}
+	return h[0]
+}
+
+func (t *AVLTree) Tree(maxNodes int64, names []string) *Tree {
+	if t.totalNodes < 1 || len(names) == 0 {
+		return new(Tree)
+	}
+
+	minValue := t.MinValue(maxNodes)
+	root := new(node)
+	children := t.root.tree(minValue, names, root)
+	for _, n := range children {
+		n.parent = nil
+	}
+
+	return &Tree{root: children}
+}
+
+func (n *AVLNode) tree(minValue int64, names []string, parent *node) []*node {
+	i := NewAVLChildrenIterator(n)
+	children := make([]*node, 0)
+	truncated := int64(0)
+	for i.Next() {
+		avlNode := i.At()
+		if avlNode.Total >= minValue && avlNode.Location >= 0 && avlNode.Location < int32(len(names)) {
+			aux := &node{
+				parent: parent,
+				name:   names[avlNode.Location],
+				self:   avlNode.Value,
+				total:  avlNode.Total,
+			}
+			aux.children = avlNode.children.root.tree(minValue, names, aux)
+			children = append(children, aux)
+		} else {
+			truncated += avlNode.Total
+		}
+	}
+	if truncated > 0 {
+		children = append(children, &node{
+			parent: parent,
+			name:   truncatedNodeName,
+			self:   truncated,
+			total:  truncated,
+		})
+	}
+	return children
+}
+
+type AVLIterator struct {
+	includeChildren bool
+
+	current *AVLNode
+
+	queue []*AVLNode
+}
+
+func NewAVLChildrenIterator(node *AVLNode) *AVLIterator {
+	return &AVLIterator{
+		includeChildren: false,
+		current:         node,
+		queue:           make([]*AVLNode, 0), // TODO?
+	}
+}
+
+func NewAVLIterator(t AVLTree) *AVLIterator {
+	return &AVLIterator{
+		includeChildren: true,
+		current:         t.root,
+		queue:           make([]*AVLNode, 0, t.totalNodes+1),
+	}
+}
+
+func (i *AVLIterator) Next() bool {
+	return i.current != nil
+}
+
+func (i *AVLIterator) At() *AVLNode {
+	at := i.current
+	if at.left != nil {
+		i.queue = append(i.queue, at.left)
+	}
+	if i.includeChildren {
+		if at.children.root != nil {
+			i.queue = append(i.queue, at.children.root)
+		}
+	}
+	if at.right != nil {
+		i.queue = append(i.queue, at.right)
+	}
+	if len(i.queue) > 0 {
+		i.current, i.queue = i.queue[0], i.queue[1:]
+	} else {
+		i.current = nil
+	}
+	return at
+}
+
+func (i *AVLIterator) Err() error {
+	return nil
+}
+
+func (i *AVLIterator) Close() error {
+	return nil
+}

--- a/pkg/model/stacktraces_test.go
+++ b/pkg/model/stacktraces_test.go
@@ -1,7 +1,14 @@
 package model
 
 import (
+	"bufio"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -145,4 +152,184 @@ func TestStackTraceMerger(t *testing.T) {
 			require.Equal(t, tc.expected.String(), actual.String())
 		})
 	}
+}
+
+func TestTree(t *testing.T) {
+	tree2 := NewStacktraceTree(10)
+	tree2.Insert([]int32{7}, 2)
+	tree2.Insert([]int32{7, 3}, 100)
+	tree2.Insert([]int32{3, 7}, 1000)
+	tree2.Insert([]int32{3, 7}, 50)
+	tree2.Insert([]int32{1, 2, 3}, 10)
+	tree2.Insert([]int32{4, 2, 3}, 5)
+
+	tree2.Traverse(1000, func(index int32, children []int32) error {
+		fmt.Println(tree2.Nodes[index].Location, tree2.Nodes[index].Value, tree2.Nodes[index].Total)
+		return nil
+	})
+	NN := int64(2)
+	t2 := tree2.Tree(NN, []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"})
+	fmt.Println(t2.String())
+
+	tree := AVLTree{}
+	tree.Insert([]int32{1, 2, 3}, 10)
+	tree.Insert([]int32{4, 2, 3}, 5)
+	tree.Insert([]int32{7}, 2)
+	tree.Insert([]int32{7, 3}, 100)
+	tree.Insert([]int32{3, 7}, 1000)
+	tree.Insert([]int32{3, 7}, 50)
+	fmt.Println(tree.Len())
+	i := NewAVLIterator(tree)
+	n := 0
+	for i.Next() {
+		n++
+		i.At()
+	}
+	fmt.Println(n)
+	tr := tree.Tree(NN, []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"})
+	fmt.Println(tr.String())
+
+	require.Equal(t, true, t2.Equal(tr))
+	require.Equal(t, t2.String(), tr.String())
+
+}
+
+type fileline struct {
+	stack []int32
+	value int64
+}
+
+var names []string
+var lines []fileline
+
+func init() {
+	names = make([]string, 0, 20000000)
+	for i := 0; i < 20000000; i++ {
+		names = append(names, strconv.Itoa(i))
+	}
+
+	lines, _ = readLines("./testdata/stacktraces.log")
+}
+
+func readLines(path string) ([]fileline, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+
+	lines := make([]fileline, 0)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Split(line, "]")
+
+		stackStr := strings.Trim(parts[0], "[")
+		valStr := strings.TrimSpace(parts[1])
+
+		var stack []int32
+		if len(stackStr) > 0 {
+			for _, s := range strings.Split(stackStr, " ") {
+				i, _ := strconv.Atoi(s)
+				stack = append(stack, int32(i))
+			}
+		}
+		value, _ := strconv.ParseInt(valStr, 10, 64)
+
+		lines = append(lines, fileline{stack, value})
+	}
+	return lines, nil
+}
+
+func TestStacktraceTree_InsertFromFile(t *testing.T) {
+	tree := NewStacktraceTree(0)
+	start := time.Now()
+	for line := range lines {
+		tree.Insert(lines[line].stack, lines[line].value)
+	}
+	fmt.Println("trie:", time.Since(start))
+
+	tree2 := AVLTree{}
+	start = time.Now()
+	for line := range lines {
+		tree2.Insert(lines[line].stack, lines[line].value)
+	}
+	fmt.Println("avl:", time.Since(start))
+
+	start = time.Now()
+	resultingTree1 := tree.Tree(20000000, names)
+	fmt.Println("trie:", time.Since(start))
+	start = time.Now()
+	resultingTree2 := tree.Tree(20000000, names)
+	fmt.Println("avl:", time.Since(start))
+
+	require.Equal(t, true, resultingTree1.Equal(resultingTree2))
+}
+
+func TestStacktraceTree_Iterator(t *testing.T) {
+	tree := AVLTree{}
+	start := time.Now()
+	for line := range lines {
+		tree.Insert(lines[line].stack, lines[line].value)
+	}
+	fmt.Println("avl:", time.Since(start))
+
+	i := NewAVLIterator(tree)
+	n := int32(0)
+	for i.Next() {
+		n++
+		i.At()
+	}
+	require.Equal(t, n, tree.Len())
+}
+
+func TestStacktraceTree_MinValue(t *testing.T) {
+	tree := NewStacktraceTree(0)
+	for line := range lines {
+		tree.Insert(lines[line].stack, lines[line].value)
+	}
+	start := time.Now()
+	mv1 := tree.MinValue(int64(len(tree.Nodes) - 1))
+	fmt.Println("trie:", time.Since(start))
+
+	tree2 := AVLTree{}
+	for line := range lines {
+		tree2.Insert(lines[line].stack, lines[line].value)
+	}
+
+	start = time.Now()
+	mv2 := tree2.MinValue(int64(tree2.Len() - 1))
+	fmt.Println("avl:", time.Since(start))
+
+	require.Equal(t, mv1, mv2)
+}
+
+func TestStacktraceTree_MinValueRandom(t *testing.T) {
+	tree := NewStacktraceTree(0)
+	for line := range lines {
+		tree.Insert(lines[line].stack, lines[line].value)
+	}
+
+	tree2 := AVLTree{}
+	for line := range lines {
+		tree2.Insert(lines[line].stack, lines[line].value)
+	}
+
+	totalTrie := time.Duration(0)
+	totalAVL := time.Duration(0)
+	l := len(tree.Nodes)
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i <= l; i += rand.Intn(1000000) + 1 {
+		start := time.Now()
+		mv1 := tree.MinValue(int64(i))
+		totalTrie += time.Since(start)
+		start = time.Now()
+		mv2 := tree2.MinValue(int64(i))
+		totalAVL += time.Since(start)
+		fmt.Println(i, "trie:", mv1, "avl:", mv2)
+		require.Equal(t, mv1, mv2)
+	}
+	fmt.Println("total trie:", totalTrie)
+	fmt.Println("total avl:", totalAVL)
 }

--- a/pkg/model/tree.go
+++ b/pkg/model/tree.go
@@ -29,6 +29,39 @@ type node struct {
 	name        string
 }
 
+func (t *Tree) Equal(c *Tree) bool {
+	sort.Slice(t.root, func(i, j int) bool {
+		return t.root[i].name < t.root[j].name
+	})
+	sort.Slice(c.root, func(i, j int) bool {
+		return c.root[i].name < c.root[j].name
+	})
+	for i, n := range t.root {
+		if !n.equal(c.root[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func (n *node) equal(c *node) bool {
+	if n.self != c.self || n.total != c.total || n.name != c.name {
+		return false
+	}
+	sort.Slice(n.children, func(i, j int) bool {
+		return n.children[i].name < n.children[j].name
+	})
+	sort.Slice(c.children, func(i, j int) bool {
+		return c.children[i].name < c.children[j].name
+	})
+	for i, cn := range n.children {
+		if !cn.equal(c.children[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 func (t *Tree) String() string {
 	type branch struct {
 		nodes []*node


### PR DESCRIPTION
Implementation of the hackathon idea I developed two weeks ago.

The current implementation of `StactraceTree` (pkg/model/stacktraces.go) is pretty bad at loading big trees. 
Every node's children are stored in a linked list, so when we are inserting a new stacktrace frame, on every level we need to search for current node linearly, or check them all to ensure there's not a hit. This makes the creation of big trees to perform very poorly.

We should see good improvements just by replacing this linked list by any indexed structure such a map. In my case, insead, I used a AVL tree to store the children of a node. Note that this AVL tree does not replace the original "Trie", where the topology of the tree has a meaning (the stacktraces sequence order). This is important as AVL trees are self-balancing, hence we loose the order aspect we need in order to construct stacktraces. 

I just choose to use AVL trees because I wanted to test some other techniques, where we can use SIMD to boost search performance [[blog](https://clement-jean.github.io/simd_binary_search_tree/)]. My implementation is very far from that, as that technique requires the tree to be stored as an array. Right now my implementation is suboptimal and I believe that can be improved.

I include tests for this. In the test, you will see simple benchmarking. I downloaded a whole ops block and I processed it to have a simple 1GB text file representing a huge tree of symbols ids. The file contains 8M lines and the resulting tree after 8M insertions has over 10M nodes. 

Here you have an example of a single run of the benchmark, on the 3 public functions of the class. Trie is the original implementation, avl is the proposed one:
```
Insert
trie: 24.488639292s
avl: 3.671334667s

Tree
trie: 570.854958ms
avl: 555.209541ms

MinValue
trie: 45.229334ms
avl: 306.089458ms
```

We can see huge improvements in inserting 8M nodes, while we see some slower results in MinValue.

I didn't upload the text file, please message me for a copy.

TODO:
* I did recursive implementation for simplicity, iterative should be faster.
* No array, nor SIMD techniques were explored.
* Benchmark small trees too.
* Do a _map_ implementation to benchmark and have an idea on how convenient AVL trees are.