### PR TITLE
feat(profilecli): add query span-profile subcommand

### DIFF
--- a/cmd/profilecli/main.go
+++ b/cmd/profilecli/main.go
@@ -84,6 +84,10 @@ func main() {
 	querySeriesParams := addQuerySeriesParams(querySeriesCmd)
 	queryLabelValuesCardinalityCmd := queryCmd.Command("label-values-cardinality", "Request label values cardinality.")
 	queryLabelValuesCardinalityParams := addQueryLabelValuesCardinalityParams(queryLabelValuesCardinalityCmd)
+	querySpanProfileCmd := queryCmd.Command("span-profile", "Request merged profile filtered by span IDs.")
+	querySpanProfileOutput := querySpanProfileCmd.Flag("output", "How to output the result, examples: console, raw, pprof=./my.pprof").Default("console").String()
+	querySpanProfileForce := querySpanProfileCmd.Flag("force", "Overwrite the output file if it already exists.").Short('f').Default("false").Bool()
+	querySpanProfileParams := addQuerySpanProfileParams(querySpanProfileCmd)
 
 	queryTracerCmd := app.Command("query-tracer", "Analyze query traces.")
 	queryTracerParams := addQueryTracerParams(queryTracerCmd)
@@ -182,6 +186,10 @@ func main() {
 
 	case queryLabelValuesCardinalityCmd.FullCommand():
 		if err := queryLabelValuesCardinality(ctx, queryLabelValuesCardinalityParams); err != nil {
+			os.Exit(checkError(err))
+		}
+	case querySpanProfileCmd.FullCommand():
+		if err := querySpanProfile(ctx, querySpanProfileParams, *querySpanProfileOutput, *querySpanProfileForce); err != nil {
 			os.Exit(checkError(err))
 		}
 


### PR DESCRIPTION
## What

Adds a new `query span-profile` subcommand to `profilecli` that queries profiles filtered by one or more span IDs.

## Why

Pyroscope's backend has full support for span-filtered profile queries via the `SelectMergeSpanProfile` RPC — it's used by the Grafana UI and the canary exporter. However, `profilecli` had no CLI interface for this functionality, making it inaccessible to operators and developers who want to retrieve span-correlated profiles from the command line.

## Usage

```bash
profilecli query span-profile \
  --url http://localhost:4040 \
  --query '{service_name="my-service"}' \
  --profile-type process_cpu:cpu:nanoseconds:cpu:nanoseconds \
  --span-selector 9a517183f26a089d \
  --span-selector 00000bac2a5ab0c7 \
  --from now-1h --to now \
  --output pprof=./span.pprof
```

Flags mirror the existing `query profile` subcommand:
- `--profile-type` — profile type ID (default: `process_cpu:cpu:nanoseconds:cpu:nanoseconds`)
- `--span-selector` — span ID to filter by (16 hex chars, e.g. `9a517183f26a089d`); repeatable for multiple spans
- `--max-nodes` — limit nodes returned
- `--output` — `console` (default), `raw`, or `pprof=<path>`
- `--from` / `--to` / `--query` — standard time range and label selector flags

## Implementation Details

- The `SelectMergeSpanProfile` RPC returns either a flamegraph or tree format — there is no native pprof option. The command requests `PROFILE_FORMAT_TREE` and converts the response using the same `model.UnmarshalTree` + `pprof.FromTree` path already used by `query profile --function-names-only`.
- Invalid span IDs (not exactly 16 hex characters) are rejected by the server with a clear error message.
- No new dependencies introduced; all packages used were already imported in `query.go`.

## Testing

Manually tested against a live Pyroscope instance:
1. Pushed a pprof profile containing two samples — one with a `profile_id` label (span ID) and one without.
2. `query span-profile --span-selector <id>` returned only the span-labeled sample (`func_span`, 100 samples).
3. `query profile` (no span filter) returned both samples (100 + 200), confirming correct filtering.
4. `--output pprof=...` produced a valid pprof file verified with `go tool pprof -top`.
5. Invalid span ID input produced a clear server-side error: `invalid span id length: "badinput"`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CLI subcommand that calls an existing querier RPC and reuses the existing tree-to-pprof output path, without changing server-side behavior.
> 
> **Overview**
> Adds a new `profilecli query span-profile` command to fetch merged profiles filtered by one or more span IDs.
> 
> The command wires new flags (`--profile-type`, repeatable `--span-selector`, `--max-nodes`, plus `--output`/`--force`) and implements a new query path that calls `SelectMergeSpanProfile` in tree format, converts the returned tree to pprof, and outputs it using the existing merge-profile output logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a5184d61c9b8491c495a106d37bc2afdf7f80a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->