### PR TITLE
chore: add resources to provide guidance to coding agents

### DIFF
--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -1,0 +1,95 @@
+---
+description: Development workflow, commands, and commit guidelines for Pyroscope
+globs:
+alwaysApply: false
+---
+
+# Development Workflow
+
+## Prerequisites
+
+- Go 1.24+
+- Docker
+- Node v18
+- Yarn v1.22
+- All other tools auto-download to `.tmp/bin/`
+
+## Build Commands
+
+```bash
+# Build backend
+make go/bin
+
+# Run Go tests
+make go/test
+
+# Build frontend
+yarn install
+yarn dev          # Dev server on :4041
+
+# Run backend for frontend development
+yarn backend:dev  # Runs Pyroscope server
+
+# Docker image
+make GOOS=linux GOARCH=amd64 docker-image/pyroscope/build
+```
+
+## Running Locally
+
+```bash
+# Run all components in monolithic mode with embedded Grafana
+go run ./cmd/pyroscope --target all,embedded-grafana
+# Pyroscope: http://localhost:4040
+# Grafana: http://localhost:4041
+```
+
+## Code Generation
+
+**CRITICAL**: After changing protobuf, configs, or flags:
+
+```bash
+make generate
+```
+
+Commit the generated files with your changes.
+
+## Useful Make Targets
+
+```bash
+make help              # Show all available targets
+make lint              # Run linters
+make go/test           # Run Go unit tests
+make go/bin            # Build binaries
+make go/mod            # Tidy go modules
+make generate          # Generate code (protobuf, mocks, etc.)
+make docker-image/pyroscope/build  # Build Docker image
+```
+
+## Commit Guidelines
+
+1. **Atomic Commits**: Each commit should be a logical unit
+2. **Commit Messages**: Focus on "why" not just "what"
+3. **Generated Code**: Include generated files in the same commit as source changes
+4. **Format**: Follow existing commit message style (see `git log --oneline -20`)
+
+## When Working on Features
+
+1. **Read Component Docs**: Check `docs/sources/reference-pyroscope-architecture/components/` for the component you're modifying
+2. **Understand the Ring**: If working on write/read path, understand consistent hashing
+3. **Multi-tenancy First**: Always consider multi-tenant implications
+4. **Check for Similar Code**: Pyroscope is inspired by Cortex/Mimir - similar patterns apply
+5. **Test Multi-tenancy**: Test with multiple tenants to catch isolation issues
+6. **Profile Your Changes**: Use `go test -bench` and verify performance impact
+7. **Update Documentation**: If changing user-facing behavior, update docs
+
+## Documentation Locations
+
+- **User Docs**: `docs/sources/` - Published to grafana.com
+- **Contributing**: `docs/internal/contributing/README.md`
+- **Component Docs**: `docs/sources/reference-pyroscope-architecture/components/`
+
+## Getting Help
+
+- **Contributing Guide**: `docs/internal/contributing/README.md`
+- **Code Comments**: The codebase has extensive comments - read them
+- **Git History**: Use `git blame` and `git log` to understand design decisions

