### PR TITLE
Set pre-push as default hook in `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,5 @@ repos:
         # This matches: api/**/*.proto, pkg/**/*.proto, api/buf*.yaml, pkg/buf*.yaml
         # Root-level YAML files (renovate.json, .golangci.yml, etc.) are excluded
         files: '^(api|pkg)/.*\.(proto|yaml)$'
+
+default_install_hook_types: [pre-push]


### PR DESCRIPTION
Given how slow `make fmt` can be, it makes sense to run the pre-commit steps only before pushing. This change makes this the default. Users can still install these steps manually to other hook types.

More details in comments: https://github.com/grafana/pyroscope/pull/4780