### PR TITLE
fix(api): add ingest limits to connect push requests

### DIFF
--- a/pkg/api/connect_options.go
+++ b/pkg/api/connect_options.go
@@ -2,12 +2,12 @@ package api
 
 import (
 	"connectrpc.com/connect"
-	"github.com/grafana/pyroscope/pkg/tenant"
-	"github.com/grafana/pyroscope/pkg/validation"
 
 	connectapi "github.com/grafana/pyroscope/pkg/api/connect"
+	"github.com/grafana/pyroscope/pkg/tenant"
 	"github.com/grafana/pyroscope/pkg/util"
 	"github.com/grafana/pyroscope/pkg/util/delayhandler"
+	"github.com/grafana/pyroscope/pkg/validation"
 )
 
 func connectInterceptorRecovery() connect.HandlerOption {


### PR DESCRIPTION
There are ingestion body size limits in the `/ingest` handler. This PR brings the same limit to the `Push` api.

It does not support per-tenant overrides for now, only defaults.
I could not find how to implement per tenant limits as the connect interceptor seem to be late and already read and deserialized the message.
We can probably try to do something like this https://github.com/grafana/pyroscope/commit/ba4c2a66940a010d2007961d2c983898ac1a1fd7 , but I don't like this option much, so for now not use it.