### PR TITLE
Add release notes for v1.18

### DIFF
--- a/docs/sources/release-notes/v1-1.md
+++ b/docs/sources/release-notes/v1-1.md
@@ -2,7 +2,7 @@
 title: Version 1.1 release notes
 menuTitle: V1.1
 description: Release notes for Grafana Pyroscope 1.1
-weight: 850
+weight: 890
 ---
 
 # Version 1.1 release notes

--- a/docs/sources/release-notes/v1-10.md
+++ b/docs/sources/release-notes/v1-10.md
@@ -2,7 +2,7 @@
 title: Version 1.10 release notes
 menuTitle: V1.10
 description: Release notes for Grafana Pyroscope 1.10
-weight: 400
+weight: 800
 ---
 
 # Version 1.10 release notes

--- a/docs/sources/release-notes/v1-11.md
+++ b/docs/sources/release-notes/v1-11.md
@@ -2,7 +2,7 @@
 title: Version 1.11 release notes
 menuTitle: V1.11
 description: Release notes for Grafana Pyroscope 1.11
-weight: 350
+weight: 790
 ---
 
 # Version 1.11 release notes

--- a/docs/sources/release-notes/v1-12.md
+++ b/docs/sources/release-notes/v1-12.md
@@ -2,7 +2,7 @@
 title: Version 1.12 release notes
 menuTitle: V1.12
 description: Release notes for Grafana Pyroscope 1.12
-weight: 300
+weight: 780
 ---
 
 # Version 1.12.1 release notes

--- a/docs/sources/release-notes/v1-13.md
+++ b/docs/sources/release-notes/v1-13.md
@@ -2,7 +2,7 @@
 title: Version 1.13 release notes
 menuTitle: V1.13
 description: Release notes for Grafana Pyroscope 1.13
-weight: 250
+weight: 770
 ---
 
 ## Version 1.13.6 release notes

--- a/docs/sources/release-notes/v1-14.md
+++ b/docs/sources/release-notes/v1-14.md
@@ -2,7 +2,7 @@
 title: Version 1.14 release notes
 menuTitle: V1.14
 description: Release notes for Grafana Pyroscope 1.14
-weight: 200
+weight: 760
 ---
 
 ## Version 1.14.1 release notes

--- a/docs/sources/release-notes/v1-15.md
+++ b/docs/sources/release-notes/v1-15.md
@@ -2,7 +2,7 @@
 title: Version 1.15 release notes
 menuTitle: V1.15
 description: Release notes for Grafana Pyroscope 1.15
-weight: 150
+weight: 750
 ---
 
 ## Version 1.15.3 release notes

--- a/docs/sources/release-notes/v1-16.md
+++ b/docs/sources/release-notes/v1-16.md
@@ -2,7 +2,7 @@
 title: Version 1.16 release notes
 menuTitle: V1.16
 description: Release notes for Grafana Pyroscope 1.16
-weight: 100
+weight: 740
 ---
 
 ## Version 1.16.2 release notes

--- a/docs/sources/release-notes/v1-17.md
+++ b/docs/sources/release-notes/v1-17.md
@@ -2,7 +2,7 @@
 title: Version 1.17 release notes
 menuTitle: V1.17
 description: Release notes for Grafana Pyroscope 1.17
-weight: 50
+weight: 730
 ---
 
 ## Version 1.17.0 release notes

