### PR TITLE
chore(renovate): Add json syntax validation to Renovate config validator

### DIFF
--- a/.github/workflows/renovate-config-validator.yml
+++ b/.github/workflows/renovate-config-validator.yml
@@ -25,5 +25,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Validate renovate.json syntax
+        run: jq -e . renovate.json > /dev/null
+
       - name: Validate Renovate Config
         uses: grafana/shared-workflows/actions/validate-renovate-config@051f0a1cef0e1ef9f92fbe57c65b1eec029c3904 # validate-renovate-config/v0.1.1


### PR DESCRIPTION
Fix to prevent issues like https://github.com/grafana/pyroscope/issues/4835