### PR TITLE
fix: prevent panic in Tree.IterateStacks with >1024 root nodes

### DIFF
--- a/pkg/model/tree.go
+++ b/pkg/model/tree.go
@@ -103,7 +103,11 @@ func (t *Tree) WriteCollapsed(dst io.Writer) {
 }
 
 func (t *Tree) IterateStacks(cb func(name string, self int64, stack []string)) {
-	nodes := make([]*node, len(t.root), 1024)
+	s := 1024
+	if s < len(t.root) {
+		s += len(t.root)
+	}
+	nodes := make([]*node, len(t.root), s)
 	stack := make([]string, 0, 64)
 	copy(nodes, t.root)
 	for len(nodes) > 0 {


### PR DESCRIPTION
When a tree has more than 1024 root nodes, Tree.IterateStacks would panic with "makeslice: cap out of range" because it tried to create a slice with:
  make([]*node, len(t.root), 1024)

When len(t.root) > 1024, this is invalid (length > capacity).

The fix adjusts the initial capacity to be at least len(t.root) to prevent this panic.

Added test that creates a tree with 1500 root nodes and verifies IterateStacks works correctly.