### PR TITLE
feat(v2): add admin page for inspecting TSDB indices

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -303,6 +303,7 @@ type AdminService interface {
 	DatasetProfilesHandler(w http.ResponseWriter, r *http.Request)
 	ProfileDownloadHandler(w http.ResponseWriter, r *http.Request)
 	ProfileCallTreeHandler(w http.ResponseWriter, r *http.Request)
+	DatasetTSDBIndexHandler(w http.ResponseWriter, r *http.Request)
 }
 
 func (a *API) RegisterAdmin(ad AdminService) {
@@ -313,6 +314,7 @@ func (a *API) RegisterAdmin(ad AdminService) {
 	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles", http.HandlerFunc(ad.DatasetProfilesHandler), a.registerOptionsPublicAccess()...)
 	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles/download", http.HandlerFunc(ad.ProfileDownloadHandler), a.registerOptionsPublicAccess()...)
 	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles/call-tree", http.HandlerFunc(ad.ProfileCallTreeHandler), a.registerOptionsPublicAccess()...)
+	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/index", http.HandlerFunc(ad.DatasetTSDBIndexHandler), a.registerOptionsPublicAccess()...)
 
 	a.indexPage.AddLinks(defaultWeight, "Admin", []IndexPageLink{
 		{Desc: "Object Storage Tenants & Blocks", Path: "/ops/object-store/tenants"},

--- a/pkg/operations/admin.go
+++ b/pkg/operations/admin.go
@@ -61,3 +61,7 @@ func (a *Admin) ProfileDownloadHandler(w http.ResponseWriter, r *http.Request) {
 func (a *Admin) ProfileCallTreeHandler(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "Profile call tree not available in v1 storage", http.StatusNotFound)
 }
+
+func (a *Admin) DatasetTSDBIndexHandler(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "Dataset TSDB index not available in v1 storage", http.StatusNotFound)
+}

--- a/pkg/operations/v2/admin.go
+++ b/pkg/operations/v2/admin.go
@@ -61,3 +61,7 @@ func (a *Admin) ProfileDownloadHandler(w http.ResponseWriter, r *http.Request) {
 func (a *Admin) ProfileCallTreeHandler(w http.ResponseWriter, r *http.Request) {
 	a.handlers.CreateDatasetProfileCallTreeHandler()(w, r)
 }
+
+func (a *Admin) DatasetTSDBIndexHandler(w http.ResponseWriter, r *http.Request) {
+	a.handlers.CreateDatasetTSDBIndexHandler()(w, r)
+}

--- a/pkg/operations/v2/dataset_handlers.go
+++ b/pkg/operations/v2/dataset_handlers.go
@@ -1,0 +1,306 @@
+package v2
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/dustin/go-humanize"
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+
+	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
+	"github.com/grafana/pyroscope/pkg/block"
+	"github.com/grafana/pyroscope/pkg/block/metadata"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
+	"github.com/grafana/pyroscope/pkg/phlaredb"
+	"github.com/grafana/pyroscope/pkg/phlaredb/tsdb/index"
+	httputil "github.com/grafana/pyroscope/pkg/util/http"
+)
+
+func (h *Handlers) CreateDatasetDetailsHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		tenantId := vars["tenant"]
+		if tenantId == "" {
+			httputil.Error(w, errors.New("No tenant id provided"))
+			return
+		}
+		blockId := vars["block"]
+		if blockId == "" {
+			httputil.Error(w, errors.New("No block id provided"))
+			return
+		}
+		datasetName := r.URL.Query().Get("dataset")
+		if datasetName == "" {
+			httputil.Error(w, errors.New("No dataset name provided"))
+			return
+		}
+		// Handle special case for empty dataset name
+		if datasetName == "_empty" {
+			datasetName = ""
+		}
+		shardStr := r.URL.Query().Get("shard")
+		if shardStr == "" {
+			httputil.Error(w, errors.New("No shard provided"))
+			return
+		}
+		var shard uint32
+		if _, err := fmt.Sscanf(shardStr, "%d", &shard); err != nil {
+			httputil.Error(w, errors.Wrap(err, "invalid shard parameter"))
+			return
+		}
+
+		blockTenant := r.URL.Query().Get("block_tenant")
+
+		metadataResp, err := h.MetastoreClient.GetBlockMetadata(r.Context(), &metastorev1.GetBlockMetadataRequest{
+			Blocks: &metastorev1.BlockList{
+				Tenant: blockTenant,
+				Shard:  shard,
+				Blocks: []string{blockId},
+			},
+		})
+		if err != nil {
+			httputil.Error(w, errors.Wrap(err, "failed to get block metadata"))
+			return
+		}
+
+		if len(metadataResp.Blocks) == 0 {
+			httputil.Error(w, errors.New("Block not found"))
+			return
+		}
+
+		blockMeta := metadataResp.Blocks[0]
+
+		var foundDataset *metastorev1.Dataset
+		for _, ds := range blockMeta.Datasets {
+			dsName := blockMeta.StringTable[ds.Name]
+			if dsName == datasetName {
+				foundDataset = ds
+				break
+			}
+		}
+
+		if foundDataset == nil {
+			httputil.Error(w, errors.New("Dataset not found"))
+			return
+		}
+
+		dataset := h.convertDataset(foundDataset, blockMeta.StringTable)
+
+		err = pageTemplates.datasetDetailsTemplate.Execute(w, datasetDetailsPageContent{
+			User:        tenantId,
+			BlockID:     blockId,
+			Shard:       shard,
+			BlockTenant: blockTenant,
+			Dataset:     &dataset,
+			Now:         time.Now().UTC().Format(time.RFC3339),
+		})
+		if err != nil {
+			httputil.Error(w, err)
+			return
+		}
+	}
+}
+
+func (h *Handlers) convertDataset(ds *metastorev1.Dataset, stringTable []string) datasetDetails {
+	tenant := stringTable[ds.Tenant]
+	datasetName := stringTable[ds.Name]
+
+	var labelSets []labelSet
+	pairs := metadata.LabelPairs(ds.Labels)
+	for pairs.Next() {
+		p := pairs.At()
+		var currentSet labelSet
+		for len(p) > 0 {
+			if len(p) >= 2 {
+				key := stringTable[p[0]]
+				val := stringTable[p[1]]
+				currentSet.Pairs = append(currentSet.Pairs, labelPair{Key: key, Value: val})
+				p = p[2:]
+			} else {
+				break
+			}
+		}
+		if len(currentSet.Pairs) > 0 {
+			labelSets = append(labelSets, currentSet)
+		}
+	}
+
+	var profilesSize, indexSize, symbolsSize uint64
+	if len(ds.TableOfContents) >= 3 {
+		profilesSize = ds.TableOfContents[1] - ds.TableOfContents[0]
+		indexSize = ds.TableOfContents[2] - ds.TableOfContents[1]
+		symbolsSize = (ds.TableOfContents[0] + ds.Size) - ds.TableOfContents[2]
+	}
+
+	var profilesPercentage, indexPercentage, symbolsPercentage float64
+	if ds.Size > 0 {
+		profilesPercentage = (float64(profilesSize) / float64(ds.Size)) * 100
+		indexPercentage = (float64(indexSize) / float64(ds.Size)) * 100
+		symbolsPercentage = (float64(symbolsSize) / float64(ds.Size)) * 100
+	}
+
+	return datasetDetails{
+		Tenant:             tenant,
+		Name:               datasetName,
+		MinTime:            msToTime(ds.MinTime).UTC().Format(time.RFC3339),
+		MaxTime:            msToTime(ds.MaxTime).UTC().Format(time.RFC3339),
+		Size:               humanize.Bytes(ds.Size),
+		ProfilesSize:       humanize.Bytes(profilesSize),
+		IndexSize:          humanize.Bytes(indexSize),
+		SymbolsSize:        humanize.Bytes(symbolsSize),
+		ProfilesPercentage: profilesPercentage,
+		IndexPercentage:    indexPercentage,
+		SymbolsPercentage:  symbolsPercentage,
+		LabelSets:          labelSets,
+	}
+}
+
+func (h *Handlers) CreateDatasetTSDBIndexHandler() func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		req, err := parseDatasetRequest(r)
+		if err != nil {
+			httputil.Error(w, err)
+			return
+		}
+
+		blockMeta, foundDataset, err := h.getDatasetMetadata(r.Context(), req)
+		if err != nil {
+			httputil.Error(w, err)
+			return
+		}
+
+		dataset := h.convertDataset(foundDataset, blockMeta.StringTable)
+
+		TSDBIndex, err := h.readTSDBIndex(r.Context(), blockMeta, foundDataset)
+		if err != nil {
+			httputil.Error(w, errors.Wrap(err, "failed to read TSDB index"))
+			return
+		}
+
+		err = pageTemplates.datasetIndexTemplate.Execute(w, datasetIndexPageContent{
+			User:        req.TenantID,
+			BlockID:     req.BlockID,
+			Shard:       req.Shard,
+			BlockTenant: req.BlockTenant,
+			Dataset:     &dataset,
+			TSDBIndex:   TSDBIndex,
+			Now:         time.Now().UTC().Format(time.RFC3339),
+		})
+		if err != nil {
+			httputil.Error(w, err)
+			return
+		}
+	}
+}
+
+func (h *Handlers) readTSDBIndex(ctx context.Context, blockMeta *metastorev1.BlockMeta, dataset *metastorev1.Dataset) (*tsdbIndexInfo, error) {
+	obj := block.NewObject(h.Bucket, blockMeta)
+	if err := obj.Open(ctx); err != nil {
+		return nil, fmt.Errorf("failed to open block object: %w", err)
+	}
+	defer obj.Close()
+
+	ds := block.NewDataset(dataset, obj)
+	if err := ds.Open(ctx, block.SectionTSDB); err != nil {
+		return nil, fmt.Errorf("failed to open dataset: %w", err)
+	}
+	defer ds.Close()
+
+	idx := ds.Index()
+
+	from, through := idx.Bounds()
+	fromTime := time.Unix(0, from).UTC().Format(time.RFC3339)
+	throughTime := time.Unix(0, through).UTC().Format(time.RFC3339)
+
+	labels, err := h.getIndexLabels(idx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get labels: %w", err)
+	}
+
+	symbolIter := idx.Symbols()
+	var symbols []string
+	for symbolIter.Next() {
+		symbols = append(symbols, symbolIter.At())
+	}
+	if err := symbolIter.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate symbols: %w", err)
+	}
+
+	series, err := h.getIndexSeries(idx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get series: %w", err)
+	}
+
+	return &tsdbIndexInfo{
+		From:           fromTime,
+		Through:        throughTime,
+		Checksum:       idx.Checksum(),
+		Series:         series,
+		Symbols:        symbols,
+		LabelValueSets: labels,
+	}, nil
+}
+
+func (h *Handlers) getIndexLabels(idx phlaredb.IndexReader) ([]labelValueSet, error) {
+	labelNames, err := idx.LabelNames()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get label names: %w", err)
+	}
+	var labelValueSets []labelValueSet
+	for _, labelName := range labelNames {
+		values, err := idx.LabelValues(labelName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get label values for %s: %w", labelName, err)
+		}
+
+		labelValueSets = append(labelValueSets, labelValueSet{
+			LabelName:   labelName,
+			LabelValues: values,
+		})
+	}
+	return labelValueSets, nil
+}
+
+func (h *Handlers) getIndexSeries(idx phlaredb.IndexReader) ([]seriesInfo, error) {
+	k2, v2 := index.AllPostingsKey()
+	seriesPostings, err := idx.Postings(k2, nil, v2)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get series postings: %w", err)
+	}
+
+	var seriesList []seriesInfo
+	var lbls phlaremodel.Labels
+	chunks := make([]index.ChunkMeta, 1)
+
+	seriesIdx := uint32(0)
+	for seriesPostings.Next() {
+		seriesRef := seriesPostings.At()
+		_, err := idx.Series(seriesRef, &lbls, &chunks)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get series %d: %w", seriesRef, err)
+		}
+
+		var labelPairs []labelPair
+		for _, lbl := range lbls {
+			labelPairs = append(labelPairs, labelPair{
+				Key:   lbl.Name,
+				Value: lbl.Value,
+			})
+		}
+
+		seriesList = append(seriesList, seriesInfo{
+			SeriesIndex: seriesIdx,
+			SeriesRef:   uint64(seriesRef),
+			Labels:      labelPairs,
+		})
+		seriesIdx++
+	}
+	if err := seriesPostings.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate series postings: %w", err)
+	}
+
+	return seriesList, nil
+}

