### PR TITLE
fix: pass `$IMAGE_TAG` directly to Goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
           persist-credentials: 'false'
       - name: Set GIT_LAST_COMMIT_DATE
         run: echo "GIT_LAST_COMMIT_DATE=$(git log -1 --date=iso-strict --format=%cd)" >> $GITHUB_ENV
+      - name: Set IMAGE_TAG from git tag
+        run: echo "IMAGE_TAG=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
       - name: Set IMAGE_PUBLISH_LATEST=true, so we overwrite the latest docker image tag and update Homebrew
         run: echo "IMAGE_PUBLISH_LATEST=true" >> $GITHUB_ENV
       # Forces goreleaser to use the correct previous tag for the changelog

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,8 +9,8 @@ env:
   - GORELEASER_DEBUG_INFO_FLAGS={{ if and (index .Env "GORELEASER_STRIP_DEBUG_INFO") (eq .Env.GORELEASER_STRIP_DEBUG_INFO "false")  }}{{ else }}-s -w{{ end }}
   # Use a custom image prefix (registry) or fallback to docker.io/grafana/
   - IMAGE_PREFIX={{ or (index .Env "IMAGE_PREFIX") "docker.io/grafana/" }}
-  # Allow a custom image tag to be used
-  - IMAGE_TAG={{ or (index .Env "IMAGE_TAG") .Version }}
+  # Allow a custom image tag to be used (must be set by workflow)
+  - IMAGE_TAG={{ .Env.IMAGE_TAG }}
   # Publish latest image tag
   - IMAGE_PUBLISH_LATEST={{ or (index .Env "IMAGE_PUBLISH_LATEST") "false" }}
   # Skip GitHub release upload


### PR DESCRIPTION
Goreleaser tried to infer `$IMAGE_TAG` from `.Version` which isn't present/set when the `env` block is being evaluated. Instead, require this env var to be set by callers explicitly.