### PR TITLE
feat: Add profile_id_selector for individual profile retrieval

### DIFF
--- a/api/connect-openapi/gen/querier/v1/querier.openapi.yaml
+++ b/api/connect-openapi/gen/querier/v1/querier.openapi.yaml
@@ -1209,6 +1209,16 @@ components:
           description: Select stack traces that match the provided selector.
           nullable: true
           $ref: '#/components/schemas/types.v1.StackTraceSelector'
+        profileIdSelector:
+          type: array
+          examples:
+            - - 7c9e6679-7425-40de-944b-e07fc1f90ae7
+          items:
+            type: string
+            examples:
+              - - 7c9e6679-7425-40de-944b-e07fc1f90ae7
+          title: profile_id_selector
+          description: List of Profile UUIDs to query
       title: SelectMergeProfileRequest
       additionalProperties: false
     querier.v1.SelectMergeSpanProfileRequest:

--- a/api/connect-openapi/gen/query/v1/query.openapi.yaml
+++ b/api/connect-openapi/gen/query/v1/query.openapi.yaml
@@ -461,9 +461,14 @@ components:
           format: int64
         stackTraceSelector:
           title: stack_trace_selector
-          description: 'TODO(kolesnikovae): Go PGO options.'
           nullable: true
           $ref: '#/components/schemas/types.v1.StackTraceSelector'
+        profileIdSelector:
+          type: array
+          items:
+            type: string
+          title: profile_id_selector
+          description: 'TODO(kolesnikovae): Go PGO options.'
       title: PprofQuery
       additionalProperties: false
     query.v1.PprofReport:
@@ -714,6 +719,11 @@ components:
           title: stack_trace_selector
           nullable: true
           $ref: '#/components/schemas/types.v1.StackTraceSelector'
+        profileIdSelector:
+          type: array
+          items:
+            type: string
+          title: profile_id_selector
       title: TreeQuery
       additionalProperties: false
     query.v1.TreeReport:

