### PR TITLE
fix: Failed file lookup should be 404 instead of 500

### DIFF
--- a/pkg/frontend/vcs/source/find_java.go
+++ b/pkg/frontend/vcs/source/find_java.go
@@ -3,9 +3,9 @@ package source
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strings"
 
+	"connectrpc.com/connect"
 	"github.com/go-kit/log/level"
 	"github.com/opentracing/opentracing-go"
 
@@ -67,5 +67,5 @@ func (ff FileFinder) findJavaFile(ctx context.Context, mappings ...*config.Mappi
 		return resp, nil
 	}
 
-	return nil, fmt.Errorf("no mappings provided, file not resolvable")
+	return nil, connect.NewError(connect.CodeNotFound, errors.New("no mappings provided, file not resolvable"))
 }

--- a/pkg/frontend/vcs/source/find_python.go
+++ b/pkg/frontend/vcs/source/find_python.go
@@ -3,11 +3,11 @@ package source
 import (
 	"context"
 	"errors"
-	"fmt"
 	"path/filepath"
 	"regexp"
 	"strings"
 
+	"connectrpc.com/connect"
 	"github.com/go-kit/log/level"
 	"github.com/opentracing/opentracing-go"
 
@@ -111,5 +111,5 @@ func (ff FileFinder) findPythonFile(ctx context.Context, mappings ...*config.Map
 		return f, nil
 	}
 
-	return nil, fmt.Errorf("stdlib not detected and no mappings provided, file not resolvable")
+	return nil, connect.NewError(connect.CodeNotFound, errors.New("stdlib not detected and no mappings provided, file not resolvable"))
 }


### PR DESCRIPTION
For java and python, we shouldn't fail with 500 if there is no mapping or file found