### PR TITLE
fix: Ensure to build the same architecture image, as the current machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GO_MOD_VERSION := 1.24.0
 
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
-IMAGE_PLATFORM = linux/amd64
+IMAGE_PLATFORM = linux/$(GOARCH)
 BUILDX_ARGS =
 GOPRIVATE=github.com/grafana/frostdb
 


### PR DESCRIPTION
On darwin/arm64 or linux/arm64 hosts, we currently  build a linux/amd64 image with a linux/arm64 binary.

This fixes this behaviour and aligns the image to the host's architecture.