### PR TITLE
vcs: Allow to provide functionName to the GetFile API

### DIFF
--- a/api/connect-openapi/gen/vcs/v1/vcs.openapi.yaml
+++ b/api/connect-openapi/gen/vcs/v1/vcs.openapi.yaml
@@ -409,6 +409,10 @@ components:
           type: string
           title: rootPath
           description: the root path where the project lives inside the repository
+        functionName:
+          type: string
+          title: functionName
+          description: the function name as provided by the symbols
       title: GetFileRequest
       additionalProperties: false
     vcs.v1.GetFileResponse:
@@ -435,8 +439,8 @@ components:
           type: string
           title: clientID
           description: |-
-            clientID must be propagated when calling https://github.com/login/oauth/authorize
-             in the client_id query parameter.
+            clientID must be propagated when calling
+             https://github.com/login/oauth/authorize in the client_id query parameter.
         callbackURL:
           type: string
           title: callbackURL
@@ -462,10 +466,11 @@ components:
           title: cookie
           description: |-
             Deprecated
-             In future version, this cookie won't be sent. Now, old cookie is sent alongside the new expected
-             data (token, token_expires_at and refresh_token_expires_at). Frontend will be responsible of computing
-             its own cookie from the new data.
-             Remove after completing https://github.com/grafana/explore-profiles/issues/187
+             In future version, this cookie won't be sent. Now, old cookie is sent
+             alongside the new expected data (token, token_expires_at and
+             refresh_token_expires_at). Frontend will be responsible of computing its
+             own cookie from the new data. Remove after completing
+             https://github.com/grafana/explore-profiles/issues/187
         token:
           type: string
           title: token
@@ -498,10 +503,11 @@ components:
           title: cookie
           description: |-
             Deprecated
-             In future version, this cookie won't be sent. Now, old cookie is sent alongside the new expected
-             data (token, token_expires_at and refresh_token_expires_at). Frontend will be responsible of computing
-             its own cookie from the new data.
-             Remove after completing https://github.com/grafana/explore-profiles/issues/187
+             In future version, this cookie won't be sent. Now, old cookie is sent
+             alongside the new expected data (token, token_expires_at and
+             refresh_token_expires_at). Frontend will be responsible of computing its
+             own cookie from the new data. Remove after completing
+             https://github.com/grafana/explore-profiles/issues/187
         token:
           type: string
           title: token

