### PR TITLE
feat(v2): add admin page for inspecting the symbols db

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -308,6 +308,7 @@ type AdminService interface {
 	ProfileDownloadHandler(w http.ResponseWriter, r *http.Request)
 	ProfileCallTreeHandler(w http.ResponseWriter, r *http.Request)
 	DatasetTSDBIndexHandler(w http.ResponseWriter, r *http.Request)
+	DatasetSymbolsHandler(w http.ResponseWriter, r *http.Request)
 }
 
 func (a *API) RegisterAdmin(ad AdminService) {
@@ -319,6 +320,7 @@ func (a *API) RegisterAdmin(ad AdminService) {
 	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles/download", http.HandlerFunc(ad.ProfileDownloadHandler), a.registerOptionsPublicAccess()...)
 	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/profiles/call-tree", http.HandlerFunc(ad.ProfileCallTreeHandler), a.registerOptionsPublicAccess()...)
 	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/index", http.HandlerFunc(ad.DatasetTSDBIndexHandler), a.registerOptionsPublicAccess()...)
+	a.RegisterRoute("/ops/object-store/tenants/{tenant}/blocks/{block}/datasets/symbols", http.HandlerFunc(ad.DatasetSymbolsHandler), a.registerOptionsPublicAccess()...)
 
 	a.indexPage.AddLinks(defaultWeight, "Admin", []IndexPageLink{
 		{Desc: "Object Storage Tenants & Blocks", Path: "/ops/object-store/tenants"},

--- a/pkg/operations/admin.go
+++ b/pkg/operations/admin.go
@@ -65,3 +65,7 @@ func (a *Admin) ProfileCallTreeHandler(w http.ResponseWriter, r *http.Request) {
 func (a *Admin) DatasetTSDBIndexHandler(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "Dataset TSDB index not available in v1 storage", http.StatusNotFound)
 }
+
+func (a *Admin) DatasetSymbolsHandler(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "Dataset symbols not available in v1 storage", http.StatusNotFound)
+}

--- a/pkg/operations/v2/admin.go
+++ b/pkg/operations/v2/admin.go
@@ -65,3 +65,7 @@ func (a *Admin) ProfileCallTreeHandler(w http.ResponseWriter, r *http.Request) {
 func (a *Admin) DatasetTSDBIndexHandler(w http.ResponseWriter, r *http.Request) {
 	a.handlers.CreateDatasetTSDBIndexHandler()(w, r)
 }
+
+func (a *Admin) DatasetSymbolsHandler(w http.ResponseWriter, r *http.Request) {
+	a.handlers.CreateDatasetSymbolsHandler()(w, r)
+}

--- a/pkg/operations/v2/model.go
+++ b/pkg/operations/v2/model.go
@@ -179,6 +179,70 @@ type datasetIndexPageContent struct {
 	Now         string
 }
 
+type symbolsInfo struct {
+	Strings        []symbolEntry
+	TotalStrings   int
+	Functions      []functionEntry
+	TotalFunctions int
+	Locations      []locationEntry
+	TotalLocations int
+	Mappings       []mappingEntry
+	TotalMappings  int
+}
+
+type symbolEntry struct {
+	Index  int
+	Symbol string
+}
+
+type functionEntry struct {
+	Index      int
+	ID         uint64
+	Name       string
+	SystemName string
+	Filename   string
+	StartLine  uint32
+}
+
+type locationLine struct {
+	FunctionName string
+	Line         int64
+}
+
+type locationEntry struct {
+	Index     int
+	ID        uint64
+	Address   uint64
+	MappingID uint32
+	Lines     []locationLine
+}
+
+type mappingEntry struct {
+	Index       int
+	ID          uint64
+	MemoryStart uint64
+	MemoryLimit uint64
+	FileOffset  uint64
+	Filename    string
+	BuildID     string
+}
+
+type datasetSymbolsPageContent struct {
+	User        string
+	BlockID     string
+	Shard       uint32
+	BlockTenant string
+	Dataset     *datasetDetails
+	Symbols     *symbolsInfo
+	Page        int
+	PageSize    int
+	TotalPages  int
+	HasPrevPage bool
+	HasNextPage bool
+	Tab         string
+	Now         string
+}
+
 const emptyDatasetPlaceholder = "_empty"
 
 type datasetRequest struct {

--- a/pkg/operations/v2/pages.go
+++ b/pkg/operations/v2/pages.go
@@ -30,6 +30,9 @@ var paginationHtml string
 //go:embed tool.blocks.dataset.index.gohtml
 var datasetIndexPageHtml string
 
+//go:embed tool.blocks.dataset.symbols.gohtml
+var datasetSymbolsPageHtml string
+
 type indexPageContent struct {
 	Users []string
 	Now   string
@@ -83,6 +86,7 @@ type templates struct {
 	datasetProfilesTemplate *template.Template
 	profileCallTreeTemplate *template.Template
 	datasetIndexTemplate    *template.Template
+	datasetSymbolsTemplate  *template.Template
 }
 
 var pageTemplates = initTemplates()
@@ -120,6 +124,14 @@ func initTemplates() *templates {
 	template.Must(profileCallTreeTemplate.Parse(profileCallTreePageHtml))
 	datasetIndexTemplate := template.New("dataset-index")
 	template.Must(datasetIndexTemplate.Parse(datasetIndexPageHtml))
+	datasetSymbolsTemplate := template.New("dataset-symbols").Funcs(template.FuncMap{
+		"add":  add,
+		"mul":  mul,
+		"seq":  seq,
+		"dict": dict,
+	})
+	template.Must(datasetSymbolsTemplate.Parse(paginationHtml))
+	template.Must(datasetSymbolsTemplate.Parse(datasetSymbolsPageHtml))
 	t := &templates{
 		indexTemplate:           indexTemplate,
 		blocksTemplate:          blocksTemplate,
@@ -128,6 +140,7 @@ func initTemplates() *templates {
 		datasetProfilesTemplate: datasetProfilesTemplate,
 		profileCallTreeTemplate: profileCallTreeTemplate,
 		datasetIndexTemplate:    datasetIndexTemplate,
+		datasetSymbolsTemplate:  datasetSymbolsTemplate,
 	}
 	return t
 }

--- a/pkg/operations/v2/tool.blocks.dataset.gohtml
+++ b/pkg/operations/v2/tool.blocks.dataset.gohtml
@@ -153,6 +153,20 @@
                         </div>
                     </div>
                 </div>
+                <div class="col-md-4 mb-3">
+                    <div class="card bg-dark border-secondary h-100">
+                        <div class="card-body d-flex flex-column">
+                            <h5 class="card-title">
+                                <i class="bi bi-code-slash"></i> Symbols
+                            </h5>
+                            <p class="card-text">Explore the symbols table used for profile stack traces.</p>
+                            <a href="/ops/object-store/tenants/{{ .User }}/blocks/{{ .BlockID }}/datasets/symbols?dataset={{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ .Shard }}&block_tenant={{ .BlockTenant }}"
+                               class="btn btn-primary mt-auto">
+                                View Symbols
+                            </a>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/pkg/operations/v2/tool.blocks.dataset.symbols.gohtml
+++ b/pkg/operations/v2/tool.blocks.dataset.symbols.gohtml
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html class="h-100" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <title>Bucket Blocks Explorer (v2): Dataset Symbols</title>
+
+    <link rel="stylesheet" href="/static/bootstrap-5.3.3.min.css">
+    <link rel="stylesheet" href="/static/bootstrap-icons-1.8.1.css">
+    <link rel="stylesheet" href="/static/pyroscope-styles.css">
+    <script src="/static/bootstrap-5.3.3.bundle.min.js"></script>
+</head>
+<body class="d-flex flex-column h-100">
+<main class="flex-shrink-0">
+    <div class="container">
+        <div class="header row border-bottom py-3 flex-column-reverse flex-sm-row">
+            <div class="col-12 col-sm-9 text-center text-sm-start">
+                <h3>Bucket Blocks Explorer (v2): Dataset Symbols</h3>
+            </div>
+            <div class="col-12 col-sm-3 text-center text-sm-end mb-3 mb-sm-0">
+                <a href="/ops/object-store/tenants">
+                    <img alt="Pyroscope logo" class="pyroscope-brand" src="/static/pyroscope-logo.png">
+                </a>
+            </div>
+        </div>
+        <div class="row my-3">
+            <p>
+                <a href="/ops/object-store/tenants/{{ .User }}/blocks/{{ .BlockID }}/datasets?dataset={{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ .Shard }}&block_tenant={{ .BlockTenant }}">Back to dataset</a>
+            </p>
+
+            <div class="card bg-dark border-secondary info-card mb-3">
+                <div class="card-header">
+                    <h5 class="mb-0">Dataset Information</h5>
+                </div>
+                <div class="card-body">
+                    <ul>
+                        <li>Dataset Name: {{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}<em>(empty)</em>{{ end }}</li>
+                        <li>Dataset Tenant: {{ .Dataset.Tenant }}</li>
+                        <li>Block ID: {{ .BlockID }}</li>
+                        <li>Shard: {{ .Shard }}</li>
+                    </ul>
+                </div>
+            </div>
+
+            <ul class="nav nav-tabs mb-3" id="symbolsTabs" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link {{ if eq .Tab "strings" }}active{{ end }}" href="?dataset={{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ .Shard }}&block_tenant={{ .BlockTenant }}&tab=strings&page=1&page_size={{ .PageSize }}">
+                        Strings ({{ .Symbols.TotalStrings }})
+                    </a>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link {{ if eq .Tab "functions" }}active{{ end }}" href="?dataset={{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ .Shard }}&block_tenant={{ .BlockTenant }}&tab=functions&page=1&page_size={{ .PageSize }}">
+                        Functions ({{ .Symbols.TotalFunctions }})
+                    </a>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link {{ if eq .Tab "locations" }}active{{ end }}" href="?dataset={{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ .Shard }}&block_tenant={{ .BlockTenant }}&tab=locations&page=1&page_size={{ .PageSize }}">
+                        Locations ({{ .Symbols.TotalLocations }})
+                    </a>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <a class="nav-link {{ if eq .Tab "mappings" }}active{{ end }}" href="?dataset={{ if .Dataset.Name }}{{ .Dataset.Name }}{{ else }}_empty{{ end }}&shard={{ .Shard }}&block_tenant={{ .BlockTenant }}&tab=mappings&page=1&page_size={{ .PageSize }}">
+                        Mappings ({{ .Symbols.TotalMappings }})
+                    </a>
+                </li>
+            </ul>
+
+            <div class="tab-content" id="symbolsTabContent">
+                {{ if eq .Tab "strings" }}
+                <div class="tab-pane fade show active" id="strings" role="tabpanel">
+                    <div class="d-flex justify-content-between align-items-center mt-3 mb-3">
+                        <h5 class="mb-0">Strings</h5>
+                        <div class="text-muted">
+                            {{ if gt .Symbols.TotalStrings 0 }}
+                                Showing {{ add (mul (add .Page -1) .PageSize) 1 }}-{{ if lt (mul .Page .PageSize) .Symbols.TotalStrings }}{{ mul .Page .PageSize }}{{ else }}{{ .Symbols.TotalStrings }}{{ end }} of {{ .Symbols.TotalStrings }}
+                            {{ end }}
+                        </div>
+                    </div>
+
+                    {{ if gt .TotalPages 1 }}
+                    <div class="mb-3">
+                        {{ $datasetName := "_empty" }}
+                        {{ if .Dataset.Name }}{{ $datasetName = .Dataset.Name }}{{ end }}
+                        {{ template "pagination" dict "BaseURL" (printf "?dataset=%s&shard=%d&block_tenant=%s&tab=strings" $datasetName .Shard .BlockTenant) "Page" .Page "PageSize" .PageSize "TotalPages" .TotalPages "HasPrevPage" .HasPrevPage "HasNextPage" .HasNextPage }}
+                    </div>
+                    {{ end }}
+
+                    <div class="table-responsive">
+                        <table class="table table-sm table-dark table-striped">
+                            <thead>
+                                <tr>
+                                    <th style="width: 100px;">Index</th>
+                                    <th>String</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {{ range .Symbols.Strings }}
+                                <tr>
+                                    <td>{{ .Index }}</td>
+                                    <td><code class="text-break">{{ .Symbol }}</code></td>
+                                </tr>
+                                {{ end }}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {{ if gt .TotalPages 1 }}
+                        {{ $datasetName := "_empty" }}
+                        {{ if .Dataset.Name }}{{ $datasetName = .Dataset.Name }}{{ end }}
+                        {{ template "pagination" dict "BaseURL" (printf "?dataset=%s&shard=%d&block_tenant=%s&tab=strings" $datasetName .Shard .BlockTenant) "Page" .Page "PageSize" .PageSize "TotalPages" .TotalPages "HasPrevPage" .HasPrevPage "HasNextPage" .HasNextPage }}
+                    {{ end }}
+                </div>
+                {{ end }}
+
+                {{ if eq .Tab "functions" }}
+                <div class="tab-pane fade show active" id="functions" role="tabpanel">
+                    <div class="d-flex justify-content-between align-items-center mt-3 mb-3">
+                        <h5 class="mb-0">Functions</h5>
+                        <div class="text-muted">
+                            {{ if gt .Symbols.TotalFunctions 0 }}
+                                Showing {{ add (mul (add .Page -1) .PageSize) 1 }}-{{ if lt (mul .Page .PageSize) .Symbols.TotalFunctions }}{{ mul .Page .PageSize }}{{ else }}{{ .Symbols.TotalFunctions }}{{ end }} of {{ .Symbols.TotalFunctions }}
+                            {{ end }}
+                        </div>
+                    </div>
+
+                    {{ if gt .TotalPages 1 }}
+                    <div class="mb-3">
+                        {{ $datasetName := "_empty" }}
+                        {{ if .Dataset.Name }}{{ $datasetName = .Dataset.Name }}{{ end }}
+                        {{ template "pagination" dict "BaseURL" (printf "?dataset=%s&shard=%d&block_tenant=%s&tab=functions" $datasetName .Shard .BlockTenant) "Page" .Page "PageSize" .PageSize "TotalPages" .TotalPages "HasPrevPage" .HasPrevPage "HasNextPage" .HasNextPage }}
+                    </div>
+                    {{ end }}
+
+                    <div class="table-responsive">
+                        <table class="table table-sm table-dark table-striped">
+                            <thead>
+                                <tr>
+                                    <th style="width: 80px;">Index</th>
+                                    <th style="width: 100px;">ID</th>
+                                    <th>Name</th>
+                                    <th>System Name</th>
+                                    <th>Filename</th>
+                                    <th style="width: 100px;">Line</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {{ range .Symbols.Functions }}
+                                <tr>
+                                    <td>{{ .Index }}</td>
+                                    <td>{{ .ID }}</td>
+                                    <td><code class="text-break small">{{ .Name }}</code></td>
+                                    <td><code class="text-break small">{{ .SystemName }}</code></td>
+                                    <td><code class="text-break small">{{ .Filename }}</code></td>
+                                    <td>{{ .StartLine }}</td>
+                                </tr>
+                                {{ end }}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {{ if gt .TotalPages 1 }}
+                        {{ $datasetName := "_empty" }}
+                        {{ if .Dataset.Name }}{{ $datasetName = .Dataset.Name }}{{ end }}
+                        {{ template "pagination" dict "BaseURL" (printf "?dataset=%s&shard=%d&block_tenant=%s&tab=functions" $datasetName .Shard .BlockTenant) "Page" .Page "PageSize" .PageSize "TotalPages" .TotalPages "HasPrevPage" .HasPrevPage "HasNextPage" .HasNextPage }}
+                    {{ end }}
+                </div>
+                {{ end }}
+
+                {{ if eq .Tab "locations" }}
+                <div class="tab-pane fade show active" id="locations" role="tabpanel">
+                    <div class="d-flex justify-content-between align-items-center mt-3 mb-3">
+                        <h5 class="mb-0">Locations</h5>
+                        <div class="text-muted">
+                            {{ if gt .Symbols.TotalLocations 0 }}
+                                Showing {{ add (mul (add .Page -1) .PageSize) 1 }}-{{ if lt (mul .Page .PageSize) .Symbols.TotalLocations }}{{ mul .Page .PageSize }}{{ else }}{{ .Symbols.TotalLocations }}{{ end }} of {{ .Symbols.TotalLocations }}
+                            {{ end }}
+                        </div>
+                    </div>
+
+                    {{ if gt .TotalPages 1 }}
+                    <div class="mb-3">
+                        {{ $datasetName := "_empty" }}
+                        {{ if .Dataset.Name }}{{ $datasetName = .Dataset.Name }}{{ end }}
+                        {{ template "pagination" dict "BaseURL" (printf "?dataset=%s&shard=%d&block_tenant=%s&tab=locations" $datasetName .Shard .BlockTenant) "Page" .Page "PageSize" .PageSize "TotalPages" .TotalPages "HasPrevPage" .HasPrevPage "HasNextPage" .HasNextPage }}
+                    </div>
+                    {{ end }}
+
+                    <div class="table-responsive">
+                        <table class="table table-sm table-dark table-striped">
+                            <thead>
+                                <tr>
+                                    <th style="width: 80px;">Index</th>
+                                    <th style="width: 100px;">ID</th>
+                                    <th style="width: 150px;">Address</th>
+                                    <th style="width: 100px;">Mapping</th>
+                                    <th>Lines (Function @ Line)</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {{ range .Symbols.Locations }}
+                                <tr>
+                                    <td>{{ .Index }}</td>
+                                    <td>{{ .ID }}</td>
+                                    <td><code>0x{{ printf "%x" .Address }}</code></td>
+                                    <td>{{ .MappingID }}</td>
+                                    <td>
+                                        {{ if .Lines }}
+                                            {{ range $i, $line := .Lines }}
+                                                {{ if $i }}<br>{{ end }}<code class="small">{{ $line.FunctionName }}</code>{{ if gt $line.Line 0 }} @ L{{ $line.Line }}{{ end }}
+                                            {{ end }}
+                                        {{ else }}
+                                            <em>none</em>
+                                        {{ end }}
+                                    </td>
+                                </tr>
+                                {{ end }}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {{ if gt .TotalPages 1 }}
+                        {{ $datasetName := "_empty" }}
+                        {{ if .Dataset.Name }}{{ $datasetName = .Dataset.Name }}{{ end }}
+                        {{ template "pagination" dict "BaseURL" (printf "?dataset=%s&shard=%d&block_tenant=%s&tab=locations" $datasetName .Shard .BlockTenant) "Page" .Page "PageSize" .PageSize "TotalPages" .TotalPages "HasPrevPage" .HasPrevPage "HasNextPage" .HasNextPage }}
+                    {{ end }}
+                </div>
+                {{ end }}
+
+                {{ if eq .Tab "mappings" }}
+                <div class="tab-pane fade show active" id="mappings" role="tabpanel">
+                    <div class="d-flex justify-content-between align-items-center mt-3 mb-3">
+                        <h5 class="mb-0">Mappings</h5>
+                        <div class="text-muted">
+                            {{ if gt .Symbols.TotalMappings 0 }}
+                                Showing {{ add (mul (add .Page -1) .PageSize) 1 }}-{{ if lt (mul .Page .PageSize) .Symbols.TotalMappings }}{{ mul .Page .PageSize }}{{ else }}{{ .Symbols.TotalMappings }}{{ end }} of {{ .Symbols.TotalMappings }}
+                            {{ end }}
+                        </div>
+                    </div>
+
+                    {{ if gt .TotalPages 1 }}
+                    <div class="mb-3">
+                        {{ $datasetName := "_empty" }}
+                        {{ if .Dataset.Name }}{{ $datasetName = .Dataset.Name }}{{ end }}
+                        {{ template "pagination" dict "BaseURL" (printf "?dataset=%s&shard=%d&block_tenant=%s&tab=mappings" $datasetName .Shard .BlockTenant) "Page" .Page "PageSize" .PageSize "TotalPages" .TotalPages "HasPrevPage" .HasPrevPage "HasNextPage" .HasNextPage }}
+                    </div>
+                    {{ end }}
+
+                    <div class="table-responsive">
+                        <table class="table table-sm table-dark table-striped">
+                            <thead>
+                                <tr>
+                                    <th style="width: 80px;">Index</th>
+                                    <th style="width: 100px;">ID</th>
+                                    <th style="width: 150px;">Memory Range</th>
+                                    <th style="width: 120px;">File Offset</th>
+                                    <th>Filename</th>
+                                    <th>Build ID</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {{ range .Symbols.Mappings }}
+                                <tr>
+                                    <td>{{ .Index }}</td>
+                                    <td>{{ .ID }}</td>
+                                    <td><code class="small">0x{{ printf "%x" .MemoryStart }}-0x{{ printf "%x" .MemoryLimit }}</code></td>
+                                    <td><code class="small">0x{{ printf "%x" .FileOffset }}</code></td>
+                                    <td><code class="text-break small">{{ .Filename }}</code></td>
+                                    <td><code class="text-break small">{{ .BuildID }}</code></td>
+                                </tr>
+                                {{ end }}
+                            </tbody>
+                        </table>
+                    </div>
+
+                    {{ if gt .TotalPages 1 }}
+                        {{ $datasetName := "_empty" }}
+                        {{ if .Dataset.Name }}{{ $datasetName = .Dataset.Name }}{{ end }}
+                        {{ template "pagination" dict "BaseURL" (printf "?dataset=%s&shard=%d&block_tenant=%s&tab=mappings" $datasetName .Shard .BlockTenant) "Page" .Page "PageSize" .PageSize "TotalPages" .TotalPages "HasPrevPage" .HasPrevPage "HasNextPage" .HasNextPage }}
+                    {{ end }}
+                </div>
+                {{ end }}
+            </div>
+        </div>
+    </div>
+</main>
+<footer class="footer mt-auto py-3 bg-dark">
+    <div class="container">
+        <small class="text-white-50">Status @ {{ .Now }}</small>
+    </div>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
Follow-up to #4555, #4543 and #4480, this adds a page for inspecting the symbols DB for a dataset. Also part of https://github.com/grafana/pyroscope-squad/issues/213

Entrypoint:

<img width="1999" height="1028" alt="Screenshot 2025-10-23 at 09 05 49" src="https://github.com/user-attachments/assets/0f6ace74-5538-4fb1-9461-4ada65f9573c" />

---

Strings

<img width="2037" height="1280" alt="Screenshot 2025-10-23 at 09 06 00" src="https://github.com/user-attachments/assets/7d229223-df2e-4e92-bb19-7c48ca2fcca1" />

---

Functions

<img width="2014" height="796" alt="Screenshot 2025-10-23 at 09 06 15" src="https://github.com/user-attachments/assets/58273e93-a5fa-4ec8-af3d-14dcb52f4827" />

---

Locations

<img width="2048" height="758" alt="Screenshot 2025-10-23 at 09 06 21" src="https://github.com/user-attachments/assets/80ca4f98-60e4-409d-9318-20078e25d16f" />

---

Mappings

<img width="2048" height="417" alt="Screenshot 2025-10-23 at 09 06 27" src="https://github.com/user-attachments/assets/1270bc5b-a633-4d49-9d6a-b755f9b7ac31" />
