### PR TITLE
chore: Set a maximum ingestion body size by default

### DIFF
--- a/cmd/pyroscope/help-all.txt.tmpl
+++ b/cmd/pyroscope/help-all.txt.tmpl
@@ -174,7 +174,7 @@ Usage of ./pyroscope:
   -distributor.ingestion-artificial-delay duration
     	[experimental] Target ingestion delay to apply to all tenants. If set to a non-zero value, the distributor will artificially delay ingestion time-frame by the specified duration by computing the difference between actual ingestion and the target. There is no delay on actual ingestion of samples, it is only the response back to the client.
   -distributor.ingestion-body-limit-mb float
-    	Per-tenant ingestion body size limit in MB, before decompressing. 0 to disable.
+    	Per-tenant ingestion body size limit in MB, before decompressing. 0 to disable. (default 256)
   -distributor.ingestion-burst-size-mb float
     	Per-tenant allowed ingestion burst size (in sample size). Units in MB. The burst size refers to the per-distributor local rate limiter, and should be set at least to the maximum profile size expected in a single push request. (default 2)
   -distributor.ingestion-rate-limit-mb float

--- a/pkg/validation/limits.go
+++ b/pkg/validation/limits.go
@@ -149,7 +149,7 @@ func (e LimitError) Error() string {
 func (l *Limits) RegisterFlags(f *flag.FlagSet) {
 	f.Float64Var(&l.IngestionRateMB, "distributor.ingestion-rate-limit-mb", 4, "Per-tenant ingestion rate limit in sample size per second. Units in MB.")
 	f.Float64Var(&l.IngestionBurstSizeMB, "distributor.ingestion-burst-size-mb", 2, "Per-tenant allowed ingestion burst size (in sample size). Units in MB. The burst size refers to the per-distributor local rate limiter, and should be set at least to the maximum profile size expected in a single push request.")
-	f.Float64Var(&l.IngestionBodyLimitMB, "distributor.ingestion-body-limit-mb", 0, "Per-tenant ingestion body size limit in MB, before decompressing. 0 to disable.")
+	f.Float64Var(&l.IngestionBodyLimitMB, "distributor.ingestion-body-limit-mb", 256, "Per-tenant ingestion body size limit in MB, before decompressing. 0 to disable.")
 	f.IntVar(&l.IngestionTenantShardSize, "distributor.ingestion-tenant-shard-size", 0, "The tenant's shard size used by shuffle-sharding. Must be set both on ingesters and distributors. 0 disables shuffle sharding.")
 
 	f.IntVar(&l.MaxLabelNameLength, "validation.max-length-label-name", 1024, "Maximum length accepted for label names.")


### PR DESCRIPTION
Sets the default ingestion body size limit to 256MB, which will help protect Pyroscope instances from excessively large payloads while still allowing legitimate profiling data to be ingested.