--- a/.cursor/rules/go-backend.mdc
+++ b/.cursor/rules/go-backend.mdc
@@ -1,0 +1,154 @@
+---
+description: Go backend coding standards and patterns for Pyroscope
+globs:
+  - "**/*.go"
+  - "!**/*_test.go"
+---
+
+# Go Backend Development
+
+## Import Organization
+
+Always organize imports into three groups separated by blank lines:
+
+```go
+import (
+    // Standard library
+    "context"
+    "fmt"
+
+    // Third-party packages
+    "github.com/prometheus/client_golang/prometheus"
+    "go.uber.org/atomic"
+
+    // Internal packages
+    "github.com/grafana/pyroscope/pkg/model"
+    "github.com/grafana/pyroscope/pkg/objstore"
+)
+```
+
+**Don't** add imports within the three import groups (keep them separate).
+
+## Formatting & Linting
+
+- Use `golangci-lint` (run via `make lint`)
+- gofmt for formatting
+- goimports with `-local github.com/grafana/pyroscope`
+- Enabled linters: depguard, goconst, misspell, revive, unconvert, unparam
+
+## Logging
+
+- **Use**: `github.com/go-kit/log`
+- **Don't**: `github.com/go-kit/kit/log` (deprecated import path)
+- **Don't**: `fmt.Println` for logging
+
+Use structured logging:
+
+```go
+import "github.com/go-kit/log/level"
+
+level.Error(logger).Log("msg", "failed to process", "err", err)
+level.Info(logger).Log("msg", "processing complete", "count", count)
+```
+
+## Error Handling
+
+- Always check errors explicitly
+- Wrap errors with context:
+
+```go
+if err != nil {
+    return fmt.Errorf("failed to query: %w", err)
+}
+```
+
+## Context Usage
+
+- Always pass `context.Context` as the first parameter
+- Respect context cancellation in loops and long operations:
+
+```go
+func process(ctx context.Context, items []Item) error {
+    for _, item := range items {
+        select {
+        case <-ctx.Done():
+            return ctx.Err()
+        default:
+        }
+        // process item
+    }
+    return nil
+}
+```
+
+## Multi-tenancy Pattern
+
+All requests must include a tenant ID. Extract from context:
+
+```go
+import "github.com/grafana/pyroscope/pkg/tenant"
+
+tenantID, err := tenant.ExtractTenantIDFromContext(ctx)
+if err != nil {
+    return err
+}
+```
+
+**Never** hardcode tenant IDs.
+
+## Object Storage Pattern
+
+Use the abstract Bucket interface:
+
+```go
+import "github.com/grafana/pyroscope/pkg/objstore"
+
+bucket := objstore.NewBucket(cfg)
+reader, err := bucket.Get(ctx, "path/to/object")
+```
+
+## Configuration Pattern
+
+Use `github.com/grafana/dskit` for configuration:
+
+```go
+type Config struct {
+    ListenPort int `yaml:"listen_port"`
+}
+
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+    f.IntVar(&cfg.ListenPort, "server.http-listen-port", 4040, "HTTP listen port")
+}
+```
+
+## Performance Considerations
+
+1. **Minimize Allocations in Hot Paths**:
+   - Reuse buffers with `sync.Pool`
+   - Avoid string concatenation in loops
+   - Use `strings.Builder` for string building
+
+2. **Concurrency**:
+   - Use worker pools for bounded concurrency
+   - Prefer channels for coordination over mutexes when possible
+   - Don't create unbounded goroutines - use worker pools or semaphores
+
+3. **Profile Your Changes**:
+   ```bash
+   go test -cpuprofile=cpu.prof -memprofile=mem.prof -bench=.
+   go tool pprof cpu.prof
+   ```
+
+## Code Generation
+
+**IMPORTANT**: After changing protobuf, configs, or flags:
+```bash
+make generate
+```
+Commit the generated files with your changes.
+
+## Security
+
+1. **Input Validation**: Always validate and sanitize user input
+2. **Path Traversal**: Validate object keys before storage operations
+3. **Rate Limiting**: Distributor implements per-tenant rate limiting