--- a/pkg/operations/v2/handlers.go
+++ b/pkg/operations/v2/handlers.go
@@ -15,7 +15,6 @@ import (
 	"google.golang.org/grpc"
 
 	metastorev1 "github.com/grafana/pyroscope/api/gen/proto/go/metastore/v1"
-	"github.com/grafana/pyroscope/pkg/block/metadata"
 	"github.com/grafana/pyroscope/pkg/objstore"
 	httputil "github.com/grafana/pyroscope/pkg/util/http"
 )
@@ -213,60 +212,6 @@ func (h *Handlers) CreateBlockDetailsHandler() func(http.ResponseWriter, *http.R
 	}
 }
 
-func (h *Handlers) convertDataset(ds *metastorev1.Dataset, stringTable []string) datasetDetails {
-	tenant := stringTable[ds.Tenant]
-	datasetName := stringTable[ds.Name]
-
-	var labelSets []labelSet
-	pairs := metadata.LabelPairs(ds.Labels)
-	for pairs.Next() {
-		p := pairs.At()
-		var currentSet labelSet
-		for len(p) > 0 {
-			if len(p) >= 2 {
-				key := stringTable[p[0]]
-				val := stringTable[p[1]]
-				currentSet.Pairs = append(currentSet.Pairs, labelPair{Key: key, Value: val})
-				p = p[2:]
-			} else {
-				break
-			}
-		}
-		if len(currentSet.Pairs) > 0 {
-			labelSets = append(labelSets, currentSet)
-		}
-	}
-
-	var profilesSize, indexSize, symbolsSize uint64
-	if len(ds.TableOfContents) >= 3 {
-		profilesSize = ds.TableOfContents[1] - ds.TableOfContents[0]
-		indexSize = ds.TableOfContents[2] - ds.TableOfContents[1]
-		symbolsSize = (ds.TableOfContents[0] + ds.Size) - ds.TableOfContents[2]
-	}
-
-	var profilesPercentage, indexPercentage, symbolsPercentage float64
-	if ds.Size > 0 {
-		profilesPercentage = (float64(profilesSize) / float64(ds.Size)) * 100
-		indexPercentage = (float64(indexSize) / float64(ds.Size)) * 100
-		symbolsPercentage = (float64(symbolsSize) / float64(ds.Size)) * 100
-	}
-
-	return datasetDetails{
-		Tenant:             tenant,
-		Name:               datasetName,
-		MinTime:            msToTime(ds.MinTime).UTC().Format(time.RFC3339),
-		MaxTime:            msToTime(ds.MaxTime).UTC().Format(time.RFC3339),
-		Size:               humanize.Bytes(ds.Size),
-		ProfilesSize:       humanize.Bytes(profilesSize),
-		IndexSize:          humanize.Bytes(indexSize),
-		SymbolsSize:        humanize.Bytes(symbolsSize),
-		ProfilesPercentage: profilesPercentage,
-		IndexPercentage:    indexPercentage,
-		SymbolsPercentage:  symbolsPercentage,
-		LabelSets:          labelSets,
-	}
-}
-
 func (h *Handlers) convertBlockMeta(meta *metastorev1.BlockMeta) *blockDetails {
 	minTime := msToTime(meta.MinTime).UTC()
 	maxTime := msToTime(meta.MaxTime).UTC()
@@ -287,90 +232,5 @@ func (h *Handlers) convertBlockMeta(meta *metastorev1.BlockMeta) *blockDetails {
 		CompactionLevel:   meta.CompactionLevel,
 		Size:              humanize.Bytes(meta.Size),
 		Datasets:          datasets,
-	}
-}
-
-func (h *Handlers) CreateDatasetDetailsHandler() func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)
-		tenantId := vars["tenant"]
-		if tenantId == "" {
-			httputil.Error(w, errors.New("No tenant id provided"))
-			return
-		}
-		blockId := vars["block"]
-		if blockId == "" {
-			httputil.Error(w, errors.New("No block id provided"))
-			return
-		}
-		datasetName := r.URL.Query().Get("dataset")
-		if datasetName == "" {
-			httputil.Error(w, errors.New("No dataset name provided"))
-			return
-		}
-		// Handle special case for empty dataset name
-		if datasetName == "_empty" {
-			datasetName = ""
-		}
-		shardStr := r.URL.Query().Get("shard")
-		if shardStr == "" {
-			httputil.Error(w, errors.New("No shard provided"))
-			return
-		}
-		var shard uint32
-		if _, err := fmt.Sscanf(shardStr, "%d", &shard); err != nil {
-			httputil.Error(w, errors.Wrap(err, "invalid shard parameter"))
-			return
-		}
-
-		blockTenant := r.URL.Query().Get("block_tenant")
-
-		metadataResp, err := h.MetastoreClient.GetBlockMetadata(r.Context(), &metastorev1.GetBlockMetadataRequest{
-			Blocks: &metastorev1.BlockList{
-				Tenant: blockTenant,
-				Shard:  shard,
-				Blocks: []string{blockId},
-			},
-		})
-		if err != nil {
-			httputil.Error(w, errors.Wrap(err, "failed to get block metadata"))
-			return
-		}
-
-		if len(metadataResp.Blocks) == 0 {
-			httputil.Error(w, errors.New("Block not found"))
-			return
-		}
-
-		blockMeta := metadataResp.Blocks[0]
-
-		var foundDataset *metastorev1.Dataset
-		for _, ds := range blockMeta.Datasets {
-			dsName := blockMeta.StringTable[ds.Name]
-			if dsName == datasetName {
-				foundDataset = ds
-				break
-			}
-		}
-
-		if foundDataset == nil {
-			httputil.Error(w, errors.New("Dataset not found"))
-			return
-		}
-
-		dataset := h.convertDataset(foundDataset, blockMeta.StringTable)
-
-		err = pageTemplates.datasetDetailsTemplate.Execute(w, datasetDetailsPageContent{
-			User:        tenantId,
-			BlockID:     blockId,
-			Shard:       shard,
-			BlockTenant: blockTenant,
-			Dataset:     &dataset,
-			Now:         time.Now().UTC().Format(time.RFC3339),
-		})
-		if err != nil {
-			httputil.Error(w, err)
-			return
-		}
 	}
 }

