### PR TITLE
fix: Assign appropriate HTTP status codes to errors

### DIFF
--- a/pkg/querier/http.go
+++ b/pkg/querier/http.go
@@ -10,13 +10,11 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	"github.com/gogo/status"
 	"github.com/google/pprof/profile"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/codes"
 
 	profilev1 "github.com/grafana/pyroscope/api/gen/proto/go/google/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
@@ -168,7 +166,7 @@ func (q *QueryHandlers) Render(w http.ResponseWriter, req *http.Request) {
 			MaxNodes:      &sourceProfileMaxNodes,
 		}))
 		if err != nil {
-			httputil.Error(w, connect.NewError(connect.CodeInternal, err))
+			httputil.Error(w, err)
 			return
 		}
 		// Check if profile has any data - return empty string if no data
@@ -178,7 +176,7 @@ func (q *QueryHandlers) Render(w http.ResponseWriter, req *http.Request) {
 			return
 		}
 		if err = pprofToDotProfile(w, resp.Msg, int(dotProfileMaxNodes)); err != nil {
-			httputil.Error(w, connect.NewError(connect.CodeInternal, err))
+			httputil.Error(w, err)
 		}
 		return
 	}
@@ -309,12 +307,12 @@ func parseSelectProfilesRequest(fieldNames renderRequestFieldNames, req *http.Re
 func parseQuery(fieldName string, req *http.Request) (string, *typesv1.ProfileType, error) {
 	q := req.Form.Get(fieldName)
 	if q == "" {
-		return "", nil, fmt.Errorf("'%s' is required", fieldName)
+		return "", nil, fmt.Errorf("%q is required", fieldName)
 	}
 
 	parsedSelector, err := parser.ParseMetricSelector(q)
 	if err != nil {
-		return "", nil, status.Error(codes.InvalidArgument, fmt.Sprintf("failed to parse '%s'", fieldName))
+		return "", nil, fmt.Errorf("failed to parse %q: %w", fieldName, err)
 	}
 
 	sel := make([]*labels.Matcher, 0, len(parsedSelector))
@@ -327,12 +325,12 @@ func parseQuery(fieldName string, req *http.Request) (string, *typesv1.ProfileTy
 		}
 	}
 	if nameLabel == nil {
-		return "", nil, status.Error(codes.InvalidArgument, fmt.Sprintf("'%s' must contain a profile-type selection", fieldName))
+		return "", nil, fmt.Errorf("%q must contain a profile-type selection", fieldName)
 	}
 
 	profileSelector, err := phlaremodel.ParseProfileTypeSelector(nameLabel.Value)
 	if err != nil {
-		return "", nil, status.Error(codes.InvalidArgument, fmt.Sprintf("failed to parse '%s'", fieldName))
+		return "", nil, fmt.Errorf("failed to parse %q", fieldName)
 	}
 	return convertMatchersToString(sel), profileSelector, nil
 }


### PR DESCRIPTION
We were incorrectly getting SLO read budget burns because some of our validation was being incorrectly returned as 5xx when they should have been 4xx. The read budget burns were specifically impacting our `/render` endpoint. I went through and cleaned up as many of the errors as I could, assigning them appropriate status codes.

This also removes some usages of `github.com/gogo/status` in favor of connect error codes (ultimately everything will be resolved to an HTTP status code).