### PR TITLE
fix panic in pprof split when using `relabel.LabelDrop`

### DIFF
--- a/pkg/model/pprofsplit/pprof_split.go
+++ b/pkg/model/pprofsplit/pprof_split.go
@@ -153,8 +153,7 @@ type lazyGroup struct {
 func (g *lazyGroup) addSampleGroup(stringTable []string, sg pprof.SampleGroup) {
 	if len(g.sampleGroup.Samples) == 0 {
 		g.sampleGroup.Labels = sg.Labels
-		// defensive copy, we don't want to modify the original slice
-		g.sampleGroup.Samples = append([]*profilev1.Sample(nil), sg.Samples...)
+		g.sampleGroup.Samples = append(g.sampleGroup.Samples, sg.Samples...)
 		return
 	}
 


### PR DESCRIPTION
Fixes a rare issue where having ingest relabelling rules configured to drop labels can cause panics in segment writers. The root cause is a slice aliasing bug where multiple `lazyGroups` share the same underlying sample array. When one group appends samples, it can corrupt other groups leading to incorrect data in resulting split profiles, and occasionally raise panics.

The issue surfaced after #4365 got merged. Before #4365, samples were never merged into existing groups because of another problem. Solving that exposed a new and more subtle issue that we are solving here.

I wasn't able to write a test that captures the panic behavior. I see no regression in tests or the benchmark added in #4365.