### PR TITLE
fix: Relative matching for source code mapping

### DIFF
--- a/pkg/frontend/vcs/source/find_python.go
+++ b/pkg/frontend/vcs/source/find_python.go
@@ -103,5 +103,13 @@ func (ff FileFinder) findPythonFile(ctx context.Context, mappings ...*config.Map
 		return resp, nil
 	}
 
+	// Fallback to relative file path matching
+	f, err := ff.fetchRepoFile(ctx, ff.file.Path, ff.ref)
+	if err != nil {
+		level.Warn(ff.logger).Log("msg", "failed to fetch relative file", "err", err)
+	} else {
+		return f, nil
+	}
+
 	return nil, fmt.Errorf("stdlib not detected and no mappings provided, file not resolvable")
 }

--- a/pkg/frontend/vcs/source/find_test.go
+++ b/pkg/frontend/vcs/source/find_test.go
@@ -462,6 +462,29 @@ require (
 			expectedError:   false,
 		},
 		{
+			name: "python/relative-path",
+			fileSpec: config.FileSpec{
+				FunctionName: "ListRecommendations",
+				Path:         "recommendation_server.py",
+			},
+			rootPath: "examples/python-app",
+			ref:      "main",
+			mockFiles: []mockFileResponse{
+				{
+					request: client.FileRequest{
+						Owner: "grafana",
+						Repo:  "pyroscope",
+						Ref:   "main",
+						Path:  "examples/python-app/recommendation_server.py",
+					},
+					content: "# CONTENT recommendation_server.py",
+				},
+			},
+			expectedContent: "# CONTENT recommendation_server.py",
+			expectedURL:     "https://github.com/grafana/pyroscope/blob/main/examples/python-app/recommendation_server.py",
+			expectedError:   false,
+		},
+		{
 			name: "fallback/unknown-file-extension",
 			fileSpec: config.FileSpec{
 				FunctionName: "some.function",


### PR DESCRIPTION
By introducing the python matching in #4732 we no longer do fallback to relative source matching.