### PR TITLE
fix panic in ad-hoc profile upload

### DIFF
--- a/pkg/og/structs/flamebearer/convert/convert.go
+++ b/pkg/og/structs/flamebearer/convert/convert.go
@@ -197,6 +197,10 @@ func getProfileType(name string, sampleType int, p *profilev1.Profile) (*typesv1
 		return nil, fmt.Errorf("invalid sampleID: %d", sampleType)
 	}
 
+	if p.PeriodType == nil {
+		return nil, fmt.Errorf("PeriodType is nil")
+	}
+
 	invalidStr := func(i int) bool {
 		return i < 0 || i > len(p.StringTable)
 	}


### PR DESCRIPTION
addresses the following panic:

```
	github.com/grafana/pyroscope/pkg/adhocprofiles/adhocprofiles.go:109 +0x2cb
github.com/grafana/pyroscope/pkg/adhocprofiles.(*AdHocProfiles).Upload(0xc0009cd340, {0x41572f0, 0xc00059f2c0}, 0xc0013ebe00)
	github.com/grafana/pyroscope/pkg/adhocprofiles/adhocprofiles.go:268 +0x105
github.com/grafana/pyroscope/pkg/adhocprofiles.parse(0xc000ac2c00, 0x0, 0x2000)
	github.com/grafana/pyroscope/pkg/og/structs/flamebearer/convert/convert.go:64 +0xa3
github.com/grafana/pyroscope/pkg/og/structs/flamebearer/convert.FlamebearerFromFile({{0xc0009b1420, 0xe}, {0x0, 0x0}, {{0x0, 0x0}, {0x0, 0x0}}, {0xc0008f8600, 0x1092, ...}}, ...)
	github.com/grafana/pyroscope/pkg/og/structs/flamebearer/convert/convert.go:75 +0x36
github.com/grafana/pyroscope/pkg/og/structs/flamebearer/convert.Converter.func1({0xc0008f8600?, 0xe?, 0x0?}, {0xc0009b1420?, 0x0?}, 0x0?)
	github.com/grafana/pyroscope/pkg/og/structs/flamebearer/convert/convert.go:273 +0x40d
github.com/grafana/pyroscope/pkg/og/structs/flamebearer/convert.PprofToProfile({0xc0008f8600, 0x1092, 0x1092}, {0xc0009b1420, 0xe}, 0x2000)
	github.com/grafana/pyroscope/pkg/og/structs/flamebearer/convert/convert.go:203 +0xf5
github.com/grafana/pyroscope/pkg/og/structs/flamebearer/convert.getProfileType({0xc0009b1420, 0xe}, 0x0, 0xc000ac2720)
	runtime/panic.go:792 +0x132
panic({0x2d2faa0?, 0x5f6fe40?})
	github.com/grafana/pyroscope/pkg/util/recovery.go:80 +0x2f
github.com/grafana/pyroscope/pkg/util.(*recoveryInterceptor).WrapUnary.recoveryInterceptor.WrapUnary.func1.1()
	github.com/grafana/pyroscope/pkg/util/recovery.go:46 +0x4d
github.com/grafana/pyroscope/pkg/util.PanicError({0x2d2faa0, 0x5f6fe40})
panic: runtime error: invalid memory address or nil pointer dereference
```