### PR TITLE
feat(helm): support global.imageRegistry/global.image.registry

### DIFF
--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -35,6 +35,7 @@
 | architecture.storage.migration.segmentWriterWeight | float | `1` | Specifies the fraction [0:1] that should be send to the v2 write path / segment-writer in combined mode. 0 means no traffics is sent to segment-writer. 1 means 100% of requests are sent to segment-writer. |
 | architecture.storage.v1 | bool | `true` | Enable v1 storage layer. |
 | architecture.storage.v2 | bool | `false` | Enable v2 storage layer. |
+| global.imageRegistry | string | `nil` | Overrides the Docker registry globally for all images |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
@@ -59,6 +60,7 @@
 | pyroscope.grpc.port | int | `9095` |  |
 | pyroscope.grpc.port_name | string | `"grpc"` |  |
 | pyroscope.image.pullPolicy | string | `"IfNotPresent"` |  |
+| pyroscope.image.registry | string | `""` |  |
 | pyroscope.image.repository | string | `"grafana/pyroscope"` |  |
 | pyroscope.image.tag | string | `""` |  |
 | pyroscope.imagePullSecrets | list | `[]` |  |

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -71,7 +71,8 @@ spec:
         - name: {{ if eq $component "all" }}"pyroscope"{{ else }}"{{ $component }}"{{ end }}
           securityContext:
             {{- toYaml $values.securityContext | nindent 12 }}
-          image: "{{ $values.image.repository }}:{{ $values.image.tag | default .Chart.AppVersion }}"
+          {{- $registry := $global.Values.global.imageRegistry | default $values.image.registry }}
+          image: "{{ if $registry }}{{ $registry }}/{{ end }}{{ $values.image.repository }}:{{ $values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ $values.image.pullPolicy }}
           args:
             - "-target={{ $component }}"

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -1,6 +1,9 @@
 # Default values for pyroscope.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+global:
+  # -- Overrides the Docker registry globally for all images
+  imageRegistry: null
 
 
 pyroscope:
@@ -13,6 +16,7 @@ pyroscope:
   cluster_domain: .cluster.local.
 
   image:
+    registry: ''
     repository: grafana/pyroscope
     pullPolicy: IfNotPresent
     # Allows to override the image tag, which defaults to the appVersion in the chart metadata

--- a/operations/pyroscope/jsonnet/values.json
+++ b/operations/pyroscope/jsonnet/values.json
@@ -339,6 +339,9 @@
       "v2": false
     }
   },
+  "global": {
+    "imageRegistry": null
+  },
   "ingress": {
     "annotations": {},
     "className": "",
@@ -394,6 +397,7 @@
     },
     "image": {
       "pullPolicy": "IfNotPresent",
+      "registry": "",
       "repository": "grafana/pyroscope",
       "tag": ""
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: a small Helm templating change that only affects how container image names are constructed when optional registry values are set.
> 
> **Overview**
> Adds support for overriding the container image registry in the Pyroscope Helm chart via **either** a new `global.imageRegistry` value (applies across the chart) or `pyroscope.image.registry` (per-chart).
> 
> Updates the deployment/statefulset template to prefix images with the chosen registry, and documents/threads the new values through `values.yaml` and generated `jsonnet/values.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef56d98c36a77e9278c90ece57e31352898ec48b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->