### PR TITLE
chore: Publish Github releases immediately during release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: 'false'
       - name: Set GIT_LAST_COMMIT_DATE
         run: echo "GIT_LAST_COMMIT_DATE=$(git log -1 --date=iso-strict --format=%cd)" >> $GITHUB_ENV
-      - name: Set IMAGE_PUBLISH_LATEST=true, so we overwrite the latest docker image tag
+      - name: Set IMAGE_PUBLISH_LATEST=true, so we overwrite the latest docker image tag and update Homebrew
         run: echo "IMAGE_PUBLISH_LATEST=true" >> $GITHUB_ENV
       # Forces goreleaser to use the correct previous tag for the changelog
       - name: Set GORELEASER_PREVIOUS_TAG
@@ -76,7 +76,9 @@ jobs:
       # make generate-formulas expects PYROSCOPE_TAG to be set
       - name: Set PYROSCOPE_TAG
         run: echo "PYROSCOPE_TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Update homebrew formulas
+      # Our Homebrew publishing currently assumes latest releases only
+      - if: env.IMAGE_PUBLISH_LATEST == 'true'
+        name: Update homebrew formulas
         run: |
           git config --global url."https://x-access-token:$(echo "${HOMEBREW_GITHUB_TOKEN}" | xargs)@github.com/pyroscope-io/homebrew-brew".insteadOf "https://github.com/pyroscope-io/homebrew-brew" 2> /dev/null
           git config --global user.email "dmitry+bot@pyroscope.io"

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -21,6 +21,8 @@ jobs:
         run: echo "GORELEASER_CURRENT_TAG=v0.0.0-$(./tools/image-tag)" >> $GITHUB_ENV
       - name: Set IMAGE_TAG
         run: echo "IMAGE_TAG=$(./tools/image-tag)" >> $GITHUB_ENV
+      - name: Set IMAGE_PUBLISH_LATEST=false, so we don't overwrite the latest docker image tag and Homebrew version
+        run: echo "IMAGE_PUBLISH_LATEST=false" >> $GITHUB_ENV
       - name: Set GITHUB_RELEASE_DISABLE=true, so github releases are skipped
         run: echo "GITHUB_RELEASE_DISABLE=true" >> $GITHUB_ENV
       - name: Set GORELEASER_STRIP_DEBUG_INFO=false, so binaries are not stripped of debug info

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -66,7 +66,7 @@ builds:
         -X "github.com/grafana/pyroscope/pkg/util/build.Revision={{ .ShortCommit }}"
         -X "github.com/grafana/pyroscope/pkg/util/build.BuildDate={{ .CommitDate }}"
     id: pyroscope_non_linux
-    skip: '{{ if eq .Env.GORELEASER_LINUX_ONLY "true" }}true{{ else }}else{{ end }}'
+    skip: '{{ if eq .Env.GORELEASER_LINUX_ONLY "true" }}true{{ else }}false{{ end }}'
   - env:
       - CGO_ENABLED=0
     tags:
@@ -122,7 +122,7 @@ builds:
       - -trimpath
     binary: profilecli
     id: profilecli_non_linux
-    skip: '{{ if eq .Env.GORELEASER_LINUX_ONLY "true" }}true{{ else }}else{{ end }}'
+    skip: '{{ if eq .Env.GORELEASER_LINUX_ONLY "true" }}true{{ else }}false{{ end }}'
 dockers:
   - use: buildx
     goos: linux
@@ -214,7 +214,10 @@ changelog:
     exclude:
       - "^test:"
 release:
-  draft: true
+  # Draft releases break our Homebrew release which
+  # depends on asset urls created on release "publish"
+  draft: false
+  make_latest: '{{ .Env.IMAGE_PUBLISH_LATEST }}'
   footer: |
     As always, feedback is more than welcome, feel free to open issues/discussions.
     You can reach out to the team using:

--- a/docs/internal/RELEASE.md
+++ b/docs/internal/RELEASE.md
@@ -61,11 +61,7 @@ Once merged, a `vX.Y.Z` patch release tag must be created and pushed to remote t
 > you need to make sure the release's actions to publish a `:latest` docker
 > image tag and a `home-brew` formula are removed:
 >
-> This can be done by updating the workflow in the previous release branches using those cherry-picks:
-> ```
-> git cherry-pick 73a4367a5a4cc0546f499403431e14a0b353cf2f  # Do not publish home-brew updates
-> git cherry-pick 3f3d87b4629bccbd0b8a9fffa43a3aa03e4c20bf  # Do not publish docker image tag :latest
-> ```
+> This can be done by updating `release.yml` in the previous release branches to set `$IMAGE_PUBLISH_LATEST=false`.
 
 ## Manual Release Process
 


### PR DESCRIPTION
Follow up to https://github.com/grafana/pyroscope/pull/4719

Few changes:
- Disable Github draft releases in GoReleaser to solve Homebrew release breaking
- Update `release.yml` to skip Homebrew release when not "latest" release
- Update `weekly-release.yml` to set as not "latest" release
- Updated `RELEASE.md` with new manual patch process changes
- Fix some typos when reading `$GORELEASER_LINUX_ONLY`