--- a/api/gen/proto/go/querier/v1/querier.pb.go
+++ b/api/gen/proto/go/querier/v1/querier.pb.go
@@ -921,8 +921,10 @@ type SelectMergeProfileRequest struct {
 	MaxNodes *int64 `protobuf:"varint,5,opt,name=max_nodes,json=maxNodes,proto3,oneof" json:"max_nodes,omitempty"`
 	// Select stack traces that match the provided selector.
 	StackTraceSelector *v1.StackTraceSelector `protobuf:"bytes,6,opt,name=stack_trace_selector,json=stackTraceSelector,proto3,oneof" json:"stack_trace_selector,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// List of Profile UUIDs to query
+	ProfileIdSelector []string `protobuf:"bytes,7,rep,name=profile_id_selector,json=profileIdSelector,proto3" json:"profile_id_selector,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *SelectMergeProfileRequest) Reset() {
@@ -993,6 +995,13 @@ func (x *SelectMergeProfileRequest) GetMaxNodes() int64 {
 func (x *SelectMergeProfileRequest) GetStackTraceSelector() *v1.StackTraceSelector {
 	if x != nil {
 		return x.StackTraceSelector
+	}
+	return nil
+}
+
+func (x *SelectMergeProfileRequest) GetProfileIdSelector() []string {
+	if x != nil {
+		return x.ProfileIdSelector
 	}
 	return nil
 }
@@ -1522,14 +1531,15 @@ const file_querier_v1_querier_proto_rawDesc = "" +
 	"rightTicks\x18\x06 \x01(\x03R\n" +
 	"rightTicks\"\x1f\n" +
 	"\x05Level\x12\x16\n" +
-	"\x06values\x18\x01 \x03(\x03R\x06values\"\xb4\x03\n" +
+	"\x06values\x18\x01 \x03(\x03R\x06values\"\x95\x04\n" +
 	"\x19SelectMergeProfileRequest\x12Y\n" +
 	"\x0eprofile_typeID\x18\x01 \x01(\tB2\xbaG/:-\x12+process_cpu:cpu:nanoseconds:cpu:nanosecondsR\rprofileTypeID\x12J\n" +
 	"\x0elabel_selector\x18\x02 \x01(\tB#\xbaG :\x1e\x12\x1c'{namespace=\"my-namespace\"}'R\rlabelSelector\x12*\n" +
 	"\x05start\x18\x03 \x01(\x03B\x14\xbaG\x11:\x0f\x12\r1676282400000R\x05start\x12&\n" +
 	"\x03end\x18\x04 \x01(\x03B\x14\xbaG\x11:\x0f\x12\r1676289600000R\x03end\x12 \n" +
 	"\tmax_nodes\x18\x05 \x01(\x03H\x00R\bmaxNodes\x88\x01\x01\x12S\n" +
-	"\x14stack_trace_selector\x18\x06 \x01(\v2\x1c.types.v1.StackTraceSelectorH\x01R\x12stackTraceSelector\x88\x01\x01B\f\n" +
+	"\x14stack_trace_selector\x18\x06 \x01(\v2\x1c.types.v1.StackTraceSelectorH\x01R\x12stackTraceSelector\x88\x01\x01\x12_\n" +
+	"\x13profile_id_selector\x18\a \x03(\tB/\xbaG,:*\x12(['7c9e6679-7425-40de-944b-e07fc1f90ae7']R\x11profileIdSelectorB\f\n" +
 	"\n" +
 	"_max_nodesB\x17\n" +
 	"\x15_stack_trace_selector\"\xfb\x04\n" +

--- a/api/gen/proto/go/querier/v1/querier_vtproto.pb.go
+++ b/api/gen/proto/go/querier/v1/querier_vtproto.pb.go
@@ -376,6 +376,11 @@ func (m *SelectMergeProfileRequest) CloneVT() *SelectMergeProfileRequest {
 			r.StackTraceSelector = proto.Clone(rhs).(*v1.StackTraceSelector)
 		}
 	}
+	if rhs := m.ProfileIdSelector; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.ProfileIdSelector = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -1015,6 +1020,15 @@ func (this *SelectMergeProfileRequest) EqualVT(that *SelectMergeProfileRequest) 
 		}
 	} else if !proto.Equal(this.StackTraceSelector, that.StackTraceSelector) {
 		return false
+	}
+	if len(this.ProfileIdSelector) != len(that.ProfileIdSelector) {
+		return false
+	}
+	for i, vx := range this.ProfileIdSelector {
+		vy := that.ProfileIdSelector[i]
+		if vx != vy {
+			return false
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -2548,6 +2562,15 @@ func (m *SelectMergeProfileRequest) MarshalToSizedBufferVT(dAtA []byte) (int, er
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.ProfileIdSelector) > 0 {
+		for iNdEx := len(m.ProfileIdSelector) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.ProfileIdSelector[iNdEx])
+			copy(dAtA[i:], m.ProfileIdSelector[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ProfileIdSelector[iNdEx])))
+			i--
+			dAtA[i] = 0x3a
+		}
+	}
 	if m.StackTraceSelector != nil {
 		if vtmsg, ok := interface{}(m.StackTraceSelector).(interface {
 			MarshalToSizedBufferVT([]byte) (int, error)
@@ -3355,6 +3378,12 @@ func (m *SelectMergeProfileRequest) SizeVT() (n int) {
 			l = proto.Size(m.StackTraceSelector)
 		}
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.ProfileIdSelector) > 0 {
+		for _, s := range m.ProfileIdSelector {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5572,6 +5601,38 @@ func (m *SelectMergeProfileRequest) UnmarshalVT(dAtA []byte) error {
 					return err
 				}
 			}
+			iNdEx = postIndex
+		case 7:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ProfileIdSelector", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ProfileIdSelector = append(m.ProfileIdSelector, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/api/gen/proto/go/query/v1/query.pb.go
+++ b/api/gen/proto/go/query/v1/query.pb.go
@@ -1245,6 +1245,7 @@ type TreeQuery struct {
 	MaxNodes           int64                   `protobuf:"varint,1,opt,name=max_nodes,json=maxNodes,proto3" json:"max_nodes,omitempty"`
 	SpanSelector       []string                `protobuf:"bytes,2,rep,name=span_selector,json=spanSelector,proto3" json:"span_selector,omitempty"`
 	StackTraceSelector *v11.StackTraceSelector `protobuf:"bytes,3,opt,name=stack_trace_selector,json=stackTraceSelector,proto3,oneof" json:"stack_trace_selector,omitempty"`
+	ProfileIdSelector  []string                `protobuf:"bytes,4,rep,name=profile_id_selector,json=profileIdSelector,proto3" json:"profile_id_selector,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -1296,6 +1297,13 @@ func (x *TreeQuery) GetSpanSelector() []string {
 func (x *TreeQuery) GetStackTraceSelector() *v11.StackTraceSelector {
 	if x != nil {
 		return x.StackTraceSelector
+	}
+	return nil
+}
+
+func (x *TreeQuery) GetProfileIdSelector() []string {
+	if x != nil {
+		return x.ProfileIdSelector
 	}
 	return nil
 }
@@ -1355,7 +1363,8 @@ func (x *TreeReport) GetTree() []byte {
 type PprofQuery struct {
 	state              protoimpl.MessageState  `protogen:"open.v1"`
 	MaxNodes           int64                   `protobuf:"varint,1,opt,name=max_nodes,json=maxNodes,proto3" json:"max_nodes,omitempty"`
-	StackTraceSelector *v11.StackTraceSelector `protobuf:"bytes,2,opt,name=stack_trace_selector,json=stackTraceSelector,proto3,oneof" json:"stack_trace_selector,omitempty"` // TODO(kolesnikovae): Go PGO options.
+	StackTraceSelector *v11.StackTraceSelector `protobuf:"bytes,2,opt,name=stack_trace_selector,json=stackTraceSelector,proto3,oneof" json:"stack_trace_selector,omitempty"`
+	ProfileIdSelector  []string                `protobuf:"bytes,3,rep,name=profile_id_selector,json=profileIdSelector,proto3" json:"profile_id_selector,omitempty"` // TODO(kolesnikovae): Go PGO options.
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -1400,6 +1409,13 @@ func (x *PprofQuery) GetMaxNodes() int64 {
 func (x *PprofQuery) GetStackTraceSelector() *v11.StackTraceSelector {
 	if x != nil {
 		return x.StackTraceSelector
+	}
+	return nil
+}
+
+func (x *PprofQuery) GetProfileIdSelector() []string {
+	if x != nil {
+		return x.ProfileIdSelector
 	}
 	return nil
 }
@@ -1544,20 +1560,22 @@ const file_query_v1_query_proto_rawDesc = "" +
 	"\x10TimeSeriesReport\x12/\n" +
 	"\x05query\x18\x01 \x01(\v2\x19.query.v1.TimeSeriesQueryR\x05query\x121\n" +
 	"\vtime_series\x18\x02 \x03(\v2\x10.types.v1.SeriesR\n" +
-	"timeSeries\"\xbb\x01\n" +
+	"timeSeries\"\xeb\x01\n" +
 	"\tTreeQuery\x12\x1b\n" +
 	"\tmax_nodes\x18\x01 \x01(\x03R\bmaxNodes\x12#\n" +
 	"\rspan_selector\x18\x02 \x03(\tR\fspanSelector\x12S\n" +
-	"\x14stack_trace_selector\x18\x03 \x01(\v2\x1c.types.v1.StackTraceSelectorH\x00R\x12stackTraceSelector\x88\x01\x01B\x17\n" +
+	"\x14stack_trace_selector\x18\x03 \x01(\v2\x1c.types.v1.StackTraceSelectorH\x00R\x12stackTraceSelector\x88\x01\x01\x12.\n" +
+	"\x13profile_id_selector\x18\x04 \x03(\tR\x11profileIdSelectorB\x17\n" +
 	"\x15_stack_trace_selector\"K\n" +
 	"\n" +
 	"TreeReport\x12)\n" +
 	"\x05query\x18\x01 \x01(\v2\x13.query.v1.TreeQueryR\x05query\x12\x12\n" +
-	"\x04tree\x18\x02 \x01(\fR\x04tree\"\x97\x01\n" +
+	"\x04tree\x18\x02 \x01(\fR\x04tree\"\xc7\x01\n" +
 	"\n" +
 	"PprofQuery\x12\x1b\n" +
 	"\tmax_nodes\x18\x01 \x01(\x03R\bmaxNodes\x12S\n" +
-	"\x14stack_trace_selector\x18\x02 \x01(\v2\x1c.types.v1.StackTraceSelectorH\x00R\x12stackTraceSelector\x88\x01\x01B\x17\n" +
+	"\x14stack_trace_selector\x18\x02 \x01(\v2\x1c.types.v1.StackTraceSelectorH\x00R\x12stackTraceSelector\x88\x01\x01\x12.\n" +
+	"\x13profile_id_selector\x18\x03 \x03(\tR\x11profileIdSelectorB\x17\n" +
 	"\x15_stack_trace_selector\"O\n" +
 	"\vPprofReport\x12*\n" +
 	"\x05query\x18\x01 \x01(\v2\x14.query.v1.PprofQueryR\x05query\x12\x14\n" +

--- a/api/gen/proto/go/query/v1/query_vtproto.pb.go
+++ b/api/gen/proto/go/query/v1/query_vtproto.pb.go
@@ -463,6 +463,11 @@ func (m *TreeQuery) CloneVT() *TreeQuery {
 			r.StackTraceSelector = proto.Clone(rhs).(*v11.StackTraceSelector)
 		}
 	}
+	if rhs := m.ProfileIdSelector; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.ProfileIdSelector = tmpContainer
+	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -510,6 +515,11 @@ func (m *PprofQuery) CloneVT() *PprofQuery {
 		} else {
 			r.StackTraceSelector = proto.Clone(rhs).(*v11.StackTraceSelector)
 		}
+	}
+	if rhs := m.ProfileIdSelector; rhs != nil {
+		tmpContainer := make([]string, len(rhs))
+		copy(tmpContainer, rhs)
+		r.ProfileIdSelector = tmpContainer
 	}
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
@@ -1157,6 +1167,15 @@ func (this *TreeQuery) EqualVT(that *TreeQuery) bool {
 	} else if !proto.Equal(this.StackTraceSelector, that.StackTraceSelector) {
 		return false
 	}
+	if len(this.ProfileIdSelector) != len(that.ProfileIdSelector) {
+		return false
+	}
+	for i, vx := range this.ProfileIdSelector {
+		vy := that.ProfileIdSelector[i]
+		if vx != vy {
+			return false
+		}
+	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
 
@@ -1206,6 +1225,15 @@ func (this *PprofQuery) EqualVT(that *PprofQuery) bool {
 		}
 	} else if !proto.Equal(this.StackTraceSelector, that.StackTraceSelector) {
 		return false
+	}
+	if len(this.ProfileIdSelector) != len(that.ProfileIdSelector) {
+		return false
+	}
+	for i, vx := range this.ProfileIdSelector {
+		vy := that.ProfileIdSelector[i]
+		if vx != vy {
+			return false
+		}
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
 }
@@ -2510,6 +2538,15 @@ func (m *TreeQuery) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.ProfileIdSelector) > 0 {
+		for iNdEx := len(m.ProfileIdSelector) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.ProfileIdSelector[iNdEx])
+			copy(dAtA[i:], m.ProfileIdSelector[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ProfileIdSelector[iNdEx])))
+			i--
+			dAtA[i] = 0x22
+		}
+	}
 	if m.StackTraceSelector != nil {
 		if vtmsg, ok := interface{}(m.StackTraceSelector).(interface {
 			MarshalToSizedBufferVT([]byte) (int, error)
@@ -2628,6 +2665,15 @@ func (m *PprofQuery) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.ProfileIdSelector) > 0 {
+		for iNdEx := len(m.ProfileIdSelector) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.ProfileIdSelector[iNdEx])
+			copy(dAtA[i:], m.ProfileIdSelector[iNdEx])
+			i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ProfileIdSelector[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
 	}
 	if m.StackTraceSelector != nil {
 		if vtmsg, ok := interface{}(m.StackTraceSelector).(interface {
@@ -3139,6 +3185,12 @@ func (m *TreeQuery) SizeVT() (n int) {
 		}
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if len(m.ProfileIdSelector) > 0 {
+		for _, s := range m.ProfileIdSelector {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -3179,6 +3231,12 @@ func (m *PprofQuery) SizeVT() (n int) {
 			l = proto.Size(m.StackTraceSelector)
 		}
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if len(m.ProfileIdSelector) > 0 {
+		for _, s := range m.ProfileIdSelector {
+			l = len(s)
+			n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+		}
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5754,6 +5812,38 @@ func (m *TreeQuery) UnmarshalVT(dAtA []byte) error {
 				}
 			}
 			iNdEx = postIndex
+		case 4:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ProfileIdSelector", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ProfileIdSelector = append(m.ProfileIdSelector, string(dAtA[iNdEx:postIndex]))
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])
@@ -5988,6 +6078,38 @@ func (m *PprofQuery) UnmarshalVT(dAtA []byte) error {
 					return err
 				}
 			}
+			iNdEx = postIndex
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ProfileIdSelector", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ProfileIdSelector = append(m.ProfileIdSelector, string(dAtA[iNdEx:postIndex]))
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/api/openapiv2/gen/phlare.swagger.json
+++ b/api/openapiv2/gen/phlare.swagger.json
@@ -1733,7 +1733,13 @@
           "format": "int64"
         },
         "stackTraceSelector": {
-          "$ref": "#/definitions/v1StackTraceSelector",
+          "$ref": "#/definitions/v1StackTraceSelector"
+        },
+        "profileIdSelector": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "description": "TODO(kolesnikovae): Go PGO options."
         }
       }
@@ -2518,6 +2524,12 @@
         },
         "stackTraceSelector": {
           "$ref": "#/definitions/v1StackTraceSelector"
+        },
+        "profileIdSelector": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/api/querier/v1/querier.proto
+++ b/api/querier/v1/querier.proto
@@ -199,6 +199,8 @@ message SelectMergeProfileRequest {
   optional int64 max_nodes = 5;
   // Select stack traces that match the provided selector.
   optional types.v1.StackTraceSelector stack_trace_selector = 6;
+  // List of Profile UUIDs to query
+  repeated string profile_id_selector = 7 [(gnostic.openapi.v3.property).example = {yaml: "['7c9e6679-7425-40de-944b-e07fc1f90ae7']"}];
 }
 
 message SelectSeriesRequest {

--- a/api/query/v1/query.proto
+++ b/api/query/v1/query.proto
@@ -173,6 +173,7 @@ message TreeQuery {
   int64 max_nodes = 1;
   repeated string span_selector = 2;
   optional types.v1.StackTraceSelector stack_trace_selector = 3;
+  repeated string profile_id_selector = 4;
 }
 
 message TreeReport {
@@ -183,6 +184,7 @@ message TreeReport {
 message PprofQuery {
   int64 max_nodes = 1;
   optional types.v1.StackTraceSelector stack_trace_selector = 2;
+  repeated string profile_id_selector = 3;
   // TODO(kolesnikovae): Go PGO options.
 }
 

--- a/docs/sources/reference-server-api/index.md
+++ b/docs/sources/reference-server-api/index.md
@@ -326,6 +326,7 @@ A request body with the following fields is required:
 |`end` | Milliseconds since epoch. | `1676289600000` |
 |`labelSelector` | Label selector string | `{namespace="my-namespace"}` |
 |`maxNodes` | Limit the nodes returned to only show the node with the max_node's biggest  total |  |
+|`profileIdSelector` | List of Profile UUIDs to query | `["7c9e6679-7425-40de-944b-e07fc1f90ae7"]` |
 |`profileTypeID` | Profile Type ID string in the form  <name>:<type>:<unit>:<period_type>:<period_unit>. | `process_cpu:cpu:nanoseconds:cpu:nanoseconds` |
 |`stackTraceSelector.callSite[].name` |  |  |
 |`stackTraceSelector.goPgo.aggregateCallees` | Aggregate callees causes the leaf location line number to be ignored,  thus aggregating all callee samples (but not callers). |  |
@@ -338,6 +339,9 @@ curl \
   -d '{
       "end": '$(date +%s)000',
       "labelSelector": "{namespace=\"my-namespace\"}",
+      "profileIdSelector": [
+        "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+      ],
       "profileTypeID": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
       "start": '$(expr $(date +%s) - 3600 )000'
     }' \
@@ -350,6 +354,9 @@ import datetime
 body = {
     "end": int(datetime.datetime.now().timestamp() * 1000),
     "labelSelector": "{namespace=\"my-namespace\"}",
+    "profileIdSelector": [
+      "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+    ],
     "profileTypeID": "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
     "start": int((datetime.datetime.now()- datetime.timedelta(hours = 1)).timestamp() * 1000)
   }

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_profile.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_profile.go
@@ -52,6 +52,7 @@ func (q *QueryFrontend) SelectMergeProfile(
 			Pprof: &queryv1.PprofQuery{
 				MaxNodes:           c.Msg.GetMaxNodes(),
 				StackTraceSelector: c.Msg.StackTraceSelector,
+				ProfileIdSelector:  c.Msg.ProfileIdSelector,
 			},
 		}},
 	})

--- a/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
+++ b/pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go
@@ -73,6 +73,7 @@ func (q *QueryFrontend) selectMergeStacktracesTree(
 			Tree: &queryv1.TreeQuery{
 				MaxNodes:           maxNodes,
 				StackTraceSelector: c.Msg.StackTraceSelector,
+				ProfileIdSelector:  c.Msg.ProfileIdSelector,
 			},
 		}},
 	})

--- a/pkg/querier/querier.go
+++ b/pkg/querier/querier.go
@@ -664,9 +664,8 @@ func (q *Querier) SelectMergeStacktraces(ctx context.Context, req *connect.Reque
 		req.Msg.MaxNodes = &mn
 	}
 
-	// TODO: remove when profile_id_selector is implemented
 	if len(req.Msg.ProfileIdSelector) > 0 {
-		return nil, connect.NewError(connect.CodeUnimplemented, errors.New("profile_id_selector is not yet implemented"))
+		return nil, connect.NewError(connect.CodeUnimplemented, errors.New("profile_id_selector is only supported with the v2 query backend"))
 	}
 
 	t, err := q.selectTree(ctx, req.Msg)

--- a/pkg/querybackend/query_pprof.go
+++ b/pkg/querybackend/query_pprof.go
@@ -31,7 +31,16 @@ func init() {
 }
 
 func queryPprof(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
-	entries, err := profileEntryIterator(q)
+	var profileOpts []profileIteratorOption
+	if len(query.Pprof.ProfileIdSelector) > 0 {
+		opt, err := withProfileIDSelector(query.Pprof.ProfileIdSelector...)
+		if err != nil {
+			return nil, err
+		}
+		profileOpts = append(profileOpts, opt)
+	}
+
+	entries, err := profileEntryIterator(q, profileOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/querybackend/query_tree.go
+++ b/pkg/querybackend/query_tree.go
@@ -29,7 +29,16 @@ func init() {
 }
 
 func queryTree(q *queryContext, query *queryv1.Query) (*queryv1.Report, error) {
-	entries, err := profileEntryIterator(q)
+	var profileOpts []profileIteratorOption
+	if len(query.Tree.ProfileIdSelector) > 0 {
+		opt, err := withProfileIDSelector(query.Tree.ProfileIdSelector...)
+		if err != nil {
+			return nil, err
+		}
+		profileOpts = append(profileOpts, opt)
+	}
+
+	entries, err := profileEntryIterator(q, profileOpts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Enable querying specific profiles by ID in `SelectMergeStacktraces`, `SelectMergeProfile`, and `Diff` API endpoints for the v2 architecture.

This builds on the exemplar support added in #4615, which exposes `profileIDs` in timeseries responses. With profile IDs now available in the timeline, users need a way to retrieve those specific profiles.