### PR TITLE
chore: Update java images from openjdk to sapmachine

### DIFF
--- a/examples/grafana-alloy-auto-instrumentation/java/kubernetes/java-fast-slow.yaml
+++ b/examples/grafana-alloy-auto-instrumentation/java/kubernetes/java-fast-slow.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: java-fast-slow
-          image: openjdk:21-jdk-slim
+          image: sapmachine:21-jdk-headless
           imagePullPolicy: IfNotPresent
           command: [ "java" ]
           args: [ "-jar", "/app/FastSlow.jar" ]

--- a/examples/language-sdk-instrumentation/java/fib/Dockerfile
+++ b/examples/language-sdk-instrumentation/java/fib/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-slim-bullseye
+FROM sapmachine:17-jdk-headless
 
 WORKDIR /opt/app
 

--- a/examples/language-sdk-instrumentation/java/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/java/rideshare/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM openjdk:17-slim-bullseye as builder
+FROM --platform=$BUILDPLATFORM sapmachine:17-jdk-headless AS builder
 
 WORKDIR /opt/app
 
@@ -17,7 +17,7 @@ COPY src src
 RUN ./gradlew assemble --no-daemon
 
 
-FROM  openjdk:17-slim-bullseye
+FROM sapmachine:17-jdk-headless
 
 RUN apt-get update && apt-get install ca-certificates -y && update-ca-certificates
 

--- a/examples/language-sdk-instrumentation/java/simple/Dockerfile
+++ b/examples/language-sdk-instrumentation/java/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11.0.11-jdk
+FROM sapmachine:11-jdk-headless
 
 WORKDIR /opt/app
 

--- a/examples/tracing/java/Dockerfile
+++ b/examples/tracing/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM openjdk:17-slim-bullseye as builder
+FROM --platform=$BUILDPLATFORM sapmachine:17-jdk-headless as builder
 
 WORKDIR /opt/app
 
@@ -17,7 +17,7 @@ COPY src src
 RUN ./gradlew assemble --no-daemon
 
 
-FROM  openjdk:17-slim-bullseye
+FROM sapmachine:17-jdk-headless
 
 RUN apt-get update && apt-get install ca-certificates -y && update-ca-certificates
 


### PR DESCRIPTION
openjdk imags have been retired: https://github.com/docker-library/openjdk
