### PR TITLE
feat(v2): add admin page to list, visualize and download profiles

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -300,6 +300,9 @@ type AdminService interface {
 	BlocksHandler(w http.ResponseWriter, r *http.Request)
 	BlockHandler(w http.ResponseWriter, r *http.Request)
 	DatasetHandler(w http.ResponseWriter, r *http.Request)
+	DatasetProfilesHandler(w http.ResponseWriter, r *http.Request)
+	ProfileDownloadHandler(w http.ResponseWriter, r *http.Request)
+	ProfileCallTreeHandler(w http.ResponseWriter, r *http.Request)
 }
 
 func (a *API) RegisterAdmin(ad AdminService) {
@@ -307,6 +310,9 @@ func (a *API) RegisterAdmin(ad AdminService) {
 	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks", http.HandlerFunc(ad.BlocksHandler), a.registerOptionsPublicAccess()...)
 	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}", http.HandlerFunc(ad.BlockHandler), a.registerOptionsPublicAccess()...)
 	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets", http.HandlerFunc(ad.DatasetHandler), a.registerOptionsPublicAccess()...)
+	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles", http.HandlerFunc(ad.DatasetProfilesHandler), a.registerOptionsPublicAccess()...)
+	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles/download", http.HandlerFunc(ad.ProfileDownloadHandler), a.registerOptionsPublicAccess()...)
+	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles/call-tree", http.HandlerFunc(ad.ProfileCallTreeHandler), a.registerOptionsPublicAccess()...)
 
 	a.indexPage.AddLinks(defaultWeight, "Admin", []IndexPageLink{
 		{Desc: "Object Storage Tenants & Blocks", Path: "/ops/object-store/tenants"},

--- a/pkg/operations/admin.go
+++ b/pkg/operations/admin.go
@@ -49,3 +49,15 @@ func (a *Admin) BlockHandler(w http.ResponseWriter, r *http.Request) {
 func (a *Admin) DatasetHandler(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "Dataset details not available in v1 storage", http.StatusNotFound)
 }
+
+func (a *Admin) DatasetProfilesHandler(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "Dataset profiles not available in v1 storage", http.StatusNotFound)
+}
+
+func (a *Admin) ProfileDownloadHandler(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "Profile download not available in v1 storage", http.StatusNotFound)
+}
+
+func (a *Admin) ProfileCallTreeHandler(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "Profile call tree not available in v1 storage", http.StatusNotFound)
+}

