### PR TITLE
chore: Replace openjdk image (no longer exists) with sapmachine

### DIFF
--- a/examples/grafana-alloy-auto-instrumentation/java/docker/java.Dockerfile
+++ b/examples/grafana-alloy-auto-instrumentation/java/docker/java.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM sapmachine:17-jdk-headless
 
 ADD ./FastSlow.java /FastSlow.java
 RUN javac FastSlow.java


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk documentation/example-only container change; runtime behavior should be the same aside from base image differences.
> 
> **Overview**
> Updates the Java auto-instrumentation example container build by replacing the `openjdk:17-jdk-slim` base image (no longer available) with `sapmachine:17-jdk-headless` in `examples/grafana-alloy-auto-instrumentation/java/docker/java.Dockerfile`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23b6b3a6c33173375629ad56bd24748b5c22d874. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->