### PR TITLE
chore: Fix debug image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ docker-image/pyroscope/dlv:
 	# dlv is not intended for local use and is to be installed in the
 	# platform-specific docker image together with the main Pyroscope binary.
 	@mkdir -p $(@D)
-	GOPATH=$(CURDIR)/.tmp GOAMD64=v2 CGO_ENABLED=0 $(GO) install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@v1.23.0
+	GOPATH=$(CURDIR)/.tmp GOAMD64=v2 CGO_ENABLED=0 $(GO) install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@v1.25.2
 	mv $(CURDIR)/.tmp/bin/$(GOOS)_$(GOARCH)/dlv $(CURDIR)/.tmp/bin/dlv
 
 .PHONY: clean

--- a/cmd/pyroscope/debug.Dockerfile
+++ b/cmd/pyroscope/debug.Dockerfile
@@ -5,11 +5,12 @@ SHELL [ "/busybox/sh", "-c" ]
 RUN addgroup -g 10001 -S pyroscope && \
     adduser -u 10001 -S pyroscope -G pyroscope -h /data
 
-# This folder is created by adduser command with right owner/group
+# Ensure folders are created correctly
 VOLUME /data
 VOLUME /data-compactor
 VOLUME /data-metastore
-RUN chown pyroscope:pyroscope /data /data-compactor /data-metastore
+RUN mkdir -p /data /data-compactor /data-metastore && \
+    chown pyroscope:pyroscope /data /data-compactor /data-metastore
 
 COPY .tmp/bin/dlv /usr/bin/dlv
 COPY cmd/pyroscope/pyroscope.yaml /etc/pyroscope/config.yaml


### PR DESCRIPTION
Image was failing to build and the volumes were fixed turned out dlv was outdated for the go version we are using.