--- a/pkg/operations/v2/admin.go
+++ b/pkg/operations/v2/admin.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/services"
+
+	"github.com/grafana/pyroscope/pkg/objstore"
 )
 
 type Admin struct {
@@ -14,12 +16,13 @@ type Admin struct {
 	handlers *Handlers
 }
 
-func NewAdmin(metastoreClient MetastoreClient, logger log.Logger) (*Admin, error) {
+func NewAdmin(metastoreClient MetastoreClient, bucket objstore.Bucket, logger log.Logger) (*Admin, error) {
 	a := &Admin{
 		logger: logger,
 		handlers: &Handlers{
 			Logger:          logger,
 			MetastoreClient: metastoreClient,
+			Bucket:          bucket,
 		},
 	}
 	a.Service = services.NewBasicService(nil, a.running, nil)
@@ -45,4 +48,16 @@ func (a *Admin) BlockHandler(w http.ResponseWriter, r *http.Request) {
 
 func (a *Admin) DatasetHandler(w http.ResponseWriter, r *http.Request) {
 	a.handlers.CreateDatasetDetailsHandler()(w, r)
+}
+
+func (a *Admin) DatasetProfilesHandler(w http.ResponseWriter, r *http.Request) {
+	a.handlers.CreateDatasetProfilesHandler()(w, r)
+}
+
+func (a *Admin) ProfileDownloadHandler(w http.ResponseWriter, r *http.Request) {
+	a.handlers.CreateDatasetProfileDownloadHandler()(w, r)
+}
+
+func (a *Admin) ProfileCallTreeHandler(w http.ResponseWriter, r *http.Request) {
+	a.handlers.CreateDatasetProfileCallTreeHandler()(w, r)
 }

--- a/pkg/operations/v2/handlers.go
+++ b/pkg/operations/v2/handlers.go
@@ -16,6 +16,7 @@ import (
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
 	"github.com/grafana/pyroscope/pkg/block/metadata"
+	"github.com/grafana/pyroscope/pkg/objstore"
 	httputil "github.com/grafana/pyroscope/pkg/util/http"
 )
 
@@ -27,6 +28,7 @@ type MetastoreClient interface {
 
 type Handlers struct {
 	MetastoreClient MetastoreClient
+	Bucket          objstore.Bucket
 	Logger          log.Logger
 }
 
@@ -242,16 +244,26 @@ func (h *Handlers) convertDataset(ds *metastorev1.Dataset, stringTable []string)
 		symbolsSize = (ds.TableOfContents[0] + ds.Size) - ds.TableOfContents[2]
 	}
 
+	var profilesPercentage, indexPercentage, symbolsPercentage float64
+	if ds.Size > 0 {
+		profilesPercentage = (float64(profilesSize) / float64(ds.Size)) * 100
+		indexPercentage = (float64(indexSize) / float64(ds.Size)) * 100
+		symbolsPercentage = (float64(symbolsSize) / float64(ds.Size)) * 100
+	}
+
 	return datasetDetails{
-		Tenant:       tenant,
-		Name:         datasetName,
-		MinTime:      msToTime(ds.MinTime).UTC().Format(time.RFC3339),
-		MaxTime:      msToTime(ds.MaxTime).UTC().Format(time.RFC3339),
-		Size:         humanize.Bytes(ds.Size),
-		ProfilesSize: humanize.Bytes(profilesSize),
-		IndexSize:    humanize.Bytes(indexSize),
-		SymbolsSize:  humanize.Bytes(symbolsSize),
-		LabelSets:    labelSets,
+		Tenant:             tenant,
+		Name:               datasetName,
+		MinTime:            msToTime(ds.MinTime).UTC().Format(time.RFC3339),
+		MaxTime:            msToTime(ds.MaxTime).UTC().Format(time.RFC3339),
+		Size:               humanize.Bytes(ds.Size),
+		ProfilesSize:       humanize.Bytes(profilesSize),
+		IndexSize:          humanize.Bytes(indexSize),
+		SymbolsSize:        humanize.Bytes(symbolsSize),
+		ProfilesPercentage: profilesPercentage,
+		IndexPercentage:    indexPercentage,
+		SymbolsPercentage:  symbolsPercentage,
+		LabelSets:          labelSets,
 	}
 }
 

--- a/pkg/operations/v2/profile_handlers.go
+++ b/pkg/operations/v2/profile_handlers.go
@@ -1,0 +1,548 @@
+package v2
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/parquet-go/parquet-go"
+	"github.com/pkg/errors"
+
+	googlev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/pkg/block"
+	"github.com/grafana/pyroscope/pkg/frontend/dot/measurement"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+	schemav1 "github.com/grafana/pyroscope/pkg/phlaredb/schemas/v1"
+	"github.com/grafana/pyroscope/pkg/phlaredb/symdb"
+	"github.com/grafana/pyroscope/pkg/pprof"
+	httputil "github.com/grafana/pyroscope/pkg/util/http"
+)
+
+func (h *Handlers) CreateDatasetProfilesHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := parseDatasetRequest(r)
+		if err != nil {
+			httputil.Error(w, err)
+			return
+		}
+
+		page := 1
+		if pageStr := r.URL.Query().Get("page"); pageStr != "" {
+			if _, err := fmt.Sscanf(pageStr, "%d", &page); err != nil || page < 1 {
+				page = 1
+			}
+		}
+
+		pageSize := 100
+		if pageSizeStr := r.URL.Query().Get("page_size"); pageSizeStr != "" {
+			if _, err := fmt.Sscanf(pageSizeStr, "%d", &pageSize); err != nil || pageSize < 1 || pageSize > 500 {
+				pageSize = 100
+			}
+		}
+
+		blockMeta, foundDataset, err := h.getDatasetMetadata(r.Context(), req)
+		if err != nil {
+			httputil.Error(w, err)
+			return
+		}
+
+		dataset := h.convertDataset(foundDataset, blockMeta.StringTable)
+
+		profiles, totalCount, err := h.readProfilesFromDataset(r.Context(), blockMeta, foundDataset, page, pageSize)
+		if err != nil {
+			httputil.Error(w, errors.Wrap(err, "failed to read profiles from dataset"))
+			return
+		}
+
+		totalPages := (totalCount + pageSize - 1) / pageSize
+		if totalPages == 0 {
+			totalPages = 1
+		}
+
+		err = pageTemplates.datasetProfilesTemplate.Execute(w, datasetProfilesPageContent{
+			User:        req.TenantID,
+			BlockID:     req.BlockID,
+			Shard:       req.Shard,
+			BlockTenant: req.BlockTenant,
+			Dataset:     &dataset,
+			Profiles:    profiles,
+			TotalCount:  totalCount,
+			Page:        page,
+			PageSize:    pageSize,
+			TotalPages:  totalPages,
+			HasPrevPage: page > 1,
+			HasNextPage: page < totalPages,
+			Now:         time.Now().UTC().Format(time.RFC3339),
+		})
+		if err != nil {
+			httputil.Error(w, err)
+			return
+		}
+	}
+}
+
+func (h *Handlers) readProfilesFromDataset(ctx context.Context, blockMeta *metastorev1.BlockMeta, dataset *metastorev1.Dataset, page, pageSize int) ([]profileInfo, int, error) {
+	obj := block.NewObject(h.Bucket, blockMeta)
+	if err := obj.Open(ctx); err != nil {
+		return nil, 0, fmt.Errorf("failed to open block object: %w", err)
+	}
+	defer obj.Close()
+
+	ds := block.NewDataset(dataset, obj)
+	if err := ds.Open(ctx, block.SectionProfiles, block.SectionTSDB); err != nil {
+		return nil, 0, fmt.Errorf("failed to open dataset: %w", err)
+	}
+	defer ds.Close()
+
+	it, err := block.NewProfileRowIterator(ds)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to create profile iterator: %w", err)
+	}
+	defer it.Close()
+
+	var profiles []profileInfo
+	rowNumber := 0
+	totalCount := 0
+	startRow := (page - 1) * pageSize
+	endRow := startRow + pageSize
+
+	for it.Next() {
+		if rowNumber >= startRow && rowNumber < endRow {
+			entry := it.At()
+
+			profileType := entry.Labels.Get(phlaremodel.LabelNameProfileType)
+
+			var sampleCount int
+			entry.Row.ForStacktraceIdsAndValues(func(sids []parquet.Value, vals []parquet.Value) {
+				sampleCount = len(sids)
+			})
+
+			profiles = append(profiles, profileInfo{
+				RowNumber:   rowNumber,
+				Timestamp:   time.Unix(0, entry.Timestamp).UTC().Format(time.RFC3339),
+				SeriesIndex: entry.Row.SeriesIndex(),
+				ProfileType: profileType,
+				SampleCount: sampleCount,
+			})
+		}
+		rowNumber++
+		totalCount++
+	}
+
+	if err := it.Err(); err != nil {
+		return nil, 0, fmt.Errorf("error iterating profiles: %w", err)
+	}
+
+	return profiles, totalCount, nil
+}
+
+func (h *Handlers) CreateDatasetProfileDownloadHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := parseDatasetRequest(r)
+		if err != nil {
+			httputil.Error(w, err)
+			return
+		}
+
+		rowStr := r.URL.Query().Get("row")
+		if rowStr == "" {
+			httputil.Error(w, errors.New("No row number provided"))
+			return
+		}
+		var rowNum int64
+		if _, err := fmt.Sscanf(rowStr, "%d", &rowNum); err != nil {
+			httputil.Error(w, errors.Wrap(err, "invalid row parameter"))
+			return
+		}
+
+		blockMeta, foundDataset, err := h.getDatasetMetadata(r.Context(), req)
+		if err != nil {
+			httputil.Error(w, err)
+			return
+		}
+
+		_, _, profileMeta, err := h.buildProfileResolver(r.Context(), blockMeta, foundDataset, rowNum)
+		if err != nil {
+			httputil.Error(w, errors.Wrap(err, "failed to get profile metadata"))
+			return
+		}
+
+		profile, err := h.retrieveProfile(r.Context(), blockMeta, foundDataset, rowNum)
+		if err != nil {
+			httputil.Error(w, errors.Wrap(err, "failed to download profile"))
+			return
+		}
+
+		sanitizedDataset := strings.ReplaceAll(req.DatasetName, "/", "_")
+		sanitizedProfileType := strings.ReplaceAll(profileMeta.ProfileType, ":", "_")
+		sanitizedProfileType = strings.ReplaceAll(sanitizedProfileType, "/", "_")
+
+		timestampStr := time.Unix(0, profile.TimeNanos).UTC().Format("20060102-150405")
+		filename := fmt.Sprintf("%s-%s-%s.pb.gz", sanitizedDataset, sanitizedProfileType, timestampStr)
+		h.writeProfile(w, profile, filename)
+	}
+}
+
+func (h *Handlers) retrieveProfile(
+	ctx context.Context,
+	blockMeta *metastorev1.BlockMeta,
+	dataset *metastorev1.Dataset,
+	rowNum int64,
+) (*googlev1.Profile, error) {
+	resolver, timestamp, meta, err := h.buildProfileResolver(ctx, blockMeta, dataset, rowNum)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build profile resolver: %w", err)
+	}
+	defer resolver.Release()
+
+	profile, err := resolver.Pprof()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build pprof profile: %w", err)
+	}
+
+	if t, err := phlaremodel.ParseProfileTypeSelector(meta.ProfileType); err == nil {
+		pprof.SetProfileMetadata(profile, t, timestamp, 0)
+	}
+
+	return profile, nil
+}
+
+func (h *Handlers) writeProfile(w http.ResponseWriter, profile *googlev1.Profile, filename string) {
+	data, err := profile.MarshalVT()
+	if err != nil {
+		httputil.Error(w, errors.Wrap(err, "failed to marshal profile"))
+		return
+	}
+
+	var buf bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buf)
+	if _, err := gzipWriter.Write(data); err != nil {
+		httputil.Error(w, errors.Wrap(err, "failed to compress profile"))
+		return
+	}
+	if err := gzipWriter.Close(); err != nil {
+		httputil.Error(w, errors.Wrap(err, "failed to close gzip writer"))
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/gzip")
+	w.Header().Set("Content-Encoding", "gzip")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		httputil.Error(w, errors.Wrap(err, "failed to write profile"))
+		return
+	}
+}
+
+func (h *Handlers) CreateDatasetProfileCallTreeHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := parseDatasetRequest(r)
+		if err != nil {
+			httputil.Error(w, err)
+			return
+		}
+
+		rowStr := r.URL.Query().Get("row")
+		if rowStr == "" {
+			httputil.Error(w, errors.New("No row number provided"))
+			return
+		}
+		var rowNum int64
+		if _, err := fmt.Sscanf(rowStr, "%d", &rowNum); err != nil {
+			httputil.Error(w, errors.Wrap(err, "invalid row parameter"))
+			return
+		}
+
+		blockMeta, foundDataset, err := h.getDatasetMetadata(r.Context(), req)
+		if err != nil {
+			httputil.Error(w, err)
+			return
+		}
+
+		dataset := h.convertDataset(foundDataset, blockMeta.StringTable)
+
+		tree, timestamp, profileMeta, err := h.buildProfileTree(r.Context(), blockMeta, foundDataset, rowNum)
+		if err != nil {
+			httputil.Error(w, errors.Wrap(err, "failed to build profile tree"))
+			return
+		}
+
+		err = pageTemplates.profileCallTreeTemplate.Execute(w, profileCallTreePageContent{
+			User:        req.TenantID,
+			BlockID:     req.BlockID,
+			Shard:       req.Shard,
+			BlockTenant: req.BlockTenant,
+			Dataset:     &dataset,
+			Timestamp:   time.Unix(0, timestamp).UTC().Format(time.RFC3339),
+			ProfileInfo: profileMeta,
+			Tree:        tree,
+			Now:         time.Now().UTC().Format(time.RFC3339),
+		})
+		if err != nil {
+			httputil.Error(w, err)
+			return
+		}
+	}
+}
+
+func (h *Handlers) buildProfileTree(
+	ctx context.Context,
+	blockMeta *metastorev1.BlockMeta,
+	dataset *metastorev1.Dataset,
+	rowNum int64,
+) (*treeNode, int64, *profileMetadata, error) {
+	resolver, timestamp, profileMeta, err := h.buildProfileResolver(ctx, blockMeta, dataset, rowNum)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("failed to build profile resolver: %w", err)
+	}
+	defer resolver.Release()
+
+	profile, err := resolver.Pprof()
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("failed to build pprof profile: %w", err)
+	}
+
+	tree := buildTreeFromPprof(profile, profileMeta.Unit)
+
+	return tree, timestamp, profileMeta, nil
+}
+
+func (h *Handlers) buildProfileResolver(
+	ctx context.Context,
+	blockMeta *metastorev1.BlockMeta,
+	dataset *metastorev1.Dataset,
+	rowNum int64,
+) (*symdb.Resolver, int64, *profileMetadata, error) {
+	obj := block.NewObject(h.Bucket, blockMeta)
+	if err := obj.Open(ctx); err != nil {
+		return nil, 0, nil, fmt.Errorf("failed to open block object: %w", err)
+	}
+	defer obj.Close()
+
+	ds := block.NewDataset(dataset, obj)
+	if err := ds.Open(ctx, block.SectionProfiles, block.SectionTSDB, block.SectionSymbols); err != nil {
+		return nil, 0, nil, fmt.Errorf("failed to open dataset: %w", err)
+	}
+	defer ds.Close()
+
+	it, err := block.NewProfileRowIterator(ds)
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("failed to create profile iterator: %w", err)
+	}
+	defer it.Close()
+
+	var currentRow int64
+	var targetEntry block.ProfileEntry
+	found := false
+
+	for it.Next() {
+		if currentRow == rowNum {
+			targetEntry = it.At()
+			found = true
+			break
+		}
+		currentRow++
+	}
+
+	if err := it.Err(); err != nil {
+		return nil, 0, nil, fmt.Errorf("error iterating profiles: %w", err)
+	}
+
+	if !found {
+		return nil, 0, nil, fmt.Errorf("profile row %d not found", rowNum)
+	}
+
+	var labelPairs []labelPair
+	for _, label := range targetEntry.Labels {
+		labelPairs = append(labelPairs, labelPair{
+			Key:   label.Name,
+			Value: label.Value,
+		})
+	}
+
+	var sampleCount int
+	targetEntry.Row.ForStacktraceIdsAndValues(func(sids []parquet.Value, vals []parquet.Value) {
+		sampleCount = len(sids)
+	})
+
+	profileMeta := &profileMetadata{
+		Labels:      labelPairs,
+		SampleCount: sampleCount,
+		Unit:        targetEntry.Labels.Get(phlaremodel.LabelNameUnit),
+		ProfileType: targetEntry.Labels.Get(phlaremodel.LabelNameProfileType),
+	}
+
+	resolver := symdb.NewResolver(ctx, ds.Symbols())
+
+	partitionID := targetEntry.Row.StacktracePartitionID()
+	var stacktraceIDs []uint32
+	var values []uint64
+
+	targetEntry.Row.ForStacktraceIdsAndValues(func(sids []parquet.Value, vals []parquet.Value) {
+		stacktraceIDs = make([]uint32, len(sids))
+		values = make([]uint64, len(vals))
+		for i, sid := range sids {
+			stacktraceIDs[i] = sid.Uint32()
+		}
+		for i, val := range vals {
+			values[i] = uint64(val.Int64())
+		}
+	})
+
+	samples := schemav1.Samples{
+		StacktraceIDs: stacktraceIDs,
+		Values:        values,
+	}
+	resolver.AddSamples(partitionID, samples)
+
+	return resolver, targetEntry.Timestamp, profileMeta, nil
+}
+
+// formatValue formats a value according to the pprof unit specification
+func formatValue(value uint64, unit string) string {
+	scaledValue, scaledUnit := measurement.Scale(int64(value), unit, "auto")
+	formattedValue := strings.TrimSuffix(fmt.Sprintf("%.2f", scaledValue), ".00")
+	if scaledUnit == "" {
+		return formattedValue
+	}
+	return fmt.Sprintf("%s %s", formattedValue, scaledUnit)
+}
+
+func buildTreeFromPprof(profile *googlev1.Profile, unit string) *treeNode {
+	if profile == nil || len(profile.Sample) == 0 {
+		return nil
+	}
+
+	var grandTotal uint64
+	for _, sample := range profile.Sample {
+		if len(sample.Value) > 0 {
+			grandTotal += uint64(sample.Value[0])
+		}
+	}
+
+	if grandTotal == 0 {
+		return nil
+	}
+
+	functionMap := make(map[uint64]*googlev1.Function)
+	for _, fn := range profile.Function {
+		functionMap[fn.Id] = fn
+	}
+
+	locationMap := make(map[uint64]*googlev1.Location)
+	for _, loc := range profile.Location {
+		locationMap[loc.Id] = loc
+	}
+
+	root := &treeNode{
+		Name:           "root",
+		Value:          grandTotal,
+		Percent:        100.0,
+		Location:       "",
+		FormattedValue: formatValue(grandTotal, unit),
+		Children:       make([]*treeNode, 0),
+	}
+
+	nodeMap := make(map[string]*treeNode)
+	nodeMap[""] = root
+
+	for _, sample := range profile.Sample {
+		if len(sample.Value) == 0 || len(sample.LocationId) == 0 {
+			continue
+		}
+
+		value := uint64(sample.Value[0])
+		currentPath := ""
+		currentNode := root
+
+		for i := len(sample.LocationId) - 1; i >= 0; i-- {
+			locID := sample.LocationId[i]
+			location := locationMap[locID]
+			if location == nil {
+				continue
+			}
+
+			if len(location.Line) == 0 {
+				continue
+			}
+
+			line := location.Line[0]
+			function := functionMap[line.FunctionId]
+			if function == nil {
+				continue
+			}
+
+			funcName := profile.StringTable[function.Name]
+			fileName := profile.StringTable[function.Filename]
+			lineNum := line.Line
+
+			var locationStr string
+			if fileName != "" && lineNum > 0 {
+				filePath := fileName
+				if pkgIdx := strings.Index(filePath, "/pkg/"); pkgIdx != -1 {
+					filePath = filePath[pkgIdx+1:]
+				} else if srcIdx := strings.Index(filePath, "/src/"); srcIdx != -1 {
+					filePath = filePath[srcIdx+5:]
+				} else if pathIdx := strings.LastIndex(filePath, "/"); pathIdx != -1 {
+					filePath = filePath[pathIdx+1:]
+				}
+				locationStr = fmt.Sprintf("%s:L%d", filePath, lineNum)
+			}
+
+			parentPath := currentPath
+			currentPath = fmt.Sprintf("%s/%s@%d", parentPath, funcName, line.FunctionId)
+
+			node, exists := nodeMap[currentPath]
+			if !exists {
+				node = &treeNode{
+					Name:           funcName,
+					Percent:        0,
+					Location:       locationStr,
+					FormattedValue: formatValue(0, unit),
+					Children:       make([]*treeNode, 0),
+				}
+				nodeMap[currentPath] = node
+				currentNode.Children = append(currentNode.Children, node)
+			}
+
+			node.Value += value
+
+			currentNode = node
+		}
+	}
+
+	sortAndCalculatePercents(root, float64(grandTotal), unit)
+
+	return root
+}
+
+func sortAndCalculatePercents(node *treeNode, grandTotal float64, unit string) {
+	if grandTotal > 0 {
+		node.Percent = (float64(node.Value) / grandTotal) * 100.0
+	}
+
+	node.FormattedValue = formatValue(node.Value, unit)
+
+	if len(node.Children) > 0 {
+		slices.SortFunc(node.Children, func(a, b *treeNode) int {
+			if a.Value > b.Value {
+				return -1
+			}
+			if a.Value < b.Value {
+				return 1
+			}
+			return 0
+		})
+
+		for _, child := range node.Children {
+			sortAndCalculatePercents(child, grandTotal, unit)
+		}
+	}
+}

