### PR TITLE
chore: Run update-contributors workflow once a month

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -2,7 +2,7 @@ name: Update Contributors in README
 
 on:
   schedule:
-    - cron: '0 0 1-7 * SUN'
+    - cron: '0 0 1 * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Current schedule is too often: the first week of every month and every Sunday. This modification is just for the 1st of the month at 00:00.