### PR TITLE
fix: Missing labels updates to sample groups in `VisitSampleSeries`

### DIFF
--- a/pkg/model/pprofsplit/pprof_split.go
+++ b/pkg/model/pprofsplit/pprof_split.go
@@ -88,11 +88,12 @@ func VisitSampleSeries(
 	for _, idx := range groupsKept.order {
 		for _, group := range groupsKept.m[idx] {
 			if len(group.sampleGroup.Samples) > 0 {
-				validatedLabels, err := visitor.ValidateLabels(group.labels)
+				var err error
+				group.labels, err = visitor.ValidateLabels(group.labels)
 				if err != nil {
 					return err
 				}
-				visitor.VisitSampleSeries(validatedLabels, group.sampleGroup.Samples)
+				visitor.VisitSampleSeries(group.labels, group.sampleGroup.Samples)
 			}
 		}
 	}


### PR DESCRIPTION
See https://github.com/grafana/pyroscope/pull/4662/files#r2623858860 and https://ops.grafana-ops.net/a/grafana-irm-app/incidents/4339