### PR TITLE
fix: Source code module path parsing

### DIFF
--- a/pkg/frontend/vcs/source/golang/modules.go
+++ b/pkg/frontend/vcs/source/golang/modules.go
@@ -43,6 +43,12 @@ func ParseModuleFromPath(path string) (Module, bool) {
 	}
 	filePath := parts[1][first+1:]
 	modulePath := parts[0]
+
+	// The go mod folder typically starts with "pkg/mod". If that segment can be found, shorten the module path, so no other folders with dots get accidentally picked up.
+	if pos := strings.Index(modulePath, "/pkg/mod/"); pos > 0 {
+		modulePath = modulePath[pos:]
+	}
+
 	// searching for the first domain name
 	domainParts := strings.Split(modulePath, "/")
 	for i, part := range domainParts {

--- a/pkg/frontend/vcs/source/golang/modules_test.go
+++ b/pkg/frontend/vcs/source/golang/modules_test.go
@@ -104,6 +104,28 @@ func TestParseModulePath(t *testing.T) {
 			false,
 			Module{},
 		},
+		{
+			"/Users/pyroscope/.golang/packages/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.6.darwin-arm64/src/net/http/server.go",
+			true,
+			Module{
+				Version: module.Version{
+					Path:    "golang.org/toolchain",
+					Version: "v0.0.1-go1.24.6.darwin-arm64",
+				},
+				FilePath: "src/net/http/server.go",
+			},
+		},
+		{
+			"/Users/pyroscope/.golang/packages/pkg/mod/github.com/opentracing-contrib/go-stdlib@v1.0.0/nethttp/server.go",
+			true,
+			Module{
+				Version: module.Version{
+					Path:    "github.com/opentracing-contrib/go-stdlib",
+					Version: "v1.0.0",
+				},
+				FilePath: "nethttp/server.go",
+			},
+		},
 	} {
 		t.Run(tt.input, func(t *testing.T) {
 			mod, ok := ParseModuleFromPath(tt.input)


### PR DESCRIPTION
If a folder contained a dot (e.g. `/home/christian/.golang/[...]`), it would be wrongly picked up as module path domain. This will ensure we trim this part before the actual go mod folder.
