### PR TITLE
fix: Add `profile_name` label to Speedscope profile ingestion

### DIFF
--- a/pkg/og/convert/speedscope/parser.go
+++ b/pkg/og/convert/speedscope/parser.go
@@ -70,6 +70,13 @@ func parseOne(prof *profile, putInput storage.PutInput, frames []frame, multi bo
 		putInput.LabelSet = prof.Unit.chooseKey(putInput.LabelSet)
 	}
 
+	// This label is important to prevent all speedscope profiles
+	// from the same ingestion upload being deduped during compaction.
+	// Currently, all profiles are associated with the same timestamp
+	// from `putInput`. Since profiles are deduped over label set + timestamp,
+	// this label prevents unintended downstream deduping.
+	putInput.LabelSet.Add("profile_name", prof.Name)
+
 	// TODO(petethepig): We need a way to tell if it's a default or a value set by user
 	//   See https://github.com/pyroscope-io/pyroscope/issues/1598
 	if putInput.SampleRate == 100 {

--- a/pkg/og/convert/speedscope/speedscope_test.go
+++ b/pkg/og/convert/speedscope/speedscope_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Speedscope", func() {
 		input := ingester.actual[0]
 
 		Expect(input.Units).To(Equal(metadata.SamplesUnits))
-		Expect(input.LabelSet.Normalized()).To(Equal("foo{}"))
+		Expect(input.LabelSet.Normalized()).To(Equal("foo{profile_name=simple.txt}"))
 		expectedResult := `a;b 500
 a;b;c 500
 a;b;d 400
@@ -67,12 +67,18 @@ a;b;d 400
 
 		input := ingester.actual[0]
 		Expect(input.Units).To(Equal(metadata.SamplesUnits))
-		Expect(input.LabelSet.Normalized()).To(Equal("foo.seconds{x=y}"))
+		Expect(input.LabelSet.Normalized()).To(Equal("foo.seconds{profile_name=one,x=y}"))
 		expectedResult := `a;b 500
 a;b;c 500
 a;b;d 400
 `
 		Expect(input.Val.String()).To(Equal(expectedResult))
 		Expect(input.SampleRate).To(Equal(uint32(100)))
+
+		input2 := ingester.actual[1]
+		Expect(input2.Units).To(Equal(metadata.SamplesUnits))
+		Expect(input2.LabelSet.Normalized()).To(Equal("foo.seconds{profile_name=two,x=y}"))
+		Expect(input2.Val.String()).To(Equal(expectedResult))
+		Expect(input2.SampleRate).To(Equal(uint32(100)))
 	})
 })


### PR DESCRIPTION
This label is important to prevent all speedscope profiles from the same ingestion upload being deduped during compaction

Fixes https://github.com/grafana/pyroscope/issues/4584