### PR TITLE
Add `.pre-commit-config.yaml` for pre-commit support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# Pre-commit hooks that delegate to Makefile targets
+# This ensures CI and local development use the same formatting/linting logic
+repos:
+  - repo: local
+    hooks:
+      - id: fmt
+        name: Format code (Go, protobuf, jsonnet)
+        entry: make fmt
+        language: system
+        pass_filenames: false
+        # Run on any file change - make fmt handles file filtering internally
+        always_run: true
+
+      - id: generate
+        name: Check generated protobuf files
+        entry: make generate check/unstaged-changes
+        language: system
+        pass_filenames: false
+        # Only run when protobuf-related files in api/ or pkg/ are staged
+        # This matches: api/**/*.proto, pkg/**/*.proto, api/buf*.yaml, pkg/buf*.yaml
+        # Root-level YAML files (renovate.json, .golangci.yml, etc.) are excluded
+        files: '^(api|pkg)/.*\.(proto|yaml)$'


### PR DESCRIPTION
Adds pre-commit hooks for code formatting and code generation. Code generation is only run when necessary (for protobuf-related files).

To use:
- Install pre-commit tool (via Homebrew, pip, etc.)
- Run `pre-commit install` in root of `pyroscope`

Only staged changes will be subject to pre-commit hooks for `git commit`.

To skip pre-commit, use `git commit --no-verify`.