### PR TITLE
docs(configure-client): remove detect_subproccess flag in py client

### DIFF
--- a/docs/sources/configure-client/language-sdks/python.md
+++ b/docs/sources/configure-client/language-sdks/python.md
@@ -73,7 +73,6 @@ pyroscope.configure(
     application_name    = "my.python.app", # replace this with some name for your application
     server_address      = "http://my-pyroscope-server:4040", # replace this with the address of your Pyroscope server
     sample_rate         = 100, # default is 100
-    detect_subprocesses = False, # detect subprocesses started by the main process; default is False
     oncpu               = True, # report cpu time only; default is True
     gil_only            = True, # only include traces for threads that are holding on to the Global Interpreter Lock; default is True
     enable_logging      = True, # does enable logging facility; default is False


### PR DESCRIPTION
The python and rust clients removed the `detect_subprocesses` configuration flag in [v1.0.1](https://github.com/grafana/pyroscope-rs/releases/tag/python-1.0.1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that removes a stale config flag; no runtime behavior or APIs are modified.
> 
> **Overview**
> Removes the `detect_subprocesses` option from the Python SDK configuration example in `docs/sources/configure-client/language-sdks/python.md` to match the current client capabilities.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ae8c632a81babd9e4add6eb42063df8bbeaa004. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->