### PR TITLE
doc: link to correct layer of directory

### DIFF
--- a/docs/sources/view-and-analyze-profile-data/line-by-line.md
+++ b/docs/sources/view-and-analyze-profile-data/line-by-line.md
@@ -16,7 +16,7 @@ Using this app, you can map your code directly within Grafana and visualize reso
 With these powerful capabilities, you can gain deep insights into your code's execution and identify performance bottlenecks.
 
 Every profile type works for the integration for code written in Go.
-For information on profile types and the profiles available with Go, refer to [Profiling types and their uses](../introduction/profiling-types/).
+For information on profile types and the profiles available with Go, refer to [Profiling types and their uses](../../introduction/profiling-types/).
 
 ![Example of a flame graph with the function details populated](/media/docs/grafana-cloud/profiles/screenshot-profiles-github-integration.png)
 


### PR DESCRIPTION
## Issue:
Incorrect link in the page `docs/pyroscope/latest/view-and-analyze-profile-data/line-by-line/`.

## Changes:
The existing link to `../introduction/profiling-types/` is broken due to an incorrect relative path.
Updated the link to point to the correct location: `../../introduction/profiling-types/`.

## How to test?
1. In local machine, use the command `make docs/docs`.
2. Navigate to the localhost from the console output: `http://localhost:3002/docs/pyroscope/latest/view-and-analyze-profile-data/line-by-line/` and check the corresponding link.
3. Output:
- Expected behavior: it will redirect users to `http://localhost:3002/docs/pyroscope/latest/introduction/profiling-types/`.
- Original behavior: it will redirect to non-exist blank page(status: 404).
