### PR TITLE
fix: fix recording rules on functions by relaxing ObserveSymbols condition

### DIFF
--- a/pkg/block/compaction_test.go
+++ b/pkg/block/compaction_test.go
@@ -1,18 +1,28 @@
-package block
+package block_test
 
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/pkg/block"
+	"github.com/grafana/pyroscope/pkg/metrics"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
 	"github.com/grafana/pyroscope/pkg/objstore/testutil"
+	"github.com/grafana/pyroscope/pkg/test/mocks/mockmetrics"
 )
 
 func Test_CompactBlocks(t *testing.T) {
@@ -26,12 +36,12 @@ func Test_CompactBlocks(t *testing.T) {
 	require.NoError(t, err)
 
 	dst, tempdir := testutil.NewFilesystemBucket(t, ctx, t.TempDir())
-	compactedBlocks, err := Compact(ctx, resp.Blocks, bucket,
-		WithCompactionDestination(dst),
-		WithCompactionTempDir(tempdir),
-		WithCompactionObjectOptions(
-			WithObjectDownload(filepath.Join(tempdir, "source")),
-			WithObjectMaxSizeLoadInMemory(0)), // Force download.
+	compactedBlocks, err := block.Compact(ctx, resp.Blocks, bucket,
+		block.WithCompactionDestination(dst),
+		block.WithCompactionTempDir(tempdir),
+		block.WithCompactionObjectOptions(
+			block.WithObjectDownload(filepath.Join(tempdir, "source")),
+			block.WithObjectMaxSizeLoadInMemory(0)), // Force download.
 	)
 
 	require.NoError(t, err)
@@ -46,12 +56,12 @@ func Test_CompactBlocks(t *testing.T) {
 	assert.Equal(t, string(expectedJson), string(compactedJson))
 
 	t.Run("Compact compacted blocks", func(t *testing.T) {
-		compactedBlocks, err = Compact(ctx, compactedBlocks, dst,
-			WithCompactionDestination(dst),
-			WithCompactionTempDir(tempdir),
-			WithCompactionObjectOptions(
-				WithObjectDownload(filepath.Join(tempdir, "source")),
-				WithObjectMaxSizeLoadInMemory(0)), // Force download.
+		compactedBlocks, err = block.Compact(ctx, compactedBlocks, dst,
+			block.WithCompactionDestination(dst),
+			block.WithCompactionTempDir(tempdir),
+			block.WithCompactionObjectOptions(
+				block.WithObjectDownload(filepath.Join(tempdir, "source")),
+				block.WithObjectMaxSizeLoadInMemory(0)), // Force download.
 		)
 
 		require.NoError(t, err)
@@ -59,4 +69,275 @@ func Test_CompactBlocks(t *testing.T) {
 		require.NotZero(t, compactedBlocks[0].Size)
 		require.Len(t, compactedBlocks[0].Datasets, 4)
 	})
+}
+
+func Test_CompactBlocks_recordingRules(t *testing.T) {
+	ctx := context.Background()
+	bucket, _ := testutil.NewFilesystemBucket(t, ctx, "testdata")
+
+	var resp metastorev1.GetBlockMetadataResponse
+	raw, err := os.ReadFile("testdata/block-metas.json")
+	require.NoError(t, err)
+	err = protojson.Unmarshal(raw, &resp)
+	require.NoError(t, err)
+
+	exporter := &stringExporter{}
+	ruler := new(mockmetrics.MockRuler)
+	ruler.On("RecordingRules", mock.Anything).Return([]*phlaremodel.RecordingRule{
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "goroutine:goroutine:count:goroutine:count"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_goroutines_total_count"}),
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:alloc_objects:count:space:bytes"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_alloc_total_count"}),
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:alloc_space:bytes:space:bytes"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_alloc_total_bytes"}),
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:inuse_objects:count:space:bytes"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_inuse_total_count"}),
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:inuse_space:bytes:space:bytes"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_inuse_total_bytes"}),
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "process_cpu:cpu:nanoseconds:cpu:nanoseconds"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_cpu_usage_total_nanoseconds"}),
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "process_cpu:samples:count:cpu:nanoseconds"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_cpu_usage_total_samples"}),
+		},
+		// functions
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "goroutine:goroutine:count:goroutine:count"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_goroutines_function_total_servehttp_count"}),
+			FunctionName:   "net/http.HandlerFunc.ServeHTTP",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:alloc_objects:count:space:bytes"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_alloc_function_total_servehttp_count"}),
+			FunctionName:   "net/http.HandlerFunc.ServeHTTP",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:alloc_space:bytes:space:bytes"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_alloc_function_total_servehttp_bytes"}),
+			FunctionName:   "net/http.HandlerFunc.ServeHTTP",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:inuse_objects:count:space:bytes"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_inuse_function_total_servehttp_count"}),
+			FunctionName:   "net/http.HandlerFunc.ServeHTTP",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:inuse_space:bytes:space:bytes"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_inuse_function_total_servehttp_bytes"}),
+			FunctionName:   "net/http.HandlerFunc.ServeHTTP",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "process_cpu:cpu:nanoseconds:cpu:nanoseconds"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_cpu_usage_function_total_servehttp_nanoseconds"}),
+			FunctionName:   "net/http.HandlerFunc.ServeHTTP",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "process_cpu:samples:count:cpu:nanoseconds"),
+			},
+			GroupBy:        []string{"service_name"},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_cpu_usage_function_total_servehttp_samples"}),
+			FunctionName:   "net/http.HandlerFunc.ServeHTTP",
+		},
+	})
+	sampleObserver := metrics.NewSampleObserver(0, exporter, ruler, labels.EmptyLabels())
+
+	compactedBlocks, err := block.Compact(ctx, resp.Blocks, bucket,
+		block.WithSampleObserver(sampleObserver),
+	)
+	// Close observer to flush export
+	sampleObserver.Close()
+
+	require.NoError(t, err)
+	require.Len(t, compactedBlocks, 1)
+	require.NotZero(t, compactedBlocks[0].Size)
+	require.Len(t, compactedBlocks[0].Datasets, 4)
+
+	expectedMetrics, err := os.ReadFile("testdata/profiles_recorded.txt")
+	require.NoError(t, err)
+	expectedMetricsArray := strings.Split(string(expectedMetrics), "\n")
+	sort.Strings(expectedMetricsArray)
+	actualMetricsArray := strings.Split(exporter.String(), "\n")
+	sort.Strings(actualMetricsArray)
+	assert.Equal(t, expectedMetricsArray, actualMetricsArray)
+
+	compactedJson, err := json.MarshalIndent(compactedBlocks, "", "  ")
+	require.NoError(t, err)
+	expectedJson, err := os.ReadFile("testdata/compacted.golden")
+	require.NoError(t, err)
+	assert.Equal(t, string(expectedJson), string(compactedJson))
+}
+
+func Test_CompactBlocks_recordingRules_shadowedSymbols(t *testing.T) {
+	ctx := context.Background()
+	bucket, _ := testutil.NewFilesystemBucket(t, ctx, "testdata")
+
+	var resp metastorev1.GetBlockMetadataResponse
+	raw, err := os.ReadFile("testdata/block-metas.json")
+	require.NoError(t, err)
+	err = protojson.Unmarshal(raw, &resp)
+	require.NoError(t, err)
+
+	exporter := &stringExporter{}
+	ruler := new(mockmetrics.MockRuler)
+	ruler.On("RecordingRules", mock.Anything).Return([]*phlaremodel.RecordingRule{
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "service_name", "pyroscope-test/ingester"),
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:alloc_space:bytes:space:bytes"),
+			},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_alloc_total_pyroscope_ingester_Push_bytes"}),
+			FunctionName:   "github.com/grafana/pyroscope/pkg/ingester.(*Ingester).Push",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "service_name", "pyroscope-test/ingester"),
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:inuse_space:bytes:space:bytes"),
+			},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_inuse_total_pyroscope_ingester_Push_bytes"}),
+			FunctionName:   "github.com/grafana/pyroscope/pkg/ingester.(*Ingester).Push",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "service_name", "pyroscope-test/ingester"),
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "process_cpu:samples:count:cpu:nanoseconds"),
+			},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_cpu_usage_total_pyroscope_ingester_Push_samples"}),
+			FunctionName:   "github.com/grafana/pyroscope/pkg/ingester.(*Ingester).Push",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "service_name", "pyroscope-test/ingester"),
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:alloc_space:bytes:space:bytes"),
+			},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_alloc_total_pyroscope_ingester_Serve_bytes"}),
+			FunctionName:   "net/http.HandlerFunc.ServeHTTP",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "service_name", "pyroscope-test/ingester"),
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:inuse_space:bytes:space:bytes"),
+			},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_inuse_total_pyroscope_ingester_Serve_bytes"}),
+			FunctionName:   "net/http.HandlerFunc.ServeHTTP",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "service_name", "pyroscope-test/ingester"),
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "process_cpu:samples:count:cpu:nanoseconds"),
+			},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_cpu_usage_total_pyroscope_ingester_Serve_samples"}),
+			FunctionName:   "net/http.HandlerFunc.ServeHTTP",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "service_name", "pyroscope-test/query-frontend"),
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:inuse_space:bytes:space:bytes"),
+			},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_inuse_total_query_Serve_bytes"}),
+			FunctionName:   "net/http.HandlerFunc.ServeHTTP",
+		},
+		{
+			Matchers: []*labels.Matcher{
+				labels.MustNewMatcher(labels.MatchEqual, "service_name", "pyroscope-test/query-frontend"),
+				labels.MustNewMatcher(labels.MatchEqual, "__profile_type__", "memory:alloc_space:bytes:space:bytes"),
+			},
+			ExternalLabels: labels.New(labels.Label{Name: "__name__", Value: "profiles_recorded_mem_alloc_total_query_Serve_bytes"}),
+			FunctionName:   "net/http.HandlerFunc.ServeHTTP",
+		},
+	})
+	sampleObserver := metrics.NewSampleObserver(0, exporter, ruler, labels.EmptyLabels())
+
+	compactedBlocks, err := block.Compact(ctx, resp.Blocks, bucket,
+		block.WithSampleObserver(sampleObserver),
+	)
+	// Close observer to flush export
+	sampleObserver.Close()
+
+	require.NoError(t, err)
+	require.Len(t, compactedBlocks, 1)
+	require.NotZero(t, compactedBlocks[0].Size)
+	require.Len(t, compactedBlocks[0].Datasets, 4)
+
+	expectedMetrics, err := os.ReadFile("testdata/profiles_recorded_shadowed.txt")
+	require.NoError(t, err)
+	expectedMetricsArray := strings.Split(string(expectedMetrics), "\n")
+	sort.Strings(expectedMetricsArray)
+	actualMetricsArray := strings.Split(exporter.String(), "\n")
+	sort.Strings(actualMetricsArray)
+	assert.Equal(t, expectedMetricsArray, actualMetricsArray)
+
+	compactedJson, err := json.MarshalIndent(compactedBlocks, "", "  ")
+	require.NoError(t, err)
+	expectedJson, err := os.ReadFile("testdata/compacted.golden")
+	require.NoError(t, err)
+	assert.Equal(t, string(expectedJson), string(compactedJson))
+}
+
+type stringExporter struct {
+	output string
+}
+
+func (e *stringExporter) Send(tenant string, series []prompb.TimeSeries) error {
+	for _, s := range series {
+		e.output += fmt.Sprintf("%s: %s\n", tenant, s.String())
+	}
+	return nil
+}
+
+func (*stringExporter) Flush() {}
+
+func (e *stringExporter) String() string {
+	return e.output
 }