--- a/.cursor/rules/go-testing.mdc
+++ b/.cursor/rules/go-testing.mdc
@@ -1,0 +1,140 @@
+---
+description: Go testing standards and patterns for Pyroscope
+globs:
+  - "**/*_test.go"
+---
+
+# Go Testing Standards
+
+## Test File Naming
+
+- Test files: `*_test.go`
+- Test function naming: `TestFunctionName` or `TestComponentName_Method`
+
+## Test Structure
+
+Use table-driven tests for multiple cases:
+
+```go
+func TestDistributor_Push(t *testing.T) {
+    t.Parallel()
+
+    tests := []struct {
+        name    string
+        input   *pushv1.PushRequest
+        wantErr bool
+    }{
+        {name: "valid request", input: validRequest(), wantErr: false},
+        {name: "invalid tenant", input: invalidRequest(), wantErr: true},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            d := setupDistributor(t)
+            err := d.Push(context.Background(), tt.input)
+            if tt.wantErr {
+                require.Error(t, err)
+            } else {
+                require.NoError(t, err)
+            }
+        })
+    }
+}
+```
+
+## Assertions
+
+- Use `require` for fatal assertions (test stops on failure)
+- Use `assert` for non-fatal assertions (test continues)
+
+```go
+import (
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+// Fatal - stops test immediately
+require.NoError(t, err)
+require.NotNil(t, result)
+
+// Non-fatal - continues test
+assert.Equal(t, expected, actual)
+```
+
+## Test Organization
+
+1. **Subtests**: Use `t.Run()` for grouping related cases
+2. **Parallel Tests**: Use `t.Parallel()` when tests are independent
+3. **Cleanup**: Always use `t.Cleanup()` for resource cleanup
+
+```go
+func TestComponent(t *testing.T) {
+    t.Parallel()
+
+    resource := createResource(t)
+    t.Cleanup(func() {
+        resource.Close()
+    })
+
+    t.Run("subtest", func(t *testing.T) {
+        // test logic
+    })
+}
+```
+
+## Test Data
+
+- Store test data in `testdata/` directories
+- Use relative paths from the test file
+
+## Integration Tests
+
+Use build tags for integration tests:
+
+```go
+//go:build integration
+
+package mypackage_test
+
+func TestIntegration(t *testing.T) {
+    // ...
+}
+```
+
+## Mocking
+
+- Use `mockery` for generating mocks from interfaces
+- Place mocks in appropriate locations based on scope
+
+## Multi-tenancy Testing
+
+**Always test with multiple tenants** to catch isolation issues:
+
+```go
+func TestMultiTenant(t *testing.T) {
+    tenants := []string{"tenant-a", "tenant-b"}
+
+    for _, tenant := range tenants {
+        t.Run(tenant, func(t *testing.T) {
+            ctx := tenant.InjectTenantID(context.Background(), tenant)
+            // verify tenant isolation
+        })
+    }
+}
+```
+
+## Running Tests
+
+```bash
+# Run all tests
+make go/test
+
+# Run specific package tests
+go test ./pkg/distributor/...
+
+# Run with race detector
+go test -race ./...
+
+# Run benchmarks
+go test -bench=. ./pkg/...
+```

--- a/.cursor/rules/pyroscope-general.mdc
+++ b/.cursor/rules/pyroscope-general.mdc
@@ -1,0 +1,103 @@
+---
+description: General Pyroscope project context and architecture overview
+globs:
+alwaysApply: true
+---
+
+# Pyroscope - Project Overview
+
+Pyroscope is a horizontally scalable, highly available, multi-tenant continuous profiling aggregation system.
+It stores and queries profiling data at scale, similar to how Prometheus works for metrics and Loki for logs.
+
+## Key Characteristics
+- Written in **Go**
+- Microservices-based architecture inspired by Cortex/Mimir/Loki
+- Stores profiling data in object storage (S3, GCS, Azure, etc.)
+- Multi-tenant by design
+
+## Architecture
+
+Pyroscope uses a **microservices architecture** where a single binary can run different components based on the `-target` parameter.
+
+### V1 Components
+
+**Write Path:**
+- **Distributor**: Receives profile ingestion requests, validates, and forwards to ingesters
+- **Ingester**: Stores profiles in memory, periodically flushes to disk as blocks, periodically uploads blocks to long-term object storage
+- **Compactor**: Merges blocks and removes duplicates
+
+**Read Path:**
+- **Query Frontend**: Entry point for queries, handles query splitting and caching
+- **Query Scheduler**: Manages query queue and ensures fair execution across tenants
+- **Querier**: Executes queries by fetching data from ingesters and store-gateways
+- **Store Gateway**: Indexes and serves blocks from long-term object storage
+
+### V2 Components
+
+**Write Path:**
+- **Distributor**: Receives profile ingestion requests, validates, and forwards to segment writers
+- **Segment Writer**: Writes block segments to long-term object storage and their metadata to metastore
+- **Metastore**: Maintains the block metadata index and coordinates the block compaction process
+- **Compaction Worker**: Merges small segments into larger blocks
+
+**Read Path:**
+- **Query Frontend**: Entry point for queries, creates the query plan and executes it against query backends
+- **Query Backend**: Executes queries and merges query responses
+
+### Storage
+- **Block Format**: Profiles stored in Parquet tables, series data in a TSDB index, symbols in a custom format
+- **Multi-tenant**: Each tenant has isolated storage
+- **Object Storage**: Primary storage backend (S3, GCS, Azure, local filesystem)
+
+## Repository Structure
+
+```
+.
+├── cmd/
+│   ├── pyroscope/           # Main server binary
+│   └── profilecli/          # CLI tool for profile operations
+├── pkg/                     # Core Go packages
+│   ├── distributor/         # Distributor component
+│   ├── ingester/            # Ingester component
+│   ├── querier/             # Querier component
+│   ├── frontend/            # Query frontend component
+│   ├── compactor/           # Compactor component
+│   ├── metastore/           # Metadata component
+│   ├── phlaredb/            # V1 database storage engine
+│   ├── model/               # Data models and types
+│   ├── objstore/            # Object storage abstraction
+│   ├── api/                 # API definitions and handlers
+│   └── og/                  # Legacy code (original Pyroscope) - DO NOT USE
+├── public/app/              # React/TypeScript frontend
+├── api/                     # API definitions (protobuf, OpenAPI)
+├── docs/                    # Documentation
+├── operations/              # Deployment configs (jsonnet, helm)
+├── examples/                # Example applications and SDKs
+└── tools/                   # Development and build tools
+```
+
+## Key Dependencies
+
+- **dskit**: Grafana's distributed systems toolkit (ring, services, middleware)
+- **connect**: RPC framework (gRPC-compatible)
+- **parquet-go**: Parquet file format implementation
+- **go-kit/log**: Structured logging
+- **prometheus/client_golang**: Metrics instrumentation
+- **opentracing-go**: Distributed tracing
+
+## Critical Rules
+
+1. **Multi-tenancy is Critical**: Tenant isolation bugs are severe - test thoroughly
+2. **Performance Matters**: This system handles high-throughput profiling data
+3. **Favor Simplicity**: Pyroscope values simple, maintainable code over clever abstractions
+4. **Consistency with Grafana Labs Style**: Follow patterns from dskit, Mimir, Loki
+5. **Ask Before Large Refactors**: Propose significant architectural changes before implementing
+
+## Things to Avoid
+
+1. **Don't** introduce dependencies on `pkg/og/` - this is legacy code being phased out
+2. **Don't** hardcode tenant IDs - always extract from context
+3. **Don't** create unbounded goroutines - use worker pools or semaphores
+4. **Don't** log PII or sensitive data
+5. **Don't** commit changes to `node_modules/` or generated code without source changes
+6. **Don't** modify frontend code (`public/app/`) - the frontend is not actively developed and changes are discouraged

