### PR TITLE
chore: Frontend update sweetalert2

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "redux-persist": "^6.0.0",
     "redux-query-sync": "^0.1.10",
     "sass-loader": "^9.0.2",
-    "sweetalert2": "^11.4.0, <11.4.9",
+    "sweetalert2": "^11.22.4",
     "sweetalert2-react-content": "^4.2.0",
     "timezone-mock": "^1.3.0",
     "true-myth": "~5.2.0",

--- a/public/app/ui/Modals/index.ts
+++ b/public/app/ui/Modals/index.ts
@@ -48,19 +48,27 @@ const ShowModal = async ({
   validationMessage,
   inputValidator,
 }: ShowModalParams) => {
-  const { isConfirmed, value } = await Swal.fire({
+  const baseOptions = {
     title,
     html,
     confirmButtonText,
-    input,
-    inputLabel,
-    inputPlaceholder,
-    inputValue,
-    validationMessage,
-    inputValidator,
     confirmButtonColor: getButtonStyleFromType(type),
     ...defaultParams,
-  });
+  };
+
+  const options = input
+    ? {
+        ...baseOptions,
+        input,
+        inputLabel,
+        inputPlaceholder,
+        inputValue,
+        validationMessage,
+        inputValidator,
+      }
+    : baseOptions;
+
+  const { isConfirmed, value } = await Swal.fire(options as SweetAlertOptions);
 
   if (isConfirmed) {
     onConfirm(value);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9978,10 +9978,10 @@ sweetalert2-react-content@^4.2.0:
   resolved "https://registry.yarnpkg.com/sweetalert2-react-content/-/sweetalert2-react-content-4.2.0.tgz#ab4a6e02e37150dd0ea34d00179ec76952e3f442"
   integrity sha512-eB324swnq10UJH8nAH2S6GHuAKDgH6GpGU8vI+ulYdmlPzpb0T5QPc7O4RFNRx28GzVZUnfvtpxZbKtZ5/KOnQ==
 
-"sweetalert2@^11.4.0, <11.4.9":
-  version "11.4.8"
-  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.4.8.tgz#f436eb34107c5637a0278fa7330edc722090ebbb"
-  integrity sha512-BDS/+E8RwaekGSxCPUbPnsRAyQ439gtXkTF/s98vY2l9DaVEOMjGj1FaQSorfGREKsbbxGSP7UXboibL5vgTMA==
+sweetalert2@^11.22.4:
+  version "11.26.17"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-11.26.17.tgz#be5dd2a9b8d1c3b2672de4de4d172e62f7be3a6d"
+  integrity sha512-kkaySn1IRfwNlf9AkZVqDmBINDWw9NRR6Ij0O5dBRBOD1+mbtZJWxxR9/pA90nce9E5tIIkJ7SWij4rMWXtA1g==
 
 synckit@^0.8.5:
   version "0.8.5"


### PR DESCRIPTION
```
yarn.lock (yarn)

Total: 4 (UNKNOWN: 0, LOW: 3, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌─────────────┬─────────────────────┬──────────┬────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│   Library   │    Vulnerability    │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                            │
├─────────────┼─────────────────────┼──────────┼────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ sweetalert2 │ GHSA-457r-cqc8-9vj9 │ LOW      │        │ 11.4.8            │ 11.22.4       │ sweetalert2 v10.16.10 and above contains hidden             │
│             │                     │          │        │                   │               │ functionality                                               │
│             │                     │          │        │                   │               │ https://github.com/advisories/GHSA-457r-cqc8-9vj9           │
│             ├─────────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│             │ GHSA-8jh9-wqpf-q52c │          │        │                   │               │ sweetalert2 v8.19.1 and above contains hidden functionality │
│             │                     │          │        │                   │               │ https://github.com/advisories/GHSA-8jh9-wqpf-q52c           │
│             ├─────────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│             │ GHSA-pg98-6v7f-2xfv │          │        │                   │               │ sweetalert2 v9.17.4 and above contains hidden functionality │
│             │                     │          │        │                   │               │ https://github.com/advisories/GHSA-pg98-6v7f-2xfv           │
└─────────────┴─────────────────────┴──────────┴────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────
```