--- a/pkg/block/testdata/profiles_recorded.txt
+++ b/pkg/block/testdata/profiles_recorded.txt
@@ -1,0 +1,36 @@
+anonymous: labels:<name:"__name__" value:"profiles_recorded_goroutines_total_count" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:286 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_goroutines_total_count" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<value:125 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_alloc_total_count" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:132025 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_alloc_total_count" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<value:8506 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_alloc_total_bytes" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:9.746461e+07 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_alloc_total_bytes" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<value:1.0898839e+07 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_total_count" > labels:<name:"service_name" value:"pyroscope-test/alloy" > samples:<value:74337 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_total_count" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:71502 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_total_count" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<value:8372 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_total_bytes" > labels:<name:"service_name" value:"pyroscope-test/alloy" > samples:<value:5.3795375e+07 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_total_bytes" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:4.6093095e+07 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_total_bytes" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<value:8.820688e+06 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_total_nanoseconds" > labels:<name:"service_name" value:"pyroscope-test/alloy" > samples:<value:1.5e+08 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_total_nanoseconds" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:3.4e+08 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_total_nanoseconds" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<value:1.8e+08 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_total_samples" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<value:18 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_total_samples" > labels:<name:"service_name" value:"pyroscope-test/alloy" > samples:<value:15 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_total_samples" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:34 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_goroutines_function_total_servehttp_count" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:16 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_goroutines_function_total_servehttp_count" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<value:2 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_alloc_function_total_servehttp_count" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:70921 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_alloc_function_total_servehttp_count" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<value:3 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_alloc_function_total_servehttp_bytes" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:4.6148663e+07 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_alloc_function_total_servehttp_bytes" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<value:2.136945e+06 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_function_total_servehttp_count" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:868 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_function_total_servehttp_count" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<value:17 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_function_total_servehttp_count" > labels:<name:"service_name" value:"pyroscope-test/alloy" > samples:<value:2350 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_function_total_servehttp_bytes" > labels:<name:"service_name" value:"pyroscope-test/alloy" > samples:<value:2.638198e+06 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_function_total_servehttp_bytes" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:1.5491333e+07 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_function_total_servehttp_bytes" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<value:1.753538e+06 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_function_total_servehttp_nanoseconds" > labels:<name:"service_name" value:"pyroscope-test/alloy" > samples:<value:1e+07 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_function_total_servehttp_nanoseconds" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:5e+07 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_function_total_servehttp_nanoseconds" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<> 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_function_total_servehttp_samples" > labels:<name:"service_name" value:"pyroscope-test/alloy" > samples:<value:1 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_function_total_servehttp_samples" > labels:<name:"service_name" value:"pyroscope-test/ingester" > samples:<value:5 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_function_total_servehttp_samples" > labels:<name:"service_name" value:"pyroscope-test/query-frontend" > samples:<> 

