### PR TITLE
chore: add normalization stats

### DIFF
--- a/pkg/distributor/distributor.go
+++ b/pkg/distributor/distributor.go
@@ -577,6 +577,7 @@ func (d *Distributor) pushSeries(ctx context.Context, req *distributormodel.Prof
 		sp, _ := opentracing.StartSpanFromContext(ctx, "Profile.Normalize")
 		req.Profile.Normalize()
 		sp.Finish()
+		finalLog.addFields("normalization_stats", req.Profile.Stats())
 		d.metrics.observeProfileSize(tenantID, StageNormalized, calculateRequestSize(req))
 	}
 

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -1583,3 +1583,7 @@ func (p *Profile) DebugString() string {
 	}
 	return gp.String()
 }
+
+func (p *Profile) Stats() string {
+	return p.stats.pretty()
+}


### PR DESCRIPTION
Give some visibility into dropped / invalid pprofs

https://github.com/grafana/pyroscope/issues/4807#issuecomment-3874196611

Example log:
```
ts=2026-02-10T04:31:30.854447628Z caller=distributor.go:446 component=distributor tenant=anonymous user=anonymous level=debug msg="profile accepted" service_name=repro profile_type=process_cpu matched_usage_groups=[] detected_language=rust profile_time=2026-02-05T01:26:11.084+07:00 ingestion_delay=130h5m19.77s decompressed_size=13211 sample_count=7 normalization_stats="samples_total=7 location_mapping_invalid=80 sample_location_invalid=7"
```