### PR TITLE
fix: Fix `go get` in `update-examples-cron`

### DIFF
--- a/Makefile.examples
+++ b/Makefile.examples
@@ -2,8 +2,8 @@ GITHUB_REPOSITORY ?= grafana/pyroscope
 
 .PHONY: tools/update_examples
 tools/update_examples:
-	docker build -t update_pyroscope_examples -f tools/update_examples.Dockerfile  tools
-	docker run --rm  -e GITHUB_TOKEN=$(GITHUB_TOKEN) -v$(shell pwd):/pyroscope -w /pyroscope update_pyroscope_examples bash -l -c "go run tools/update_examples.go"
+	docker buildx build --platform $(IMAGE_PLATFORM) -t update_pyroscope_examples -f tools/update_examples.Dockerfile  tools
+	docker run --rm  --platform=$(IMAGE_PLATFORM) -e GITHUB_TOKEN=$(GITHUB_TOKEN) -v$(shell pwd):/pyroscope -w /pyroscope update_pyroscope_examples bash -l -c "go run tools/update_examples.go"
 
 .PHONY: tools/update_examples_pr
 tools/update_examples_pr:

--- a/tools/update_examples.go
+++ b/tools/update_examples.go
@@ -275,15 +275,11 @@ func extractRSVersion(module string) func(tag Tag) *version {
 }
 
 func updateJfrParser() {
-	pprofVersions := getTagsV("grafana/jfr-parser", extractGoVersion("pprof"))
 	parserVersions := getTagsV("grafana/jfr-parser", extractGoVersion(""))
-	pprofVersion := pprofVersions[len(pprofVersions)-1]
 	parserVersion := parserVersions[len(parserVersions)-1]
-	fmt.Printf("jfr-parer pprof %+v\n", pprofVersion)
-	fmt.Printf("jfr-parer  %+v\n", parserVersion)
+	fmt.Printf("jfr-parser  %+v\n", parserVersion)
 
 	s.sh(" go get github.com/grafana/jfr-parser@" + parserVersion.versionV())
-	s.sh(" go get github.com/grafana/jfr-parser/pprof@" + pprofVersion.versionV())
 }
 
 func extractDotnetVersion() func(tag Tag) *version {


### PR DESCRIPTION
Latest `jfr-parser` doesn't require separate import of `jfr-parser/pprof`

Related to https://github.com/grafana/pyroscope/pull/4471