--- a/docs/sources/release-notes/v1-18.md
+++ b/docs/sources/release-notes/v1-18.md
@@ -1,0 +1,37 @@
+---
+title: Version 1.18 release notes
+menuTitle: V1.18
+description: Release notes for Grafana Pyroscope 1.18
+weight: 720
+---
+
+## Version 1.18.0 release notes
+
+The Pyroscope team is excited to present Grafana Pyroscope 1.18.0
+
+This release contains enhancements, fixes, improves stability & performance.
+
+Notable changes are listed below. For more details, check out the [1.18.0 changelog](https://github.com/grafana/pyroscope/compare/v1.17.1...v1.18.0).
+
+### Enhancements
+* The source code integration now supports Python ([#4726](https://github.com/grafana/pyroscope/pull/4726), [#4732](https://github.com/grafana/pyroscope/pull/4732), [#4730](https://github.com/grafana/pyroscope/pull/4730))
+* Implement comprehensive profile size limits across ingestion endpoints ([#4734](https://github.com/grafana/pyroscope/pull/4734))
+* Update golang version to 1.24.12 ([#4760](https://github.com/grafana/pyroscope/pull/4760))
+* Set a maximum ingestion body size by default ([#4761](https://github.com/grafana/pyroscope/pull/4761))
+* Update OpenTelemetry dependencies, `proto=v1.9.0` `profiles=v0.2.0` ([#4731](https://github.com/grafana/pyroscope/pull/4731))
+* Enforce maxNodes optionally on SelectMergeProfile through limits in v2 ([#4723](https://github.com/grafana/pyroscope/pull/4723))
+* Add benchmarks for timeseries query performance with exemplars ([#4665](https://github.com/grafana/pyroscope/pull/4665))
+
+### Fixes
+* Fix exemplar value calculation for split profiles ([#4753](https://github.com/grafana/pyroscope/pull/4753))
+* Relative matching for source code mapping ([#4754](https://github.com/grafana/pyroscope/pull/4754))
+* VCS Service: Failed file lookup should be 404 instead of 500 ([#4759](https://github.com/grafana/pyroscope/pull/4759))
+* Remove unintended double base64 encoding in vcs service ([#4703](https://github.com/grafana/pyroscope/pull/4703))
+* Frontend: Bump `qs` to address CVE-2025-15284 ([#4724](https://github.com/grafana/pyroscope/pull/4724))
+* Frontend: Bump `sweetalert2` to address GHSA-457r-cqc8-9vj9, GHSA-8jh9-wqpf-q52c and GHSA-pg98-6v7f-2xfv ([#4727](https://github.com/grafana/pyroscope/pull/4727))
+* Frontend: Bump `@remix-run/router` and `react-router` to address CVE-2026-22029 and CVE-2025-68470 ([#4763](https://github.com/grafana/pyroscope/pull/4763))
+
+### Documentation
+* Rename GitHub integration to source code integration ([#4755](https://github.com/grafana/pyroscope/pull/4755))
+* Update source code integration docs to include Java and Python support ([#4651](https://github.com/grafana/pyroscope/pull/4651))
+* Fix inline link in eBPF docs ([#4733](https://github.com/grafana/pyroscope/pull/4733))

--- a/docs/sources/release-notes/v1-2.md
+++ b/docs/sources/release-notes/v1-2.md
@@ -2,7 +2,7 @@
 title: Version 1.2 release notes
 menuTitle: V1.2
 description: Release notes for Grafana Pyroscope 1.2
-weight: 800
+weight: 880
 ---
 
 # Version 1.2 release notes

--- a/docs/sources/release-notes/v1-3.md
+++ b/docs/sources/release-notes/v1-3.md
@@ -2,7 +2,7 @@
 title: Version 1.3 release notes
 menuTitle: V1.3
 description: Release notes for Grafana Pyroscope 1.3
-weight: 750
+weight: 870
 ---
 
 # Version 1.3 release notes

--- a/docs/sources/release-notes/v1-4.md
+++ b/docs/sources/release-notes/v1-4.md
@@ -2,7 +2,7 @@
 title: Version 1.4 release notes
 menuTitle: V1.4
 description: Release notes for Grafana Pyroscope 1.4
-weight: 700
+weight: 860
 ---
 
 # Version 1.4 release notes

--- a/docs/sources/release-notes/v1-5.md
+++ b/docs/sources/release-notes/v1-5.md
@@ -2,7 +2,7 @@
 title: Version 1.5 release notes
 menuTitle: V1.5
 description: Release notes for Grafana Pyroscope 1.5
-weight: 650
+weight: 850
 ---
 
 # Version 1.5 release notes

--- a/docs/sources/release-notes/v1-6.md
+++ b/docs/sources/release-notes/v1-6.md
@@ -2,7 +2,7 @@
 title: Version 1.6 release notes
 menuTitle: V1.6
 description: Release notes for Grafana Pyroscope 1.6
-weight: 600
+weight: 840
 ---
 
 # Version 1.6 release notes

--- a/docs/sources/release-notes/v1-7.md
+++ b/docs/sources/release-notes/v1-7.md
@@ -2,7 +2,7 @@
 title: Version 1.7 release notes
 menuTitle: V1.7
 description: Release notes for Grafana Pyroscope 1.7
-weight: 550
+weight: 830
 ---
 
 # Version 1.7 release notes

--- a/docs/sources/release-notes/v1-8.md
+++ b/docs/sources/release-notes/v1-8.md
@@ -2,7 +2,7 @@
 title: Version 1.8 release notes
 menuTitle: V1.8
 description: Release notes for Grafana Pyroscope 1.8
-weight: 500
+weight: 820
 ---
 
 # Version 1.8 release notes

--- a/docs/sources/release-notes/v1-9.md
+++ b/docs/sources/release-notes/v1-9.md
@@ -2,7 +2,7 @@
 title: Version 1.9 release notes
 menuTitle: V1.9
 description: Release notes for Grafana Pyroscope 1.9
-weight: 450
+weight: 810
 ---
 
 # Version 1.9 release notes


### PR DESCRIPTION
Bringing in the release notes from the release branch. Note that I had to reset the weights as we ran out of space. This should be enough for ~70 more releases, after that we can reset the weights again :)