--- a/api/gen/proto/go/vcs/v1/vcs.pb.go
+++ b/api/gen/proto/go/vcs/v1/vcs.pb.go
@@ -59,8 +59,8 @@ func (*GithubAppRequest) Descriptor() ([]byte, []int) {
 
 type GithubAppResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// clientID must be propagated when calling https://github.com/login/oauth/authorize
-	// in the client_id query parameter.
+	// clientID must be propagated when calling
+	// https://github.com/login/oauth/authorize in the client_id query parameter.
 	ClientID string `protobuf:"bytes,1,opt,name=clientID,proto3" json:"clientID,omitempty"`
 	// If callbackURL is not empty, the URL should be propagated when
 	// calling https://github.com/login/oauth/authorize in the
@@ -161,10 +161,11 @@ func (x *GithubLoginRequest) GetAuthorizationCode() string {
 type GithubLoginResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Deprecated
-	// In future version, this cookie won't be sent. Now, old cookie is sent alongside the new expected
-	// data (token, token_expires_at and refresh_token_expires_at). Frontend will be responsible of computing
-	// its own cookie from the new data.
-	// Remove after completing https://github.com/grafana/explore-profiles/issues/187
+	// In future version, this cookie won't be sent. Now, old cookie is sent
+	// alongside the new expected data (token, token_expires_at and
+	// refresh_token_expires_at). Frontend will be responsible of computing its
+	// own cookie from the new data. Remove after completing
+	// https://github.com/grafana/explore-profiles/issues/187
 	Cookie string `protobuf:"bytes,1,opt,name=cookie,proto3" json:"cookie,omitempty"`
 	// base64 encoded encrypted token
 	Token string `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty"`
@@ -273,10 +274,11 @@ func (*GithubRefreshRequest) Descriptor() ([]byte, []int) {
 type GithubRefreshResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Deprecated
-	// In future version, this cookie won't be sent. Now, old cookie is sent alongside the new expected
-	// data (token, token_expires_at and refresh_token_expires_at). Frontend will be responsible of computing
-	// its own cookie from the new data.
-	// Remove after completing https://github.com/grafana/explore-profiles/issues/187
+	// In future version, this cookie won't be sent. Now, old cookie is sent
+	// alongside the new expected data (token, token_expires_at and
+	// refresh_token_expires_at). Frontend will be responsible of computing its
+	// own cookie from the new data. Remove after completing
+	// https://github.com/grafana/explore-profiles/issues/187
 	Cookie string `protobuf:"bytes,1,opt,name=cookie,proto3" json:"cookie,omitempty"`
 	// base64 encoded encrypted token
 	Token string `protobuf:"bytes,2,opt,name=token,proto3" json:"token,omitempty"`
@@ -355,7 +357,9 @@ type GetFileRequest struct {
 	// the path to the file as provided by the symbols
 	LocalPath string `protobuf:"bytes,3,opt,name=localPath,proto3" json:"localPath,omitempty"`
 	// the root path where the project lives inside the repository
-	RootPath      string `protobuf:"bytes,4,opt,name=rootPath,proto3" json:"rootPath,omitempty"`
+	RootPath string `protobuf:"bytes,4,opt,name=rootPath,proto3" json:"rootPath,omitempty"`
+	// the function name as provided by the symbols
+	FunctionName  string `protobuf:"bytes,5,opt,name=functionName,proto3" json:"functionName,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -414,6 +418,13 @@ func (x *GetFileRequest) GetLocalPath() string {
 func (x *GetFileRequest) GetRootPath() string {
 	if x != nil {
 		return x.RootPath
+	}
+	return ""
+}
+
+func (x *GetFileRequest) GetFunctionName() string {
+	if x != nil {
+		return x.FunctionName
 	}
 	return ""
 }
@@ -860,12 +871,13 @@ const file_vcs_v1_vcs_proto_rawDesc = "" +
 	"\x06cookie\x18\x01 \x01(\tR\x06cookie\x12\x14\n" +
 	"\x05token\x18\x02 \x01(\tR\x05token\x12(\n" +
 	"\x10token_expires_at\x18\x03 \x01(\x03R\x0etokenExpiresAt\x127\n" +
-	"\x18refresh_token_expires_at\x18\x04 \x01(\x03R\x15refreshTokenExpiresAt\"\x82\x01\n" +
+	"\x18refresh_token_expires_at\x18\x04 \x01(\x03R\x15refreshTokenExpiresAt\"\xa6\x01\n" +
 	"\x0eGetFileRequest\x12$\n" +
 	"\rrepositoryURL\x18\x01 \x01(\tR\rrepositoryURL\x12\x10\n" +
 	"\x03ref\x18\x02 \x01(\tR\x03ref\x12\x1c\n" +
 	"\tlocalPath\x18\x03 \x01(\tR\tlocalPath\x12\x1a\n" +
-	"\brootPath\x18\x04 \x01(\tR\brootPath\"=\n" +
+	"\brootPath\x18\x04 \x01(\tR\brootPath\x12\"\n" +
+	"\ffunctionName\x18\x05 \x01(\tR\ffunctionName\"=\n" +
 	"\x0fGetFileResponse\x12\x18\n" +
 	"\acontent\x18\x01 \x01(\tR\acontent\x12\x10\n" +
 	"\x03URL\x18\x02 \x01(\tR\x03URL\"J\n" +

--- a/api/gen/proto/go/vcs/v1/vcs_vtproto.pb.go
+++ b/api/gen/proto/go/vcs/v1/vcs_vtproto.pb.go
@@ -139,6 +139,7 @@ func (m *GetFileRequest) CloneVT() *GetFileRequest {
 	r.Ref = m.Ref
 	r.LocalPath = m.LocalPath
 	r.RootPath = m.RootPath
+	r.FunctionName = m.FunctionName
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -436,6 +437,9 @@ func (this *GetFileRequest) EqualVT(that *GetFileRequest) bool {
 		return false
 	}
 	if this.RootPath != that.RootPath {
+		return false
+	}
+	if this.FunctionName != that.FunctionName {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -1206,6 +1210,13 @@ func (m *GetFileRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.FunctionName) > 0 {
+		i -= len(m.FunctionName)
+		copy(dAtA[i:], m.FunctionName)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.FunctionName)))
+		i--
+		dAtA[i] = 0x2a
+	}
 	if len(m.RootPath) > 0 {
 		i -= len(m.RootPath)
 		copy(dAtA[i:], m.RootPath)
@@ -1733,6 +1744,10 @@ func (m *GetFileRequest) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	l = len(m.RootPath)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.FunctionName)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -2652,6 +2667,38 @@ func (m *GetFileRequest) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.RootPath = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field FunctionName", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.FunctionName = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/api/openapiv2/gen/phlare.swagger.json
+++ b/api/openapiv2/gen/phlare.swagger.json
@@ -1260,7 +1260,7 @@
       "properties": {
         "clientID": {
           "type": "string",
-          "description": "clientID must be propagated when calling https://github.com/login/oauth/authorize\nin the client_id query parameter."
+          "description": "clientID must be propagated when calling\nhttps://github.com/login/oauth/authorize in the client_id query parameter."
         },
         "callbackURL": {
           "type": "string",
@@ -1273,7 +1273,7 @@
       "properties": {
         "cookie": {
           "type": "string",
-          "title": "Deprecated\nIn future version, this cookie won't be sent. Now, old cookie is sent alongside the new expected\ndata (token, token_expires_at and refresh_token_expires_at). Frontend will be responsible of computing\nits own cookie from the new data.\nRemove after completing https://github.com/grafana/explore-profiles/issues/187"
+          "title": "Deprecated\nIn future version, this cookie won't be sent. Now, old cookie is sent\nalongside the new expected data (token, token_expires_at and\nrefresh_token_expires_at). Frontend will be responsible of computing its\nown cookie from the new data. Remove after completing\nhttps://github.com/grafana/explore-profiles/issues/187"
         },
         "token": {
           "type": "string",
@@ -1296,7 +1296,7 @@
       "properties": {
         "cookie": {
           "type": "string",
-          "title": "Deprecated\nIn future version, this cookie won't be sent. Now, old cookie is sent alongside the new expected\ndata (token, token_expires_at and refresh_token_expires_at). Frontend will be responsible of computing\nits own cookie from the new data.\nRemove after completing https://github.com/grafana/explore-profiles/issues/187"
+          "title": "Deprecated\nIn future version, this cookie won't be sent. Now, old cookie is sent\nalongside the new expected data (token, token_expires_at and\nrefresh_token_expires_at). Frontend will be responsible of computing its\nown cookie from the new data. Remove after completing\nhttps://github.com/grafana/explore-profiles/issues/187"
         },
         "token": {
           "type": "string",

--- a/api/vcs/v1/vcs.proto
+++ b/api/vcs/v1/vcs.proto
@@ -13,8 +13,8 @@ service VCSService {
 message GithubAppRequest {}
 
 message GithubAppResponse {
-  // clientID must be propagated when calling https://github.com/login/oauth/authorize
-  // in the client_id query parameter.
+  // clientID must be propagated when calling
+  // https://github.com/login/oauth/authorize in the client_id query parameter.
   string clientID = 1;
   // If callbackURL is not empty, the URL should be propagated when
   // calling https://github.com/login/oauth/authorize in the
@@ -28,10 +28,11 @@ message GithubLoginRequest {
 
 message GithubLoginResponse {
   // Deprecated
-  // In future version, this cookie won't be sent. Now, old cookie is sent alongside the new expected
-  // data (token, token_expires_at and refresh_token_expires_at). Frontend will be responsible of computing
-  // its own cookie from the new data.
-  // Remove after completing https://github.com/grafana/explore-profiles/issues/187
+  // In future version, this cookie won't be sent. Now, old cookie is sent
+  // alongside the new expected data (token, token_expires_at and
+  // refresh_token_expires_at). Frontend will be responsible of computing its
+  // own cookie from the new data. Remove after completing
+  // https://github.com/grafana/explore-profiles/issues/187
   string cookie = 1;
   // base64 encoded encrypted token
   string token = 2;
@@ -45,10 +46,11 @@ message GithubRefreshRequest {}
 
 message GithubRefreshResponse {
   // Deprecated
-  // In future version, this cookie won't be sent. Now, old cookie is sent alongside the new expected
-  // data (token, token_expires_at and refresh_token_expires_at). Frontend will be responsible of computing
-  // its own cookie from the new data.
-  // Remove after completing https://github.com/grafana/explore-profiles/issues/187
+  // In future version, this cookie won't be sent. Now, old cookie is sent
+  // alongside the new expected data (token, token_expires_at and
+  // refresh_token_expires_at). Frontend will be responsible of computing its
+  // own cookie from the new data. Remove after completing
+  // https://github.com/grafana/explore-profiles/issues/187
   string cookie = 1;
   // base64 encoded encrypted token
   string token = 2;
@@ -67,6 +69,8 @@ message GetFileRequest {
   string localPath = 3;
   // the root path where the project lives inside the repository
   string rootPath = 4;
+  // the function name as provided by the symbols
+  string functionName = 5;
 }
 
 message GetFileResponse {


### PR DESCRIPTION
This allows the backend to make calls which language a particular request is for and avoids adding complexity to the frontend/drilldown.