### PR TITLE
chore: add all contributors as codeowners for /cmd package (Vibe Kanban)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -56,6 +56,9 @@
 /pkg/phlaredb/schemas/v1/ @simonswine @aleks-p
 /pkg/parquet/ @simonswine
 
+# cmd
+/cmd/ @simonswine @marcsanmi @aleks-p @alsoba13 @korniltsev-grafanista @bryanhuhta
+
 # api
 /api/ @simonswine @marcsanmi @aleks-p
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk; this only updates review ownership rules and does not affect runtime code. The main impact is process-related (who is requested/required to review changes under `cmd/`).
> 
> **Overview**
> Adds a new `CODEOWNERS` rule for the `cmd/` directory, assigning it to a broader set of maintainers (`@simonswine`, `@marcsanmi`, `@aleks-p`, `@alsoba13`, `@korniltsev-grafanista`, `@bryanhuhta`) so changes under `cmd/` request review from this group.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b57adb3d03d460929ebadbae0545a71550775ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->