### PR TITLE
profilecli: add --force/-f flag to overwrite output files

### DIFF
--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -73,9 +73,11 @@ func main() {
 	queryCmd := app.Command("query", "Query profile store.")
 	queryProfileCmd := queryCmd.Command("profile", "Request merged profile.").Alias("merge")
 	queryProfileOutput := queryProfileCmd.Flag("output", "How to output the result, examples: console, raw, pprof=./my.pprof").Default("console").String()
+	queryProfileForce := queryProfileCmd.Flag("force", "Overwrite the output file if it already exists.").Short('f').Default("false").Bool()
 	queryProfileParams := addQueryProfileParams(queryProfileCmd)
 	queryGoPGOCmd := queryCmd.Command("go-pgo", "Request profile for Go PGO.")
 	queryGoPGOOutput := queryGoPGOCmd.Flag("output", "How to output the result, examples: console, raw, pprof=./my.pprof").Default("pprof=./default.pgo").String()
+	queryGoPGOForce := queryGoPGOCmd.Flag("force", "Overwrite the output file if it already exists.").Short('f').Default("false").Bool()
 	queryGoPGOParams := addQueryGoPGOParams(queryGoPGOCmd)
 	querySeriesCmd := queryCmd.Command("series", "Request series labels.")
 	querySeriesParams := addQuerySeriesParams(querySeriesCmd)
@@ -141,11 +143,11 @@ func main() {
 			}
 		}
 	case queryProfileCmd.FullCommand():