--- a/pkg/operations/v2/model.go
+++ b/pkg/operations/v2/model.go
@@ -149,6 +149,36 @@ type profileMetadata struct {
 	ProfileType string
 }
 
+type tsdbIndexInfo struct {
+	From           string
+	Through        string
+	Checksum       uint32
+	Series         []seriesInfo
+	Symbols        []string
+	LabelValueSets []labelValueSet
+}
+
+type labelValueSet struct {
+	LabelName   string
+	LabelValues []string
+}
+
+type seriesInfo struct {
+	SeriesIndex uint32
+	SeriesRef   uint64
+	Labels      []labelPair
+}
+
+type datasetIndexPageContent struct {
+	User        string
+	BlockID     string
+	Shard       uint32
+	BlockTenant string
+	Dataset     *datasetDetails
+	TSDBIndex   *tsdbIndexInfo
+	Now         string
+}
+
 const emptyDatasetPlaceholder = "_empty"
 
 type datasetRequest struct {

--- a/pkg/operations/v2/pages.go
+++ b/pkg/operations/v2/pages.go
@@ -27,6 +27,9 @@ var profileCallTreePageHtml string
 //go:embed tool.pagination.gohtml
 var paginationHtml string
 
+//go:embed tool.blocks.dataset.index.gohtml
+var datasetIndexPageHtml string
+
 type indexPageContent struct {
 	Users []string
 	Now   string
@@ -79,6 +82,7 @@ type templates struct {
 	datasetDetailsTemplate  *template.Template
 	datasetProfilesTemplate *template.Template
 	profileCallTreeTemplate *template.Template
+	datasetIndexTemplate    *template.Template
 }
 
 var pageTemplates = initTemplates()
@@ -114,6 +118,8 @@ func initTemplates() *templates {
 		"dict": dict,
 	})
 	template.Must(profileCallTreeTemplate.Parse(profileCallTreePageHtml))
+	datasetIndexTemplate := template.New("dataset-index")
+	template.Must(datasetIndexTemplate.Parse(datasetIndexPageHtml))
 	t := &templates{
 		indexTemplate:           indexTemplate,
 		blocksTemplate:          blocksTemplate,
@@ -121,6 +127,7 @@ func initTemplates() *templates {
 		datasetDetailsTemplate:  datasetDetailsTemplate,
 		datasetProfilesTemplate: datasetProfilesTemplate,
 		profileCallTreeTemplate: profileCallTreeTemplate,
+		datasetIndexTemplate:    datasetIndexTemplate,
 	}
 	return t
 }

--- a/pkg/operations/v2/tool.blocks.dataset.gohtml
+++ b/pkg/operations/v2/tool.blocks.dataset.gohtml
@@ -139,6 +139,20 @@
                         </div>
                     </div>
                 </div>
+                <div class="col-md-4 mb-3">
+                    <div class="card bg-dark border-secondary h-100">
+                        <div class="card-body d-flex flex-column">
+                            <h5 class="card-title">
+                                <i class="bi bi-list-nested"></i> TSDB Index
+                            </h5>
+                            <p class="card-text">Inspect the time series database index for this dataset.</p>
+                            <a href="/ops/object-store/tenants/{{ .User }}/blocks/{{ .BlockID }}/datasets/index?dataset={{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ .Shard }}&block_tenant={{ .BlockTenant }}"
+                               class="btn btn-primary mt-auto">
+                                View TSDB Index
+                            </a>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/pkg/operations/v2/tool.blocks.dataset.index.gohtml
+++ b/pkg/operations/v2/tool.blocks.dataset.index.gohtml
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html class="h-100" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Bucket Blocks Explorer (v2): TSDB Index</title>
+
+    <link rel="stylesheet" href="/static/bootstrap-5.3.3.min.css">
+    <link rel="stylesheet" href="/static/bootstrap-icons-1.8.1.css">
+    <link rel="stylesheet" href="/static/pyroscope-styles.css">
+    <script src="/static/bootstrap-5.3.3.bundle.min.js"></script>
+
+    <style>
+        .info-card {
+            margin-bottom: 20px;
+        }
+        .label-value-set {
+            margin-bottom: 15px;
+            padding: 10px;
+            border: 1px solid #495057;
+            border-radius: 4px;
+        }
+        .label-name-header {
+            font-weight: 600;
+            color: #0dcaf0;
+            margin-bottom: 5px;
+        }
+        .value-list {
+            margin-left: 20px;
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 13px;
+            color: #adb5bd;
+        }
+        .symbol-list {
+            font-family: 'Courier New', Courier, monospace;
+            font-size: 13px;
+            color: #adb5bd;
+            max-height: 400px;
+            overflow-y: auto;
+        }
+        .count-badge {
+            background-color: #198754;
+            color: white;
+            padding: 2px 8px;
+            border-radius: 3px;
+            font-size: 12px;
+            margin-left: 10px;
+        }
+    </style>
+</head>
+<body class="d-flex flex-column h-100">
+<main class="flex-shrink-0">
+    <div class="container">
+        <div class="header row border-bottom py-3 flex-column-reverse flex-sm-row">
+            <div class="col-12 col-sm-9 text-center text-sm-start">
+                <h3>Bucket Blocks Explorer (v2): TSDB Index</h3>
+            </div>
+            <div class="col-12 col-sm-3 text-center text-sm-end mb-3 mb-sm-0">
+                <a href="/ops/object-store/tenants">
+                    <img alt="Pyroscope logo" class="pyroscope-brand" src="/static/pyroscope-logo.png">
+                </a>
+            </div>
+        </div>
+        <div class="row my-3">
+            <p>
+                <a href="/ops/object-store/tenants/{{ .User }}/blocks/{{ .BlockID }}/datasets?dataset={{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ .Shard }}&block_tenant={{ .BlockTenant }}">Back to dataset</a>
+            </p>
+
+            <div class="card bg-dark border-secondary info-card">
+                <div class="card-header">
+                    <h5 class="mb-0">Dataset Information</h5>
+                </div>
+                <div class="card-body">
+                    <ul>
+                        <li>Dataset Name: {{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}<em>(empty)</em>{{ end }}</li>
+                        <li>Dataset Tenant: {{ .Dataset.Tenant }}</li>
+                        <li>Block ID: {{ .BlockID }}</li>
+                        <li>Shard: {{ .Shard }}</li>
+                    </ul>
+                </div>
+            </div>
+
+            {{ if .TSDBIndex }}
+                <div class="card bg-dark border-secondary info-card">
+                    <div class="card-header">
+                        <h5 class="mb-0">Index Summary</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="col-md-6">
+                                <p><strong>Time Range:</strong></p>
+                                <ul>
+                                    <li>From: {{ .TSDBIndex.From }}</li>
+                                    <li>Through: {{ .TSDBIndex.Through }}</li>
+                                </ul>
+                            </div>
+                            <div class="col-md-6">
+                                <p><strong>Statistics:</strong></p>
+                                <ul>
+                                    <li>Number of Series: {{ len .TSDBIndex.Series }}</li>
+                                    <li>Number of Labels: {{ len .TSDBIndex.LabelValueSets }}</li>
+                                    <li>Number of Symbols: {{ len .TSDBIndex.Symbols }}</li>
+                                    <li>Checksum: {{ printf "%08x" .TSDBIndex.Checksum }}</li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="card bg-dark border-secondary info-card">
+                    <div class="card-header">
+                        <h5 class="mb-0">Series</h5>
+                    </div>
+                    <div class="card-body">
+                        {{ if .TSDBIndex.Series }}
+                            <div class="table-responsive">
+                                <table class="table table-striped table-sm table-dark">
+                                    <thead>
+                                        <tr>
+                                            <th>Series Index</th>
+                                            <th>Series Ref</th>
+                                            <th>Labels</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {{ range .TSDBIndex.Series }}
+                                        <tr>
+                                            <td><code>{{ .SeriesIndex }}</code></td>
+                                            <td><code class="text-muted small">{{ .SeriesRef }}</code></td>
+                                            <td>
+                                                {{ if .Labels }}
+                                                    {{ range $i, $label := .Labels }}
+                                                        {{ if $i }}, {{ end }}<span class="font-monospace small">{{ $label.Key }}={{ $label.Value }}</span>
+                                                    {{ end }}
+                                                {{ else }}
+                                                    <span class="text-muted">-</span>
+                                                {{ end }}
+                                            </td>
+                                        </tr>
+                                        {{ end }}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {{ else }}
+                            <div class="alert alert-info" role="alert">
+                                No series found.
+                            </div>
+                        {{ end }}
+                    </div>
+                </div>
+
+                <div class="card bg-dark border-secondary info-card">
+                    <div class="card-header">
+                        <h5 class="mb-0">Labels</h5>
+                    </div>
+                    <div class="card-body">
+                        {{ if .TSDBIndex.LabelValueSets }}
+                            {{ range .TSDBIndex.LabelValueSets }}
+                                <div class="label-value-set">
+                                    <div class="label-name-header">
+                                        {{ .LabelName }}
+                                        <span class="count-badge">{{ len .LabelValues }} values</span>
+                                    </div>
+                                    <div class="value-list">
+                                        {{ range .LabelValues }}
+                                            <div>{{ . }}</div>
+                                        {{ end }}
+                                    </div>
+                                </div>
+                            {{ end }}
+                        {{ else }}
+                            <div class="alert alert-info" role="alert">
+                                No labels found.
+                            </div>
+                        {{ end }}
+                    </div>
+                </div>
+
+                <div class="card bg-dark border-secondary info-card">
+                    <div class="card-header">
+                        <h5 class="mb-0">Symbol Table</h5>
+                    </div>
+                    <div class="card-body">
+                        {{ if .TSDBIndex.Symbols }}
+                            <div class="symbol-list">
+                                {{ range .TSDBIndex.Symbols }}
+                                    <div>{{ . }}</div>
+                                {{ end }}
+                            </div>
+                        {{ else }}
+                            <div class="alert alert-info" role="alert">
+                                No symbols found.
+                            </div>
+                        {{ end }}
+                    </div>
+                </div>
+            {{ else }}
+                <div class="alert alert-warning" role="alert">
+                    No index information available.
+                </div>
+            {{ end }}
+        </div>
+    </div>
+</main>
+<footer class="footer mt-auto py-3 bg-dark">
+    <div class="container">
+        <small class="text-white-50">Status @ {{ .Now }}</small>
+    </div>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
Follow-up to #4480 and #4543, this adds a page for inspecting the TSDB index for a dataset. It is fairly simple right now, but can be expanded later on (e.g., linking series with profiles). Also part of https://github.com/grafana/pyroscope-squad/issues/213

Entrypoint:

<img width="2092" height="1020" alt="Screenshot 2025-10-22 at 13 42 51" src="https://github.com/user-attachments/assets/700155cc-da05-47b4-b754-ec90c7a4103b" />

---

General info, series stored in the index:

<img width="2041" height="1647" alt="Screenshot 2025-10-22 at 13 43 04" src="https://github.com/user-attachments/assets/d1830b1b-26b0-4ce6-993b-bcda786c2f8f" />

---

All labels and the index symbol table

<img width="2065" height="1160" alt="Screenshot 2025-10-22 at 13 43 18" src="https://github.com/user-attachments/assets/2cfc2885-5453-45ec-87c1-b882943ad340" />

<img width="2035" height="749" alt="Screenshot 2025-10-22 at 13 43 24" src="https://github.com/user-attachments/assets/847deee7-478b-4ad8-95b8-045415727662" />