--- a/pkg/block/testdata/profiles_recorded_shadowed.txt
+++ b/pkg/block/testdata/profiles_recorded_shadowed.txt
@@ -1,0 +1,8 @@
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_alloc_total_pyroscope_ingester_Push_bytes" > samples:<value:1.2128258e+07 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_total_pyroscope_ingester_Push_bytes" > samples:<value:1.588276e+06 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_total_pyroscope_ingester_Push_samples" > samples:<value:2 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_alloc_total_pyroscope_ingester_Serve_bytes" > samples:<value:4.6148663e+07 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_total_pyroscope_ingester_Serve_bytes" > samples:<value:1.5491333e+07 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_cpu_usage_total_pyroscope_ingester_Serve_samples" > samples:<value:5 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_inuse_total_query_Serve_bytes" > samples:<value:1.753538e+06 > 
+anonymous: labels:<name:"__name__" value:"profiles_recorded_mem_alloc_total_query_Serve_bytes" > samples:<value:2.136945e+06 > 

--- a/pkg/metrics/observer.go
+++ b/pkg/metrics/observer.go
@@ -177,11 +177,14 @@ func (o *SampleObserver) initSeriesState(row block.ProfileEntry) {
 	}
 }
 
-// ObserveSymbols will skip observation if no rule evaluated true for matchers.
+// ObserveSymbols will observe symbols as soon as there's a function rule targeting this dataset.
+// Symbols are observed only once, and the current rule may have symbols that a future matching rule needs.
+// This is suboptimal as we may read more symbols than needed. However, the current interface does not let us do better,
+// and a bigger refactor may be needed to address this issue.
 // At the end of this process we'll have a map stacktraceId -> matching rule, so later we can get stacktraces from the
 // row and quickly look up for matching rules
 func (o *SampleObserver) ObserveSymbols(strings []string, functions []schemav1.InMemoryFunction, locations []schemav1.InMemoryLocation, stacktraceValues [][]int32, stacktraceIds []uint32) {
-	if !o.state.recordSymbols {
+	if len(o.state.targetStrings) == 0 {
 		return
 	}
 


### PR DESCRIPTION
We have this setup where SampleObserver will sequentially observe profiles while compacted, and will detect context switch such as tenant, dataset (service_name), or series (changing fingerprint between consecutive profiles). During the compaction, at the rewrite symbols step, SampleObserver also has the opportunity to observe symbols.

Symbols are written within the context of a dataset, that means that on a dataset switch, new symbols are considered and the previous ones are dispatched. When we detect a dataset switch, we find all recording rules that will be needed for the dataset and keep track of all the symbols (function names) we need to observe, which is fine.

We had this condition where we don't observe symbols if the current profile does not match any rule with a function, which appears to be wrong. The reason for this is that Symbols are only read once, so we can have this run condition where some symbols are written, but not observed (no matching rules for the current profile), but those symbols are important in a following row, but they are skipped forever.

## Example

A simple example of this is when we process CPU go profiles. Nanoseconds and samples are an exact same tree but different values. Same for memory bytes/objects, they share the topology of the tree but not the totals. 

* **rule:** record function "foo" on cpu-samples

Sample observer sequence:
| Row                     | SymbolRewriter                          | SymbolObserver                          |
|-------------------------|-----------------------------------------|-----------------------------------------|
| ...                     | ...                                     | ...                                     |
| profile_cpu_nanoseconds | rewriting new symbols                  | (no rule matching - no symbols observed) |
| profile_cpu_samples     | (no new symbols - no symbols rewritten) | (skipped)                               |


There are more complex corner cases where this can happen.

## Solution:
The proposed solution is to observe symbols for every rule on the whole dataset, no matter whether the current row matches or not. We were doing dataset-wide work here already (once we observe symbols, we observe for every rule in that dataset, not only for the current row), but we were not always observing.

There's a risk here where we observe symbols that will be never match ANY row. Solution for that would need to know beforehand if rows match, by reading them twice or reimplementing a more intelligent way of fetching symbols on demand.