### PR TITLE
fix: Redirect to admin pages when no query API available

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -139,6 +139,10 @@ func (a *API) RegisterAPI(statusService statusv1.StatusServiceServer) error {
 	return nil
 }
 
+func (a *API) RegisterRedirectToAdmin() {
+	a.RegisterRoute("/", http.RedirectHandler("/admin", http.StatusFound), a.registerOptionsPublicAccess()...)
+}
+
 func (a *API) RegisterCatchAll() error {
 	uiIndexHandler, err := public.NewIndexHandler(a.cfg.BaseURL)
 	if err != nil {

--- a/pkg/pyroscope/pyroscope.go
+++ b/pkg/pyroscope/pyroscope.go
@@ -617,8 +617,17 @@ func (f *Pyroscope) Run() error {
 		}
 	}
 
-	if err = f.API.RegisterCatchAll(); err != nil {
-		return err
+	// only query-frontend, query-backend, querier and target all should register the UI
+	if slices.Contains(f.Cfg.Target, All) ||
+		slices.Contains(f.Cfg.Target, QueryFrontend) ||
+		slices.Contains(f.Cfg.Target, QueryBackend) ||
+		slices.Contains(f.Cfg.Target, Querier) {
+
+		if err = f.API.RegisterCatchAll(); err != nil {
+			return err
+		}
+	} else {
+		f.API.RegisterRedirectToAdmin()
 	}
 
 	serviceFailed := func(service services.Service) {


### PR DESCRIPTION
This PR make sure that on component without query APIs we do not offer the UI and instead redirect to the /admin page.
