### PR TITLE
fix: Remove unintended double base64 encoding in vcs service

### DIFF
--- a/pkg/frontend/vcs/source/find.go
+++ b/pkg/frontend/vcs/source/find.go
@@ -88,11 +88,7 @@ func (ff FileFinder) findFallback(ctx context.Context) (*vcsv1.GetFileResponse, 
 	// todo: add more languages support
 	default:
 		// by default we return the file content at the given path without any processing.
-		content, err := ff.fetchRepoFile(ctx, ff.file.Path, ff.ref)
-		if err != nil {
-			return nil, err
-		}
-		return newFileResponse(content.Content, content.URL)
+		return ff.fetchRepoFile(ctx, ff.file.Path, ff.ref)
 	}
 }
 

--- a/pkg/frontend/vcs/source/find_test.go
+++ b/pkg/frontend/vcs/source/find_test.go
@@ -404,6 +404,28 @@ require (
 			expectedURL:     "https://github.com/stretchr/testify/blob/v1.10.0/require/require.go",
 			expectedError:   false,
 		},
+		{
+			name: "fallback/unknown-file-extension",
+			fileSpec: config.FileSpec{
+				FunctionName: "some.function",
+				Path:         "scripts/example.unknown_extension",
+			},
+			ref: "main",
+			mockFiles: []mockFileResponse{
+				{
+					request: client.FileRequest{
+						Owner: "grafana",
+						Repo:  "pyroscope",
+						Ref:   "main",
+						Path:  "scripts/example.unknown_extension",
+					},
+					content: "# Python script content\nprint('hello')",
+				},
+			},
+			expectedContent: "# Python script content\nprint('hello')",
+			expectedURL:     "https://github.com/grafana/pyroscope/blob/main/scripts/example.unknown_extension",
+			expectedError:   false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The fallback default path was calling `newFileResponse` twice, leading to double encoding.