### PR TITLE
fix(lidia): use stable sort

### DIFF
--- a/lidia/builder.go
+++ b/lidia/builder.go
@@ -78,7 +78,7 @@ func (rb *rangesBuilder) add(va uint64, e rangeEntry) {
 }
 
 func (rb *rangesBuilder) sort() {
-	sort.Sort(&sortByVADepth{rb})
+	sort.Stable(&sortByVADepth{rb})
 }
 
 // sortByVADepth sorts the ranges by VA and then by depth.


### PR DESCRIPTION
We used to use unstable sort and after  this check added
https://github.com/grafana/pyroscope/blob/a49b562cd2fc84ce4f1e165af1ae6fc074ff2695/lidia/lidia.go#L176

The final table changed randomly
```
Without table 

before check
9cbb0 pthread_create@@GLIBC_2.34
9cbb0 __GI___pthread_create
9cbb0 pthread_create@GLIBC_2.2.5
9cbb0 __pthread_create_2_1

after check
9cbb0 __GI___pthread_create
9cbb0 pthread_create@GLIBC_2.2.5
9cbb0 __pthread_create_2_1
9cbb0 pthread_create@@GLIBC_2.34

With stable

before check
9cbb0 __pthread_create_2_1
9cbb0 __GI___pthread_create
9cbb0 pthread_create@GLIBC_2.2.5
9cbb0 pthread_create@@GLIBC_2.34

after check
9cbb0 __pthread_create_2_1
9cbb0 __GI___pthread_create
9cbb0 pthread_create@GLIBC_2.2.5
9cbb0 pthread_create@@GLIBC_2.34

```

The unstable sort leads to unpredictable results making harder to inspect/test the final table https://github.com/grafana/opentelemetry-ebpf-profiler/pull/40/files