### PR TITLE
fix: Fetching go stdlib without configs

### DIFF
--- a/pkg/frontend/vcs/config/config.go
+++ b/pkg/frontend/vcs/config/config.go
@@ -173,6 +173,10 @@ type FileSpec struct {
 // FindMapping finds a mapping configuration that matches the given FileSpec
 // Returns nil if no matching mapping is found
 func (c *PyroscopeConfig) FindMapping(file FileSpec) *MappingConfig {
+	if c == nil {
+		return nil
+	}
+
 	// Find the longest matching prefix
 	var bestMatch *MappingConfig
 	var bestMatchLen = -1

--- a/pkg/frontend/vcs/source/find_go.go
+++ b/pkg/frontend/vcs/source/find_go.go
@@ -81,7 +81,7 @@ func (ff FileFinder) fetchGoStdlib(ctx context.Context, path string, version str
 	defer sp.Finish()
 
 	// if there is no version detected, use the one from .pyroscope.yaml
-	if version == "" {
+	if version == "" && ff.config != nil {
 		mapping := ff.config.FindMapping(config.FileSpec{Path: "$GOROOT/src"})
 		if mapping != nil {
 			return ff.fetchMappingFile(ctx, mapping, path)

--- a/pkg/frontend/vcs/source/find_test.go
+++ b/pkg/frontend/vcs/source/find_test.go
@@ -414,15 +414,18 @@ require (
 			mockClient := newMockVCSClient()
 
 			// Populate pyroscopeYAML content into first mock file (if present)
-			mockFiles := append(tt.mockFiles, mockFileResponse{
-				request: client.FileRequest{
-					Owner: tt.owner,
-					Repo:  tt.repo,
-					Ref:   tt.ref,
-					Path:  filepath.Join(tt.rootPath, ".pyroscope.yaml"),
-				},
-				content: tt.pyroscopeYAML,
-			})
+			mockFiles := tt.mockFiles
+			if tt.pyroscopeYAML != "" {
+				mockFiles = append(mockFiles, mockFileResponse{
+					request: client.FileRequest{
+						Owner: tt.owner,
+						Repo:  tt.repo,
+						Ref:   tt.ref,
+						Path:  filepath.Join(tt.rootPath, ".pyroscope.yaml"),
+					},
+					content: tt.pyroscopeYAML,
+				})
+			}
 			mockClient.addFiles(mockFiles...)
 
 			// Setup repository URL


### PR DESCRIPTION
This fixes a panics, when go std lib is queried, without a version identifier. This actually had a test case, but it was wired up incorrectly.
