### PR TITLE
profilecli(canary): do not check for service.name label

### DIFF
--- a/cmd/profilecli/canary_exporter_probes.go
+++ b/cmd/profilecli/canary_exporter_probes.go
@@ -502,7 +502,7 @@ func (ce *canaryExporter) testLabelNames(ctx context.Context, now time.Time) err
 		model.LabelNameServiceNamePrivate,
 		model.LabelNameType,
 		model.LabelNameUnit,
-		"service.name",
+		//"service.name", // todo: return once write path is ready for utf8 labels
 		model.LabelNameServiceName,
 	}
 

--- a/pkg/validation/validate.go
+++ b/pkg/validation/validate.go
@@ -160,6 +160,7 @@ func ValidateLabels(limits LabelValidationLimits, tenantID string, ls []*typesv1
 		}
 		if origName, newName, ok := SanitizeLegacyLabelName(l.Name); ok && origName != newName {
 			var err error
+			// todo update canary exporter to check for utf8 labels, at least service.name once the write path supports utf8
 			ls, idx, err = handleSanitizedLabel(ls, idx, origName, newName)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Before https://github.com/grafana/pyroscope/pull/4662 we used to (some times?) store unsanitized labels. Now we don't.
Until we properly store utf8 labels, we should not check for incorrect label `service.name` in the canary exporter