### PR TITLE
chore: Configure Renovate to respect minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,8 @@
   "timezone": "UTC",
   "schedule": ["before 4am on monday"],
   "prConcurrentLimit": 10,
+  "prCreation": "not-pending",
+  "internalChecksFilter": "strict",
   "ignoreDeps": [],
   "separateMajorMinor": true,
   "separateMultipleMajor": true,
@@ -13,27 +15,31 @@
       "matchManagers": ["gomod"],
       "matchFileNames": ["go.mod", "api/go.mod", "lidia/go.mod"],
       "groupName": "gomod",
-      "schedule": ["before 4am on monday"]
+      "schedule": ["before 4am on monday"],
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Group all npm updates",
       "matchManagers": ["npm"],
       "matchFileNames": ["package.json"],
       "groupName": "npm",
-      "schedule": ["before 4am on monday"]
+      "schedule": ["before 4am on monday"],
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Group all Docker updates",
       "matchManagers": ["dockerfile"],
       "matchFileNames": ["cmd/pyroscope/**"],
       "groupName": "docker",
-      "schedule": ["before 4am on the first day of the month"]
+      "schedule": ["before 4am on the first day of the month"],
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Group all GitHub Actions updates",
       "matchManagers": ["github-actions"],
       "groupName": "github-actions",
-      "schedule": ["before 4am on monday"]
+      "schedule": ["before 4am on monday"],
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Go modules examples - only pyroscope-go package",
@@ -49,7 +55,8 @@
       "allowedVersions": "/.*/",
       "matchPackageNames": ["github.com/grafana/pyroscope-go"],
       "groupName": "examples-gomod",
-      "schedule": ["before 4am on monday"]
+      "schedule": ["before 4am on monday"],
+      "minimumReleaseAge": "3 days"
     },
     {
       "description": "Automatically merge patch updates",


### PR DESCRIPTION
## Summary

This PR configures Renovate to wait 3 days after a package version is released before creating update PRs. This helps avoid rushing to adopt very new releases that might have bugs or issues.

I have followed this section: https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days

Currently this is done using PR check, but that means that PRs are already there and aren't supposed to be merged:

<img width="903" height="89" alt="image" src="https://github.com/user-attachments/assets/67d0a156-77bd-4778-a90a-9d6e688dd044" />

See #4771