--- a/.gitignore
+++ b/.gitignore
@@ -21,10 +21,12 @@ data-metastore/
 **/dist
 
 # IDE
-.cursor
 .idea
 .vscode
 .zed
+pyroscope.sln
+.cursor/*
+!.cursor/rules/
 
 # Frontend
 public/build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,385 @@
+# Pyroscope - AI Agent Development Guide
+
+This document provides context and guidance for AI coding assistants (Claude, Cursor, GitHub Copilot, etc.) working on the Pyroscope codebase.
+
+## What is Pyroscope?
+
+Pyroscope is a horizontally scalable, highly available, multi-tenant continuous profiling aggregation system. 
+It's designed to store and query profiling data at scale, similar to how Prometheus works for metrics and Loki for logs.
+
+**Key Characteristics:**
+- Written in **Go**
+- Microservices-based architecture inspired by Cortex/Mimir/Loki
+- Stores profiling data in object storage (S3, GCS, Azure, etc.)
+- Multi-tenant by design
+
+## Architecture Overview
+
+Pyroscope uses a **microservices architecture** where a single binary can run different components based on the `-target` parameter.
+
+### V1 Components
+
+**Write Path:**
+- **Distributor**: Receives profile ingestion requests, validates, and forwards to ingesters
+- **Ingester**: Stores profiles in memory, periodically flushes to disk as blocks, periodically uploads blocks to long-term object storage
+- **Compactor**: Merges blocks and removes duplicates
+
+**Read Path:**
+- **Query Frontend**: Entry point for queries, handles query splitting and caching
+- **Query Scheduler**: Manages query queue and ensures fair execution across tenants
+- **Querier**: Executes queries by fetching data from ingesters and store-gateways
+- **Store Gateway**: Indexes and serves blocks from long-term object storage
+
+### V2 Components
+
+**Write Path:**
+- **Distributor**: Receives profile ingestion requests, validates, and forwards to segment writers
+- **Segment Writer**: Writes block segments to long-term object storage and the block metadata to metastore
+- **Metastore**: Maintains an index for the block metadata and coordinates the block compaction process
+- **Compaction Worker**: Merges small segments into larger blocks
+
+**Read Path:**
+- **Query Frontend**: Entry point for queries, creates the query plan and executes it against query backends
+- **Query Backend**: Executes queries and merges query responses
+
+### Storage
+
+- **Block Format**: Profiles stored in Parquet tables, series data in a TSDB index, symbols in a custom format
+- **Multi-tenant**: Each tenant has isolated storage
+- **Object Storage**: Primary storage backend (S3, GCS, Azure, local filesystem)
+
+## Repository Structure
+
+```
+.
+├── cmd/
+│   ├── pyroscope/           # Main server binary
+│   └── profilecli/          # CLI tool for profile operations
+├── pkg/                     # Core Go packages
+│   ├── distributor/         # Distributor component
+│   ├── ingester/            # Ingester component
+│   ├── querier/             # Querier component
+│   ├── frontend/            # Query frontend component
+│   ├── compactor/           # Compactor component
+│   ├── metastore/           # Metadata component
+│   ├── phlaredb/            # V1 database storage engine
+│   ├── model/               # Data models and types
+│   ├── objstore/            # Object storage abstraction
+│   ├── api/                 # API definitions and handlers
+│   └── og/                  # Legacy code (original Pyroscope)
+├── public/app/              # React/TypeScript frontend
+├── api/                     # API definitions (protobuf, OpenAPI)
+├── docs/                    # Documentation
+├── operations/              # Deployment configs (jsonnet, helm)
+├── examples/                # Example applications and SDKs
+└── tools/                   # Development and build tools
+```
+
+## Tech Stack
+
+### Backend
+- **Language**: Go 1.24+
+- **RPC**: gRPC with Connect protocol
+- **Storage**: Parquet, TSDB
+- **Hash Ring**: Consistent hashing with memberlist (gossip protocol)
+- **Observability**: Prometheus metrics, Structured logs, Distributed traces, pprof profiles
+
+### Frontend
+- **Language**: TypeScript
+- **Framework**: React
+- **Build**: Webpack
+- **Styling**: Emotion (CSS-in-JS)
+- **State**: React hooks, Context API
+- **UI Library**: Grafana UI components
+
+### Testing
+- **Go**: Standard `testing` package, testify for assertions
+- **Frontend**: Jest, React Testing Library, Cypress (e2e)
+
+## Development Workflow
+
+### Setup & Build
+
+```bash
+# Install dependencies (Go 1.24+, Docker, Node v18, Yarn v1.22)
+# All other tools auto-download to .tmp/bin/
+
+# Build backend
+make go/bin
+
+# Run tests
+make go/test
+
+# Build frontend
+yarn install
+yarn dev          # Dev server on :4041
+
+# Run backend for frontend development
+yarn backend:dev  # Runs Pyroscope server
+
+# Docker image
+make GOOS=linux GOARCH=amd64 docker-image/pyroscope/build
+```
+
+### Code Generation
+
+**IMPORTANT**: After changing protobuf, configs, or flags:
+```bash
+make generate
+```
+Commit the generated files with your changes.
+
+### Running Locally
+
+```bash
+# Run all components in monolithic mode with embedded Grafana
+go run ./cmd/pyroscope --target all,embedded-grafana
+# Pyroscope: http://localhost:4040
+# Grafana: http://localhost:4041
+```
+
+## Code Style & Conventions
+
+### Go Code
+
+1. **Imports**: Three groups separated by blank lines:
+   ```go
+   import (
+       // Standard library
+       "context"
+       "fmt"
+
+       // Third-party packages
+       "github.com/prometheus/client_golang/prometheus"
+       "go.uber.org/atomic"
+
+       // Internal packages
+       "github.com/grafana/pyroscope/pkg/model"
+       "github.com/grafana/pyroscope/pkg/objstore"
+   )
+   ```
+
+2. **Formatting**: Use `golangci-lint` (run via `make lint`)
+   - gofmt for formatting
+   - goimports with `-local github.com/grafana/pyroscope`
+
+3. **Linting**:
+   - Enabled: depguard, goconst, misspell, revive, unconvert, unparam
+   - Use `github.com/go-kit/log` (NOT `github.com/go-kit/kit/log`)
+
+4. **Error Handling**:
+   - Always check errors explicitly
+   - Wrap errors with context: `fmt.Errorf("failed to query: %w", err)`
+   - Use structured logging: `level.Error(logger).Log("msg", "failed to process", "err", err)`
+
+5. **Context**:
+   - Always pass `context.Context` as the first parameter
+   - Respect context cancellation in loops and long operations
+
+6. **Testing**:
+   - File naming: `*_test.go`
+   - Test function naming: `TestFunctionName` or `TestComponentName_Method`
+   - Use table-driven tests for multiple cases
+   - Prefer `t.Run()` for subtests
+   - Use `require` for fatal assertions, `assert` for non-fatal
+
+### TypeScript/React Code
+
+1. **File Extensions**: `.tsx` for components, `.ts` for utilities
+2. **Components**: Use functional components with hooks
+3. **Styling**: Use Emotion CSS-in-JS with Grafana UI theme
+4. **Props**: Define explicit TypeScript interfaces for all component props
+5. **Formatting**: Use Prettier (run via `yarn lint`)
+
+## Common Patterns
+
+### Multi-tenancy
+
+All requests must include a tenant ID in the `X-Scope-OrgID` header:
+
+```go
+import "github.com/grafana/pyroscope/pkg/tenant"
+
+// Extract tenant ID from context
+tenantID, err := tenant.ExtractTenantIDFromContext(ctx)
+if err != nil {
+    return err
+}
+```
+
+### Consistent Hashing
+
+Components use a hash ring for sharding:
+
+```go
+// Get ingester for a given label set
+replicationSet, err := ring.Get(key, op, bufDescs, bufHosts, bufZones)
+```
+
+### Object Storage
+
+Abstract object storage operations:
+
+```go
+import "github.com/grafana/pyroscope/pkg/objstore"
+
+// Use the Bucket interface
+bucket := objstore.NewBucket(cfg)
+reader, err := bucket.Get(ctx, "path/to/object")
+```
+
+### Configuration
+
+Use `github.com/grafana/dskit` for configuration:
+
+```go
+type Config struct {
+    ListenPort int `yaml:"listen_port"`
+    // Use RegisterFlags pattern
+}
+
+func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
+    f.IntVar(&cfg.ListenPort, "server.http-listen-port", 4040, "HTTP listen port")
+}
+```
+
+Run `make generate` after changing config definitions, to regenerate docs.
+
+## Testing Best Practices
+
+1. **Unit Tests**: Test individual functions/methods in isolation
+2. **Integration Tests**: Use build tags: `//go:build integration`
+3. **Mocking**: Use `mockery` for generating mocks from interfaces
+4. **Fixtures**: Store test data in `testdata/` directories
+5. **Parallel Tests**: Use `t.Parallel()` when tests are independent
+6. **Cleanup**: Always use `t.Cleanup()` for resource cleanup
+
+Example test:
+```go
+func TestDistributor_Push(t *testing.T) {
+    t.Parallel()
+
+    tests := []struct {
+        name    string
+        input   *pushv1.PushRequest
+        wantErr bool
+    }{
+        {name: "valid request", input: validRequest(), wantErr: false},
+        {name: "invalid tenant", input: invalidRequest(), wantErr: true},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            d := setupDistributor(t)
+            err := d.Push(context.Background(), tt.input)
+            if tt.wantErr {
+                require.Error(t, err)
+            } else {
+                require.NoError(t, err)
+            }
+        })
+    }
+}
+```
+
+## Common Pitfalls & Things to Avoid
+
+1. **Don't** introduce dependencies on `pkg/og/` - this is legacy code being phased out
+2. **Don't** use `github.com/go-kit/kit/log` - use `github.com/go-kit/log`
+3. **Don't** forget to run `make generate` after changing protobuf/config definitions
+4. **Don't** hardcode tenant IDs – always extract from context
+5. **Don't** create unbounded goroutines – use worker pools or semaphores
+6. **Don't** ignore context cancellation in loops
+7. **Don't** log PII or sensitive data
+8. **Don't** use `fmt.Println` for logging - use structured logging
+9. **Don't** add imports within the three import groups (keep them separate)
+10. **Don't** commit changes to `node_modules/` or generated code without source changes
+
+## Security Considerations
+
+1. **Input Validation**: Always validate and sanitize user input
+2. **Path Traversal**: Validate object keys before storage operations
+3. **Rate Limiting**: Distributor implements per-tenant rate limiting
+4. **Authentication**: Multi-tenancy via `X-Scope-OrgID` header (authentication delegated to gateway)
+
+## Performance Considerations
+
+1. **Profiling**: This is a profiling system – profile your own changes!
+   ```bash
+   go test -cpuprofile=cpu.prof -memprofile=mem.prof -bench=.
+   go tool pprof cpu.prof
+   ```
+
+2. **Allocations**: Minimize allocations in hot paths
+   - Reuse buffers with `sync.Pool`
+   - Avoid string concatenation in loops
+   - Use `strings.Builder` for string building
+
+3. **Concurrency**:
+   - Use worker pools for bounded concurrency
+   - Prefer channels for coordination over mutexes when possible
+   - Always consider the scalability implications
+
+## Documentation
+
+- **User Docs**: `docs/sources/` - Published to grafana.com
+- **Contributing**: `docs/internal/contributing/README.md`
+- **Component Docs**: In `docs/sources/reference-pyroscope-architecture/components/`
+
+## Useful Make Targets
+
+```bash
+make help              # Show all available targets
+make lint              # Run linters
+make go/test           # Run Go unit tests
+make go/bin            # Build binaries
+make go/mod            # Tidy go modules
+make generate          # Generate code (protobuf, mocks, etc.)
+make docker-image/pyroscope/build  # Build Docker image
+```
+
+## Key Dependencies
+
+- **dskit**: Grafana's distributed systems toolkit (ring, services, middleware)
+- **connect**: RPC framework (gRPC-compatible)
+- **parquet-go**: Parquet file format implementation
+- **go-kit/log**: Structured logging
+- **prometheus/client_golang**: Metrics instrumentation
+- **opentracing-go**: Distributed tracing
+
+## When Working on Features
+
+1. **Read Component Docs**: Check `docs/sources/reference-pyroscope-architecture/components/` for the component you're modifying
+2. **Understand the Ring**: If working on write/read path, understand consistent hashing
+3. **Multi-tenancy First**: Always consider multi-tenant implications
+4. **Check for Similar Code**: Pyroscope is inspired by Cortex/Mimir - similar patterns apply
+5. **Test Multi-tenancy**: Test with multiple tenants to catch isolation issues
+6. **Profile Your Changes**: Use `go test -bench` and verify performance impact
+7. **Update Documentation**: If changing user-facing behavior, update docs
+
+## Getting Help
+
+- **Contributing Guide**: `docs/internal/contributing/README.md`
+- **Code Comments**: The codebase has extensive comments – read them
+- **Git History**: Use `git blame` and `git log` to understand design decisions
+
+## Commit Guidelines
+
+- **Atomic Commits**: Each commit should be a logical unit
+- **Commit Messages**: Focus on "why" not just "what"
+- **Generated Code**: Include generated files in the same commit as source changes
+- **Format**: Follow existing commit message style (see `git log --oneline -20`)
+
+## Additional Notes for AI Agents
+
+- **Favor Simplicity**: Pyroscope values simple, maintainable code over clever abstractions
+- **Performance Matters**: This system handles high-throughput profiling data
+- **Multi-tenancy is Critical**: Tenant isolation bugs are severe – test thoroughly
+- **Consistency with Grafana Labs Style**: Follow patterns from dskit, Mimir, Loki
+- **Ask Before Large Refactors**: Propose significant architectural changes before implementing
+
+---
+
+For detailed setup and contributing instructions, see:
+- `docs/internal/contributing/README.md` - Development setup and workflow
+- `docs/sources/reference-pyroscope-architecture/` - System architecture deep dive

--- a/docs/internal/contributing/README.md
+++ b/docs/internal/contributing/README.md
@@ -19,7 +19,7 @@ a piece of work is finished it should:
 
 To be able to run make targets you'll need to install:
 
-- [Go](https://go.dev/doc/install) (>= 1.22)
+- [Go](https://go.dev/doc/install) (>= 1.24)
 - [Docker](https://docs.docker.com/engine/install/)
 
 All other required tools will be automatically downloaded `$(pwd)/.tmp/bin`.
@@ -66,16 +66,6 @@ make GOOS=linux GOARCH=amd64 docker-image/pyroscope/build
 make IMAGE_PLATFORM=linux/arm64 GOOS=linux GOARCH=arm64 docker-image/pyroscope/build
 ```
 
-#### Apple arm64 builds (M1/M2 chips)
-
-If you encounter errors during the installation of the node packages due to missing arm64 build of `canvas`:
-
-```
-brew install pkg-config cairo pango libpng jpeg giflib librsvg
-```
-
-See https://github.com/Automattic/node-canvas/issues/1662
-
 #### Running examples locally
 replace `image: grafana/pyroscope` with the local tag name you got from docker-image/pyroscope/build (i.e):
 
@@ -86,36 +76,44 @@ replace `image: grafana/pyroscope` with the local tag name you got from docker-i
       - '4040:4040'
 ```
 
-#### Run with Pyroscope with embedded Grafana + Explore Profiles
+#### Run with Pyroscope with embedded Grafana + Profiles Drilldown
 
-In order to quickly test the whole stack it is possible to run an embedded Grafana by using target parameter:
+To quickly test the whole stack it is possible to run an embedded Grafana by using the target parameter:
 
 ```
 go run ./cmd/pyroscope --target all,embedded-grafana
 ```
 
-This will start additional to Pyroscope on `:4040`, the embedded Grafana on port `:4041`.
+This will Pyroscope on `:4040` and the embedded Grafana on port `:4041`.
 
-#### Front end development
+#### Frontend development
+
+The frontend application is not in active development. While the UI it provides is usable and stable,
+the recommended way to view and analyze profiling data is to use the 
+[Profiles Drilldown](https://grafana.com/docs/grafana/latest/visualizations/simplified-exploration/profiles/) Grafana app (pre-installed in recent Grafana versions).
+
+If you do need to make changes to the frontend code, the following instructions should get you started.
 
 **Versions for development tools**:
 - Node v18
 - Yarn v1.22
 
-The front end code is all located in the `public/app` directory, although its `plugin.json`
-file exists at the repository root.
+The frontend code is located in the `public/app` directory, although its `package.json` file is at the repository root.
 
-To run the local front end source code:
+To run the local frontend application in development mode:
+
 ```sh
-yarn 
+yarn install
 yarn dev
 ```
 
-This will install / update front end dependencies and launch a process that will build
-the front end code, launch a pyroscope web app service at `http://localhost:4041`,
-and keep that web app updated any time you save the front end source code.
-The resulting web app will not initially be connected to a pyroscope server,
-so all attempts to fetch data will fail.
+This will:
+- install and update frontend dependencies
+- launch a process that will build the frontend code
+- serve the built app at `http://localhost:4041`
+- keep the web app updated any time you update the frontend source code
+
+The web app will not initially be connected to a Pyroscope server, so all attempts to fetch data will fail.
 
 To launch a pyroscope server for development purposes:
 ```sh
@@ -127,7 +125,7 @@ This yarn script actually runs the following:
 make build run 'PARAMS=--config.file ./cmd/pyroscope/pyroscope.yaml'
 ```
 
-It will take a while for this process to build and start serving pyroscope data, but
+It can take a while for this process to build and start serving pyroscope data, but
 once it is fully active, the pyroscope web app service at `http://localhost:4041`
 will be able to interact with it.
 
@@ -158,6 +156,6 @@ Commit the changes to `go.mod` and `go.sum` before submitting your pull request.
 
 The Grafana Pyroscope documentation is compiled into a website published at [grafana.com](https://grafana.com/).
 
-To start the website locally you can use `make docs/docs` and follow console instructions to access the website.
+To start the website locally you can use `make docs/docs`. The command will print instructions on how to access the website.
 
 Note: if you attempt to view pages on GitHub, it's likely that you might find broken links or pages. That is expected and should not be addressed unless it is causing issues with the site that occur as part of the build.


### PR DESCRIPTION
Adds [CLAUDE.md](https://www.anthropic.com/engineering/claude-code-best-practices) and [Cursor Rules](https://cursor.com/docs/context/rules) to guide coding agents on best practices, things to avoid, etc.

I used Claude Code to create a foundation for CLAUDE.md using the existing contribution guide and then made it better. The Cursor Rules are derived from CLAUDE.md. 

I've verified that the instructions work in both Claude Code and Cursor by asking questions like _What are the main components in Pyroscope's write path?_. I haven't tried generating code and seeing how well best practices are followed.

This is open for debate and contributions. Feel free to suggest changes, add support for other agents or raise your concerns if you have any. 