--- a/pkg/operations/v2/tool.blocks.dataset.gohtml
+++ b/pkg/operations/v2/tool.blocks.dataset.gohtml
@@ -55,20 +55,52 @@
                     <td>{{ .Dataset.MaxTime }}</td>
                 </tr>
                 <tr>
-                    <td>Size</td>
+                    <td>Total Size</td>
                     <td>{{ .Dataset.Size }}</td>
                 </tr>
                 <tr>
-                    <td>Profiles Size</td>
-                    <td>{{ .Dataset.ProfilesSize }}</td>
-                </tr>
-                <tr>
-                    <td>Index Size</td>
-                    <td>{{ .Dataset.IndexSize }}</td>
-                </tr>
-                <tr>
-                    <td>Symbols Size</td>
-                    <td>{{ .Dataset.SymbolsSize }}</td>
+                    <td colspan="2">
+                        <div class="mb-2"><strong>Size Distribution</strong></div>
+                        <div class="d-flex align-items-center mb-2" style="height: 40px;">
+                            <div class="d-flex w-100" style="height: 100%; border-radius: 4px; overflow: hidden;">
+                                <div class="d-flex align-items-center justify-content-center text-white fw-bold"
+                                     style="background-color: #0d6efd; width: {{ .Dataset.ProfilesPercentage }}%; min-width: 0;"
+                                     title="Profiles: {{ .Dataset.ProfilesSize }}">
+                                    {{ if ge .Dataset.ProfilesPercentage 10.0 }}
+                                        <span class="small">{{ printf "%.1f" .Dataset.ProfilesPercentage }}%</span>
+                                    {{ end }}
+                                </div>
+                                <div class="d-flex align-items-center justify-content-center text-white fw-bold"
+                                     style="background-color: #198754; width: {{ .Dataset.IndexPercentage }}%; min-width: 0;"
+                                     title="Index: {{ .Dataset.IndexSize }}">
+                                    {{ if ge .Dataset.IndexPercentage 10.0 }}
+                                        <span class="small">{{ printf "%.1f" .Dataset.IndexPercentage }}%</span>
+                                    {{ end }}
+                                </div>
+                                <div class="d-flex align-items-center justify-content-center text-white fw-bold"
+                                     style="background-color: #ffc107; width: {{ .Dataset.SymbolsPercentage }}%; min-width: 0;"
+                                     title="Symbols: {{ .Dataset.SymbolsSize }}">
+                                    {{ if ge .Dataset.SymbolsPercentage 10.0 }}
+                                        <span class="small text-dark">{{ printf "%.1f" .Dataset.SymbolsPercentage }}%</span>
+                                    {{ end }}
+                                </div>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-wrap gap-3 small">
+                            <div>
+                                <span class="d-inline-block" style="width: 16px; height: 16px; background-color: #0d6efd; border-radius: 2px; vertical-align: middle;"></span>
+                                <span class="ms-1">Profiles: {{ .Dataset.ProfilesSize }} ({{ printf "%.1f" .Dataset.ProfilesPercentage }}%)</span>
+                            </div>
+                            <div>
+                                <span class="d-inline-block" style="width: 16px; height: 16px; background-color: #198754; border-radius: 2px; vertical-align: middle;"></span>
+                                <span class="ms-1">Index: {{ .Dataset.IndexSize }} ({{ printf "%.1f" .Dataset.IndexPercentage }}%)</span>
+                            </div>
+                            <div>
+                                <span class="d-inline-block" style="width: 16px; height: 16px; background-color: #ffc107; border-radius: 2px; vertical-align: middle;"></span>
+                                <span class="ms-1">Symbols: {{ .Dataset.SymbolsSize }} ({{ printf "%.1f" .Dataset.SymbolsPercentage }}%)</span>
+                            </div>
+                        </div>
+                    </td>
                 </tr>
                 <tr>
                     <td>Labels</td>
