### PR TITLE
fix(renovate): Address invalid renovate.json syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -115,5 +115,5 @@
         "executionMode": "update"
       }
     }
-  ],
+  ]
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/pyroscope/issues/4835