### PR TITLE
Add Renovate rules for managing Makefile dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,16 @@
   "ignoreDeps": [],
   "separateMajorMinor": true,
   "separateMultipleMajor": true,
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^Makefile$"],
+      "matchStrings": [
+        "\\$\\(GO\\) install\\s+(?:.*\\s)?(?<depName>[\\w.\\/-]+)@(?<currentValue>v[\\d.]+)"
+      ],
+      "datasourceTemplate": "go"
+    }
+  ],
   "packageRules": [
     {
       "description": "Group all Go module updates (main project)",
@@ -65,6 +75,13 @@
       "automergeType": "pr",
       "automergeStrategy": "squash",
       "platformAutomerge": true
+    },
+    {
+      "description": "Group all Makefile tool updates",
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["Makefile"],
+      "groupName": "makefile-tools",
+      "schedule": ["before 4am on monday"]
     }
   ]
 }


### PR DESCRIPTION
Manages the dependencies here: https://github.com/grafana/pyroscope/blob/2528d6a1ce47fe87f7356da38e76e4c05e6ff88a/Makefile#L323-L402

Note that dependencies like `goreleaser` and `helm` that would be sensitive to major version upgrades have their current major version encoded in the module path already, and thus shouldn't be upgraded by these Renovate rules.