@@ -90,6 +122,24 @@
                     </td>
                 </tr>
             </table>
+
+            <h4 class="mt-4 mb-3">Dataset Explorer</h4>
+            <div class="row">
+                <div class="col-md-4 mb-3">
+                    <div class="card bg-dark border-secondary h-100">
+                        <div class="card-body d-flex flex-column">
+                            <h5 class="card-title">
+                                <i class="bi bi-file-earmark-text"></i> Profiles
+                            </h5>
+                            <p class="card-text">View and download individual profiles from this dataset.</p>
+                            <a href="/ops/object-store/tenants/{{ .User }}/blocks/{{ .BlockID }}/datasets/profiles?dataset={{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ .Shard }}&block_tenant={{ .BlockTenant }}"
+                               class="btn btn-primary mt-auto">
+                                View Profiles
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </main>

--- a/pkg/operations/v2/tool.blocks.dataset.profiles.gohtml
+++ b/pkg/operations/v2/tool.blocks.dataset.profiles.gohtml
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html class="h-100" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Bucket Blocks Explorer (v2): Dataset Profiles - {{ .Dataset.Name }}</title>
+
+    <link rel="stylesheet" href="/static/bootstrap-5.3.3.min.css">
+    <link rel="stylesheet" href="/static/bootstrap-icons-1.8.1.css">
+    <link rel="stylesheet" href="/static/pyroscope-styles.css">
+    <script src="/static/bootstrap-5.3.3.bundle.min.js"></script>
+</head>
+<body class="d-flex flex-column h-100">
+<main class="flex-shrink-0">
+    <div class="container">
+        <div class="header row border-bottom py-3 flex-column-reverse flex-sm-row">
+            <div class="col-12 col-sm-9 text-center text-sm-start">
+                <h3>Bucket Blocks Explorer (v2): Dataset Profiles</h3>
+            </div>
+            <div class="col-12 col-sm-3 text-center text-sm-end mb-3 mb-sm-0">
+                <a href="/ops/object-store/tenants">
+                    <img alt="Pyroscope logo" class="pyroscope-brand" src="/static/pyroscope-logo.png">
+                </a>
+            </div>
+        </div>
+        <div class="row my-3">
+            <p>
+                <a href="/ops/object-store/tenants/{{ .User }}/blocks/{{ .BlockID }}/datasets?dataset={{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ .Shard }}&block_tenant={{ .BlockTenant }}">Back to dataset</a>
+            </p>
+
+            <div class="card bg-dark border-secondary info-card mb-3">
+                <div class="card-header">
+                    <h5 class="mb-0">Dataset Information</h5>
+                </div>
+                <div class="card-body">
+                    <ul>
+                        <li>Dataset Name: {{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}<em>(empty)</em>{{ end }}</li>
+                        <li>Dataset Tenant: {{ .Dataset.Tenant }}</li>
+                        <li>Block ID: {{ .BlockID }}</li>
+                        <li>Shard: {{ .Shard }}</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="d-flex justify-content-between align-items-center mt-3 mb-3">
+                <h5 class="mb-0">Profiles</h5>
+                <div class="text-muted">
+                    Total: <strong>{{ .TotalCount }}</strong> profiles
+                    {{ if gt .TotalCount 0 }}
+                        | Showing {{ add (mul (add .Page -1) .PageSize) 1 }}-{{ if lt (mul .Page .PageSize) .TotalCount }}{{ mul .Page .PageSize }}{{ else }}{{ .TotalCount }}{{ end }}
+                    {{ end }}
+                </div>
+            </div>
+
+            {{ if .Profiles }}
+                {{ if gt .TotalPages 1 }}
+                <div class="mb-3">
+                    {{ $datasetName := "_empty" }}
+                    {{ if .Dataset.Name }}{{ $datasetName = .Dataset.Name }}{{ end }}
+                    {{ template "pagination" dict "BaseURL" (printf "?dataset=%s&shard=%d&block_tenant=%s" $datasetName .Shard .BlockTenant) "Page" .Page "PageSize" .PageSize "TotalPages" .TotalPages "HasPrevPage" .HasPrevPage "HasNextPage" .HasNextPage }}
+                </div>
+                {{ end }}
+
+                <div class="table-responsive">
+                    <table class="table table-striped table-sm table-dark">
+                        <thead>
+                            <tr>
+                                <th>Timestamp</th>
+                                <th>Series Index</th>
+                                <th>Profile Type</th>
+                                <th>Samples</th>
+                                <th>Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {{ range .Profiles }}
+                            <tr>
+                                <td><code class="small">{{ .Timestamp }}</code></td>
+                                <td><code>{{ .SeriesIndex }}</code></td>
+                                <td>{{ if .ProfileType }}<code class="small">{{ .ProfileType }}</code>{{ else }}<span class="text-muted">-</span>{{ end }}</td>
+                                <td>{{ .SampleCount }}</td>
+                                <td>
+                                    <a href="/ops/object-store/tenants/{{ $.User }}/blocks/{{ $.BlockID }}/datasets/profiles/call-tree?dataset={{ if $.Dataset.Name }}{{ $.Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ $.Shard }}&block_tenant={{ $.BlockTenant }}&row={{ .RowNumber }}"
+                                       class="btn btn-sm btn-success me-1">
+                                        <i class="bi bi-eye"></i> Call Tree
+                                    </a>
+                                    <a href="/ops/object-store/tenants/{{ $.User }}/blocks/{{ $.BlockID }}/datasets/profiles/download?dataset={{ if $.Dataset.Name }}{{ $.Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ $.Shard }}&block_tenant={{ $.BlockTenant }}&row={{ .RowNumber }}"
+                                       class="btn btn-sm btn-primary"
+                                       download>
+                                        <i class="bi bi-download"></i> Download
+                                    </a>
+                                </td>
+                            </tr>
+                            {{ end }}
+                        </tbody>
+                    </table>
+                </div>
+
+                {{ if gt .TotalPages 1 }}
+                    {{ $datasetName := "_empty" }}
+                    {{ if .Dataset.Name }}{{ $datasetName = .Dataset.Name }}{{ end }}
+                    {{ template "pagination" dict "BaseURL" (printf "?dataset=%s&shard=%d&block_tenant=%s" $datasetName .Shard .BlockTenant) "Page" .Page "PageSize" .PageSize "TotalPages" .TotalPages "HasPrevPage" .HasPrevPage "HasNextPage" .HasNextPage }}
+                {{ end }}
+            {{ else }}
+                <div class="alert alert-warning" role="alert">
+                    No profiles found in this dataset.
+                </div>
+            {{ end }}
+        </div>
+    </div>
+</main>
+<footer class="footer mt-auto py-3 bg-dark">
+    <div class="container">
+        <small class="text-white-50">Status @ {{ .Now }}</small>
+    </div>
+</footer>
+</body>
+</html>

--- a/pkg/operations/v2/tool.blocks.profile.call.tree.gohtml
+++ b/pkg/operations/v2/tool.blocks.profile.call.tree.gohtml
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html class="h-100" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Bucket Blocks Explorer (v2): Profile Call Tree</title>
+
+    <link rel="stylesheet" href="/static/bootstrap-5.3.3.min.css">
+    <link rel="stylesheet" href="/static/bootstrap-icons-1.8.1.css">
+    <link rel="stylesheet" href="/static/pyroscope-styles.css">
+    <script src="/static/bootstrap-5.3.3.bundle.min.js"></script>
+
+    <style>
+        .tree-view {
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 14px;
+            line-height: 1.5;
+        }
+        .tree-node {
+            margin: 0 !important;
+            list-style-type: none;
+            padding: 0 !important;
+        }
+        .tree-node > li {
+            margin: 0 !important;
+            padding: 0 !important;
+            line-height: 1.5 !important;
+        }
+        .tree-toggle {
+            cursor: pointer;
+            user-select: none;
+            color: #6c757d;
+            margin-right: 5px;
+            font-family: monospace;
+            display: inline-block;
+            width: 35px;
+            text-align: left;
+            white-space: nowrap;
+        }
+        .tree-toggle:hover {
+            color: #adb5bd;
+        }
+        .tree-content {
+            display: flex;
+            align-items: baseline;
+            gap: 0;
+            margin: 0;
+            padding: 0;
+            width: 100%;
+        }
+        .tree-name-section {
+            width: 50%;
+            min-width: 0;
+            margin: 0;
+            padding: 0;
+        }
+        .tree-name-section.clickable {
+            cursor: pointer;
+        }
+        .tree-name {
+            color: #0dcaf0;
+            font-weight: 500;
+        }
+        .tree-value {
+            color: #ffc107;
+            text-align: right;
+            white-space: nowrap;
+            width: 5%;
+            flex-shrink: 0;
+            margin: 0;
+            padding: 0;
+        }
+        .tree-percent {
+            color: #6c757d;
+            text-align: right;
+            white-space: nowrap;
+            width: 5%;
+            flex-shrink: 0;
+            margin: 0 0 0 10px;
+            padding: 0;
+        }
+        .tree-extra {
+            width: 40%;
+            flex-shrink: 0;
+            margin: 0 0 0 15px;
+            padding: 0;
+            font-size: 12px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        .tree-children {
+            margin-left: 0 !important;
+            padding: 0 !important;
+        }
+        .tree-children .tree-name-section {
+            padding-left: 20px;
+        }
+        .tree-children .tree-children .tree-name-section {
+            padding-left: 40px;
+        }
+        .tree-children .tree-children .tree-children .tree-name-section {
+            padding-left: 60px;
+        }
+        .tree-children .tree-children .tree-children .tree-children .tree-name-section {
+            padding-left: 80px;
+        }
+        .tree-children .tree-children .tree-children .tree-children .tree-children .tree-name-section {
+            padding-left: 100px;
+        }
+        .tree-children .tree-children .tree-children .tree-children .tree-children .tree-children .tree-name-section {
+            padding-left: 120px;
+        }
+    </style>
+</head>
+<body class="d-flex flex-column h-100">
+<main class="flex-shrink-0">
+    <div class="container-fluid">
+        <div class="header row border-bottom py-3 flex-column-reverse flex-sm-row">
+            <div class="col-12 col-sm-9 text-center text-sm-start">
+                <h3>Bucket Blocks Explorer (v2): Profile Call Tree</h3>
+            </div>
+            <div class="col-12 col-sm-3 text-center text-sm-end mb-3 mb-sm-0">
+                <a href="/ops/object-store/tenants">
+                    <img alt="Pyroscope logo" class="pyroscope-brand" src="/static/pyroscope-logo.png">
+                </a>
+            </div>
+        </div>
+        <div class="row my-3">
+            <p>
+                <a href="/ops/object-store/tenants/{{ .User }}/blocks/{{ .BlockID }}/datasets/profiles?dataset={{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ .Shard }}&block_tenant={{ .BlockTenant }}">Back to profiles</a>
+            </p>
+
+            <div class="row mb-3">
+                <div class="col-md-6">
+                    <div class="card bg-dark border-secondary info-card h-100">
+                        <div class="card-header">
+                            <h5 class="mb-0">Dataset Information</h5>
+                        </div>
+                        <div class="card-body">
+                            <ul>
+                                <li>Dataset Name: {{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}<em>(empty)</em>{{ end }}</li>
+                                <li>Dataset Tenant: {{ .Dataset.Tenant }}</li>
+                                <li>Block ID: {{ .BlockID }}</li>
+                                <li>Shard: {{ .Shard }}</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
+                {{ if .ProfileInfo }}
+                <div class="col-md-6">
+                    <div class="card bg-dark border-secondary info-card h-100">
+                        <div class="card-header">
+                            <h5 class="mb-0">Profile Information</h5>
+                        </div>
+                        <div class="card-body py-2">
+                            <div class="row mb-2">
+                                <div class="col-12">
+                                    <strong class="text-muted">Profile Type:</strong>
+                                    <span class="ms-2">
+                                        <code class="text-primary fs-6">{{ .ProfileInfo.ProfileType }}</code>
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="row mb-2">
+                                <div class="col-12">
+                                    <strong class="text-muted">Timestamp:</strong>
+                                    <span class="ms-2">
+                                        {{ .Timestamp }}
+                                    </span>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-12">
+                                    <strong class="text-muted">Labels:</strong>
+                                    <span class="ms-2">
+                                        {{ range $index, $label := .ProfileInfo.Labels }}{{ if $index }}, {{ end }}<code class="text-info">{{ $label.Key }}</code>=<code class="text-warning">{{ $label.Value }}</code>{{ end }}
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                {{ end }}
+            </div>
+
+            <div class="card bg-dark border-secondary">
+                <div class="card-header">
+                    <h5 class="mb-0">Call Tree</h5>
+                    <small class="text-muted">Click [+]/[-] to expand/collapse nodes.</small>
+                </div>
+                <div class="card-body">
+                    {{ if .Tree }}
+                        <div class="tree-view">
+                            <ul class="tree-node">
+                                {{ template "tree-node" dict "Node" .Tree "Level" 0 }}
+                            </ul>
+                        </div>
+                    {{ else }}
+                        <div class="alert alert-warning" role="alert">
+                            No call tree available for this profile.
+                        </div>
+                    {{ end }}
+                </div>
+            </div>
+        </div>
+    </div>
+</main>
+<footer class="footer mt-auto py-3 bg-dark">
+    <div class="container">
+        <small class="text-white-50">Status @ {{ .Now }}</small>
+    </div>
+</footer>
+
+<script>
+    function toggleNode(element) {
+        // We need to find the tree-children div which is a sibling of the parent tree-content div
+        const treeContent = element.parentElement;
+        const listItem = treeContent.parentElement;
+        const childrenContainer = listItem.querySelector('.tree-children');
+        const toggle = element.querySelector('.tree-toggle');
+
+        if (childrenContainer) {
+            if (childrenContainer.style.display === 'none') {
+                childrenContainer.style.display = 'block';
+                toggle.textContent = '[-]';
+            } else {
+                childrenContainer.style.display = 'none';
+                toggle.textContent = '[+]';
+            }
+        }
+    }
+</script>
+</body>
+</html>
+
+{{ define "tree-node" }}
+    {{ $node := .Node }}
+    {{ $level := .Level }}
+    <li>
+        {{ if gt (len $node.Children) 0 }}
+            <div class="tree-content">
+                <div class="tree-name-section clickable" onclick="toggleNode(this)">
+                    <span class="tree-toggle">{{ if eq $level 0 }}[-]{{ else }}[+]{{ end }}</span>
+                    <span class="tree-name">{{ $node.Name }}</span>
+                </div>
+                <div class="tree-value">{{ $node.FormattedValue }}</div>
+                <div class="tree-percent">{{ printf "%.2f" $node.Percent }}%</div>
+                <div class="tree-extra">{{ if $node.Location }}<span class="text-muted">{{ $node.Location }}</span>{{ end }}</div>
+            </div>
+            <ul class="tree-node tree-children" style="display: {{ if eq $level 0 }}block{{ else }}none{{ end }};">
+                {{ range $node.Children }}
+                    {{ template "tree-node" dict "Node" . "Level" (add $level 1) }}
+                {{ end }}
+            </ul>
+        {{ else }}
+            <div class="tree-content">
+                <div class="tree-name-section">
+                    <span class="tree-toggle"></span>
+                    <span class="tree-name">{{ $node.Name }}</span>
+                </div>
+                <div class="tree-value">{{ $node.FormattedValue }}</div>
+                <div class="tree-percent">{{ printf "%.2f" $node.Percent }}%</div>
+                <div class="tree-extra">{{ if $node.Location }}<span class="text-muted">{{ $node.Location }}</span>{{ end }}</div>
+            </div>
+        {{ end }}
+    </li>
+{{ end }}

--- a/pkg/operations/v2/tool.pagination.gohtml
+++ b/pkg/operations/v2/tool.pagination.gohtml
@@ -1,0 +1,55 @@
+{{/*
+    Required parameters (pass via dict):
+    - BaseURL: string - the base URL without query params (e.g., "?dataset=foo&shard=1")
+    - Page: int - current page number
+    - PageSize: int - items per page
+    - TotalPages: int - total number of pages
+    - HasPrevPage: bool - whether there's a previous page
+    - HasNextPage: bool - whether there's a next page
+*/}}
+
+{{ define "pagination" }}
+    {{ $baseURL := .BaseURL }}
+    {{ $currentPage := .Page }}
+    {{ $pageSize := .PageSize }}
+    {{ $totalPages := .TotalPages }}
+    {{ $hasPrev := .HasPrevPage }}
+    {{ $hasNext := .HasNextPage }}
+
+    <nav aria-label="Pagination">
+        <ul class="pagination justify-content-center">
+            <li class="page-item {{ if not $hasPrev }}disabled{{ end }}">
+                <a class="page-link" href="{{ $baseURL }}&page=1&page_size={{ $pageSize }}">First</a>
+            </li>
+            <li class="page-item {{ if not $hasPrev }}disabled{{ end }}">
+                <a class="page-link" href="{{ $baseURL }}&page={{ add $currentPage -1 }}&page_size={{ $pageSize }}">Previous</a>
+            </li>
+
+            {{ $startPage := add $currentPage -2 }}
+            {{ if lt $startPage 1 }}{{ $startPage = 1 }}{{ end }}
+            {{ $endPage := add $currentPage 2 }}
+            {{ if gt $endPage $totalPages }}{{ $endPage = $totalPages }}{{ end }}
+
+            {{ if gt $startPage 1 }}
+                <li class="page-item disabled"><span class="page-link">...</span></li>
+            {{ end }}
+
+            {{ range $page := seq $startPage $endPage }}
+                <li class="page-item {{ if eq $page $currentPage }}active{{ end }}">
+                    <a class="page-link" href="{{ $baseURL }}&page={{ $page }}&page_size={{ $pageSize }}">{{ $page }}</a>
+                </li>
+            {{ end }}
+
+            {{ if lt $endPage $totalPages }}
+                <li class="page-item disabled"><span class="page-link">...</span></li>
+            {{ end }}
+
+            <li class="page-item {{ if not $hasNext }}disabled{{ end }}">
+                <a class="page-link" href="{{ $baseURL }}&page={{ add $currentPage 1 }}&page_size={{ $pageSize }}">Next</a>
+            </li>
+            <li class="page-item {{ if not $hasNext }}disabled{{ end }}">
+                <a class="page-link" href="{{ $baseURL }}&page={{ $totalPages }}&page_size={{ $pageSize }}">Last</a>
+            </li>
+        </ul>
+    </nav>
+{{ end }}

--- a/pkg/pyroscope/modules_experimental.go
+++ b/pkg/pyroscope/modules_experimental.go
@@ -332,7 +332,7 @@ func (f *Pyroscope) initMetastoreAdmin() (services.Service, error) {
 func (f *Pyroscope) initAdminV2() (services.Service, error) {
 	level.Info(f.logger).Log("msg", "initializing v2 admin (metastore-based)")
 
-	a, err := operationsv2.NewAdmin(f.metastoreClient, f.logger)
+	a, err := operationsv2.NewAdmin(f.metastoreClient, f.storageBucket, f.logger)
 	if err != nil {
 		level.Info(f.logger).Log("msg", "failed to initialize v2 admin", "err", err)
 		return nil, nil


### PR DESCRIPTION
Follow-up to #4480, this adds a way to explore profiles inside a block dataset. An upcoming PR will also add pages to inspect the TSDB index and symbols. Part of https://github.com/grafana/pyroscope-squad/issues/213.

Entrypoint:

<img width="2002" height="1625" alt="Screenshot 2025-10-20 at 14 31 34" src="https://github.com/user-attachments/assets/10d55972-65de-49c9-9e44-baae26d35aef" />

---

List of profiles (parquet data), including a download (pprof) option. Note that data is pre-sorted (in parquet) by labels and then timestamps. We could add sorting options in the future.

<img width="2026" height="1126" alt="Screenshot 2025-10-20 at 14 31 45" src="https://github.com/user-attachments/assets/e40df2c4-631a-45e1-8fea-3c9450994dd5" />

---

Profile call-tree (experimental visualization):

<img width="3807" height="1015" alt="Screenshot 2025-10-20 at 14 31 56" src="https://github.com/user-attachments/assets/2e68cb88-6c14-43ba-9b3f-c17fcb97e626" />