-		if err := queryProfile(ctx, queryProfileParams, *queryProfileOutput); err != nil {
+		if err := queryProfile(ctx, queryProfileParams, *queryProfileOutput, *queryProfileForce); err != nil {
 			os.Exit(checkError(err))
 		}
 	case queryGoPGOCmd.FullCommand():
-		if err := queryGoPGO(ctx, queryGoPGOParams, *queryGoPGOOutput); err != nil {
+		if err := queryGoPGO(ctx, queryGoPGOParams, *queryGoPGOOutput, *queryGoPGOForce); err != nil {
 			os.Exit(checkError(err))
 		}
 	case querySeriesCmd.FullCommand():

--- a/cmd/profilecli/output.go
+++ b/cmd/profilecli/output.go
@@ -41,7 +41,7 @@ func outputSeries(result []*typesv1.Labels) error {
 	return nil
 }
 
-func outputMergeProfile(ctx context.Context, outputFlag string, profile *googlev1.Profile) error {
+func outputMergeProfile(ctx context.Context, outputFlag string, force bool, profile *googlev1.Profile) error {
 	mypp := pp.New()
 	mypp.SetColoringEnabled(isatty.IsTerminal(os.Stdout.Fd()))
 	mypp.SetExportedOnly(true)
@@ -77,8 +77,14 @@ func outputMergeProfile(ctx context.Context, outputFlag string, profile *googlev
 			return errors.Wrap(err, "failed to marshal protobuf")
 		}
 
-		// open new file, fail when the file already exists
-		f, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0644)
+		// open new file, fail when the file already exists unless force is set
+		flags := os.O_RDWR | os.O_CREATE
+		if force {
+			flags |= os.O_TRUNC
+		} else {
+			flags |= os.O_EXCL
+		}
+		f, err := os.OpenFile(filePath, flags, 0644)
 		if err != nil {
 			return errors.Wrap(err, "failed to create pprof file")
 		}

--- a/cmd/profilecli/query-blocks.go
+++ b/cmd/profilecli/query-blocks.go
@@ -30,6 +30,7 @@ type blocksQueryParams struct {
 type blocksQueryProfileParams struct {
 	*blocksQueryParams
 	Output             string
+	Force              bool
 	ProfileType        string
 	StacktraceSelector []string
 }
@@ -53,6 +54,7 @@ func addBlocksQueryProfileParams(queryCmd commander) *blocksQueryProfileParams {
 	params := new(blocksQueryProfileParams)
 	params.blocksQueryParams = addBlocksQueryParams(queryCmd)
 	queryCmd.Flag("output", "How to output the result, examples: console, raw, pprof=./my.pprof").Default("console").StringVar(&params.Output)
+	queryCmd.Flag("force", "Overwrite the output file if it already exists.").Short('f').Default("false").BoolVar(&params.Force)
 	queryCmd.Flag("profile-type", "Profile type to query.").Default("process_cpu:cpu:nanoseconds:cpu:nanoseconds").StringVar(&params.ProfileType)
 	queryCmd.Flag("stacktrace-selector", "Only query locations with those symbols. Provide multiple times starting with the root").StringsVar(&params.StacktraceSelector)
 	return params
@@ -117,7 +119,7 @@ func blocksQueryProfile(ctx context.Context, params *blocksQueryProfileParams) e
 		return errors.Wrap(err, "failed to query")
 	}
 
-	return outputMergeProfile(ctx, params.Output, resp)
+	return outputMergeProfile(ctx, params.Output, params.Force, resp)
 }
 
 func blocksQuerySeries(ctx context.Context, params *blocksQuerySeriesParams) error {

--- a/cmd/profilecli/query.go
+++ b/cmd/profilecli/query.go
@@ -106,7 +106,7 @@ func addQueryProfileParams(queryCmd commander) *queryProfileParams {
 	return params
 }
 
-func queryProfile(ctx context.Context, params *queryProfileParams, outputFlag string) (err error) {
+func queryProfile(ctx context.Context, params *queryProfileParams, outputFlag string, force bool) (err error) {
 	from, to, err := params.parseFromTo()
 	if err != nil {
 		return err
@@ -137,17 +137,17 @@ func queryProfile(ctx context.Context, params *queryProfileParams, outputFlag st
 		level.Info(logger).Log("msg", "selecting with stackstrace selector", "call-site", fmt.Sprintf("%#+v", params.StacktraceSelector))
 	}
 
-	return selectMergeProfile(ctx, params.phlareClient, outputFlag, req)
+	return selectMergeProfile(ctx, params.phlareClient, outputFlag, force, req)
 }
 
-func selectMergeProfile(ctx context.Context, client *phlareClient, outputFlag string, req *querierv1.SelectMergeProfileRequest) error {
+func selectMergeProfile(ctx context.Context, client *phlareClient, outputFlag string, force bool, req *querierv1.SelectMergeProfileRequest) error {
 	qc := client.queryClient()
 	resp, err := qc.SelectMergeProfile(ctx, connect.NewRequest(req))
 	if err != nil {
 		return errors.Wrap(err, "failed to query")
 	}
 
-	return outputMergeProfile(ctx, outputFlag, resp.Msg)
+	return outputMergeProfile(ctx, outputFlag, force, resp.Msg)
 }
 
 type queryGoPGOParams struct {
@@ -164,7 +164,7 @@ func addQueryGoPGOParams(queryCmd commander) *queryGoPGOParams {
 	return params
 }
 
-func queryGoPGO(ctx context.Context, params *queryGoPGOParams, outputFlag string) (err error) {
+func queryGoPGO(ctx context.Context, params *queryGoPGOParams, outputFlag string, force bool) (err error) {
 	from, to, err := params.parseFromTo()
 	if err != nil {
 		return err
@@ -179,7 +179,7 @@ func queryGoPGO(ctx context.Context, params *queryGoPGOParams, outputFlag string
 		"keep-locations", params.KeepLocations,
 		"aggregate-callees", params.AggregateCallees,
 	)
-	return selectMergeProfile(ctx, params.phlareClient, outputFlag,
+	return selectMergeProfile(ctx, params.phlareClient, outputFlag, force,
 		&querierv1.SelectMergeProfileRequest{
 			ProfileTypeID: params.ProfileType,
 			Start:         from.UnixMilli(),


### PR DESCRIPTION
## Summary
- Add `-f`/`--force` flag to profilecli commands that write pprof output files
- When enabled, allows overwriting existing files instead of failing with "file exists" error
- Flag is disabled by default to preserve the current safe behavior

**Affected commands:**
- `profilecli query profile`
- `profilecli query go-pgo`
- `profilecli admin blocks query profile`

## Test plan
- [ ] Run `profilecli query profile --output pprof=./test.pprof` twice without `--force` - should fail on second run
- [ ] Run `profilecli query profile --output pprof=./test.pprof -f` twice - should succeed both times
- [ ] Verify `--help` shows the new flag for all three commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)