### PR TITLE
fix: preserve original timestamps in exemplars during aggregation

### DIFF
--- a/pkg/model/time_series.go
+++ b/pkg/model/time_series.go
@@ -117,9 +117,6 @@ func (a *sumTimeSeriesAggregator) GetAndReset() *typesv1.Point {
 	var exemplars []*typesv1.Exemplar
 	if len(a.exemplars) > 0 {
 		exemplars = selectTopNExemplarsProto(a.exemplars, a.maxExemplarsPerPoint)
-		for _, ex := range exemplars {
-			ex.Timestamp = tsCopy
-		}
 	}
 
 	a.ts = -1
@@ -167,9 +164,6 @@ func (a *avgTimeSeriesAggregator) GetAndReset() *typesv1.Point {
 	var exemplars []*typesv1.Exemplar
 	if len(a.exemplars) > 0 {
 		exemplars = selectTopNExemplarsProto(a.exemplars, a.maxExemplarsPerPoint)
-		for _, ex := range exemplars {
-			ex.Timestamp = tsCopy
-		}
 	}
 
 	a.ts = -1

--- a/pkg/model/time_series_test.go
+++ b/pkg/model/time_series_test.go
@@ -169,13 +169,13 @@ func Test_RangeSeriesWithExemplars(t *testing.T) {
 		out          []*typesv1.Series
 	}{
 		{
-			name: "exemplar tracking keeps highest value",
+			name: "exemplar timestamps preserved during aggregation",
 			series: []*typesv1.Series{{
 				Labels: []*typesv1.LabelPair{{Name: "service_name", Value: "api"}},
 				Points: []*typesv1.Point{
-					{Timestamp: 1000, Value: 100.0, Exemplars: []*typesv1.Exemplar{{ProfileId: "prof-1", Value: 100, Timestamp: 1000}}},
-					{Timestamp: 1000, Value: 300.0, Exemplars: []*typesv1.Exemplar{{ProfileId: "prof-2", Value: 300, Timestamp: 1000}}},
-					{Timestamp: 2000, Value: 200.0, Exemplars: []*typesv1.Exemplar{{ProfileId: "prof-3", Value: 200, Timestamp: 2000}}},
+					{Timestamp: 947, Value: 100.0, Exemplars: []*typesv1.Exemplar{{ProfileId: "prof-1", Value: 100, Timestamp: 947}}},
+					{Timestamp: 987, Value: 300.0, Exemplars: []*typesv1.Exemplar{{ProfileId: "prof-2", Value: 300, Timestamp: 987}}},
+					{Timestamp: 1847, Value: 200.0, Exemplars: []*typesv1.Exemplar{{ProfileId: "prof-3", Value: 200, Timestamp: 1847}}},
 				},
 			}},
 			start:       1000,
@@ -185,8 +185,8 @@ func Test_RangeSeriesWithExemplars(t *testing.T) {
 			out: []*typesv1.Series{{
 				Labels: []*typesv1.LabelPair{{Name: "service_name", Value: "api"}},
 				Points: []*typesv1.Point{
-					{Timestamp: 1000, Value: 400.0, Annotations: []*typesv1.ProfileAnnotation{}, Exemplars: []*typesv1.Exemplar{{ProfileId: "prof-2", Value: 300, Timestamp: 1000}}},
-					{Timestamp: 2000, Value: 200.0, Annotations: []*typesv1.ProfileAnnotation{}, Exemplars: []*typesv1.Exemplar{{ProfileId: "prof-3", Value: 200, Timestamp: 2000}}},
+					{Timestamp: 1000, Value: 400.0, Annotations: []*typesv1.ProfileAnnotation{}, Exemplars: []*typesv1.Exemplar{{ProfileId: "prof-2", Value: 300, Timestamp: 987}}},
+					{Timestamp: 2000, Value: 200.0, Annotations: []*typesv1.ProfileAnnotation{}, Exemplars: []*typesv1.Exemplar{{ProfileId: "prof-3", Value: 200, Timestamp: 1847}}},
 				},
 			}},
 		},


### PR DESCRIPTION
Closes https://github.com/grafana/pyroscope-squad/issues/650

 
Exemplar timestamps were being overwritten with step-aligned timestamps during aggregation, losing the original profile capture time needed for accurate drill-down.


<img width="1871" height="259" alt="Screenshot 2025-11-25 at 12 28 09" src="https://github.com/user-attachments/assets/513410fb-6310-4560-9016-10382243d69c" />
