### PR TITLE
fix(examples): update eBPF profiler to support Linux 6.16+ kernels

### DIFF
--- a/examples/grafana-alloy-auto-instrumentation/ebpf-otel/Dockerfile
+++ b/examples/grafana-alloy-auto-instrumentation/ebpf-otel/Dockerfile
@@ -3,9 +3,9 @@ RUN apt-get update && apt-get -y install wget gcc
 RUN wget https://go.dev/dl/go1.22.10.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.22.10.linux-amd64.tar.gz
 # fixed versions for pyroscope, otel-collector, otel-profiler due to protocol changes
-RUN wget https://github.com/open-telemetry/opentelemetry-ebpf-profiler/archive/d90d670c1b32a525de0b57e845ec75d7d24a49b6.tar.gz
+RUN wget https://github.com/open-telemetry/opentelemetry-ebpf-profiler/archive/19cb11e6bf00c04e4f8d793e944e71478f9608d9.tar.gz
 RUN mkdir /profiler
-RUN tar --strip-components=1 -C /profiler -xzf d90d670c1b32a525de0b57e845ec75d7d24a49b6.tar.gz
+RUN tar --strip-components=1 -C /profiler -xzf 19cb11e6bf00c04e4f8d793e944e71478f9608d9.tar.gz
 WORKDIR /profiler
 RUN /usr/local/go/bin/go build .
 

--- a/examples/grafana-alloy-auto-instrumentation/ebpf-otel/README.md
+++ b/examples/grafana-alloy-auto-instrumentation/ebpf-otel/README.md
@@ -10,6 +10,14 @@ These examples demonstrate:
 3. Pyroscope receiving and visualizing the profiles via Grafana
 
 ## Docker example
+
+**Note for ARM64 users**: If running on ARM64 Linux, update the Dockerfile:
+```dockerfile
+# Line 3: Change amd64 to arm64
+RUN wget https://go.dev/dl/go1.22.10.linux-arm64.tar.gz
+RUN tar -C /usr/local -xzf go1.22.10.linux-arm64.tar.gz
+```
+
 1. Start the environment:
 
 ```bash

--- a/examples/grafana-alloy-auto-instrumentation/ebpf-otel/docker/docker-compose.yml
+++ b/examples/grafana-alloy-auto-instrumentation/ebpf-otel/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   otel-collector:
     # fixed versions for pyroscope, otel-collector, otel-profiler due to protocol changes
-    image: otel/opentelemetry-collector-contrib:0.129.1
+    image: otel/opentelemetry-collector-contrib:0.141.0
     command: ["--config=/etc/otel-collector-config.yaml", "--feature-gates=service.profilesSupport"]
     volumes:
       - ./config/otel-collector-config.yaml:/etc/otel-collector-config.yaml
@@ -30,7 +30,7 @@ services:
 
   pyroscope:
     # fixed versions for pyroscope, otel-collector, otel-profiler due to protocol changes
-    image: grafana/pyroscope:weekly-f125-16eebf27b
+    image: grafana/pyroscope:weekly-f147-b3e95303c
     command: ["-self-profiling.disable-push=true"]
     ports:
       - "4040:4040"


### PR DESCRIPTION
Fixes the OpenTelemetry ebpf profiler example to work with Linux kernel 6.16+.

See https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/738