### PR TITLE
chore(release): do not run on weekly tags, pass correct release tag explicitly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ on:
     # run only against tags
     tags:
       - "v*"
-      # do not run for weekly release tags
-      - "!weekly-f*"
 
 permissions:
   contents: write


### PR DESCRIPTION
After last weekly tag we got this error https://github.com/grafana/pyroscope/actions/runs/20374721626/job/58745102666

```  
⨯ release failed after 0s                  error=failed to parse tag 'weekly-f150-34b5c64ce' as semver: Invalid Semantic Version
```` 

Fix the problem when there are multiple tags on the same commit
    I think this logic https://github.com/goreleaser/goreleaser/blob/179d039a649bd7142829f67b97c88cd0593ce252/internal/pipe/git/git.go#L262 executes the following  and tries to use `weekly-f150-34b5c64ce` as the release tag. 
```
$ git tag --points-at HEAD --sort -version:refname
weekly-f150-34b5c64ce
v1.17.0
```

    
To fix the ambiguity, we now pass `GORELEASER_CURRENT_TAG`

Also change the weekly tag filter - we don't push `v0.0.0-weekly*` tags - replace with `weekly-f*`
