### PR TITLE
chore: Allow to control mounting of shared volume

### DIFF
--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -73,6 +73,7 @@
 | pyroscope.persistence.annotations | object | `{}` |  |
 | pyroscope.persistence.enabled | bool | `false` |  |
 | pyroscope.persistence.metastore.subPath | string | `".metastore"` |  |
+| pyroscope.persistence.shared.enabled | bool | `true` |  |
 | pyroscope.persistence.shared.subPath | string | `".shared"` |  |
 | pyroscope.persistence.size | string | `"10Gi"` |  |
 | pyroscope.podAnnotations."profiles.grafana.com/cpu.port_name" | string | `"http2"` |  |

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -211,7 +211,7 @@ spec:
               mountPath: /data-compactor
               subPath: compactor
             {{- end }}
-            {{- if $hasV2 }}
+            {{- if (and $hasV2 $values.persistence.shared.enabled) }}
             - name: data
               mountPath: /data-shared
               subPath: {{ $values.persistence.shared.subPath }}

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -151,6 +151,7 @@ pyroscope:
       subPath: .metastore
 
     shared:
+      enabled: true
       # subPath to use of the data volume for the shared storage used as bucket replacement.
       subPath: .shared
 

--- a/operations/pyroscope/jsonnet/values.json
+++ b/operations/pyroscope/jsonnet/values.json
@@ -419,6 +419,7 @@
         "subPath": ".metastore"
       },
       "shared": {
+        "enabled": true,
         "subPath": ".shared"
       },
       "size": "10Gi"


### PR DESCRIPTION
In order to test micro-services mode without a bucket, we by default mount a shared volume in the helm chart.

This PR allows to switch this off using a flag.