### PR TITLE
remove hardcoded metrics port in rideshare example

### DIFF
--- a/examples/language-sdk-instrumentation/golang-push/rideshare/main.go
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"log/slog"
 	"net/http"
 	"os"
 	"time"
@@ -89,11 +88,6 @@ func main() {
 
 	// Register Prometheus metrics handler
 	http.Handle("/metrics", promhttp.Handler())
-	go func() {
-		if err := http.ListenAndServe(":5001", nil); err != nil {
-			slog.Error("metrics server error", "error", err)
-		}
-	}()
 
 	http.Handle("/", otelhttp.NewHandler(http.HandlerFunc(index), "IndexHandler"))
 


### PR DESCRIPTION
Addresses `listen tcp :5001: bind: address already in use ` when running the rideshare Go example with `RIDESHARE_LISTEN_PORT=5001`. With this change, metrics will be served on the same port as the application itself.

The code I've removed was added in #4075, but in my tests the example works as before with docker compose. The prometheus config hardcodes port 5000 anyway, which lines up with the default `RIDESHARE_LISTEN_PORT=5000`.