### PR TITLE
Update golang version to 1.25.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
       - name: Format
         run: make fmt check/unstaged-changes
   check-generated:
@@ -40,7 +40,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
       - name: Check generated files
         run: make generate check/unstaged-changes
   test:
@@ -63,7 +63,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
       - name: Go Mod
         run: make check/go/mod
       - name: Test
@@ -78,7 +78,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
       - name: Run linter
         run: make lint
       - name: Check helm manifests
@@ -109,7 +109,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
@@ -139,7 +139,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
       # login to docker hub
       - id: get-secrets
         uses: grafana/shared-workflows/actions/get-vault-secrets@c2f1df59dba624b3fd509e5181aa8da5217120c0

--- a/.github/workflows/fuzzer.yml
+++ b/.github/workflows/fuzzer.yml
@@ -16,6 +16,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
       - name: Run Fuzz_Merge_Single
         run: go test -fuzz=Fuzz_Merge_Single --fuzztime 1h -run '^$' -v ./pkg/pprof/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
           cache: false
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
       - name: Run tests
         run: make examples/test

--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -47,7 +47,7 @@ jobs:
           echo "user-id=$(gh api "/users/${APP_BOT}" --jq .id)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
         with:
-          go-version: 1.25.7
+          go-version: 1.25.8
       - name: Update contributors
         run: make update-contributors
 

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -39,7 +39,7 @@ jobs:
           git tag "$IMAGE_TAG"
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
-          go-version: "1.25.7"
+          go-version: "1.25.8"
           cache: false
       # setup docker buildx
       - name: Set up QEMU

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@ version: 2
 before:
   hooks:
     # This hook ensures that goreleaser uses the correct go version for a Pyroscope release
-    - sh -euc 'go version | grep "go version go1.25.7 " || { echo "Unexpected go version"; exit 1; }'
+    - sh -euc 'go version | grep "go version go1.25.8 " || { echo "Unexpected go version"; exit 1; }'
 env:
   # Strip debug information from the binary by default, weekly builds will have debug information
   - GORELEASER_DEBUG_INFO_FLAGS={{ if and (index .Env "GORELEASER_STRIP_DEBUG_INFO") (eq .Env.GORELEASER_STRIP_DEBUG_INFO "false")  }}{{ else }}-s -w{{ end }}

--- a/.pyroscope.yaml
+++ b/.pyroscope.yaml
@@ -8,5 +8,5 @@ source_code:
        github:
         owner: golang
         repo: go
-        ref: go1.25.7
+        ref: go1.25.8
         path: src

--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/pyroscope/api
 
 go 1.24.6
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/examples/golang-pgo/Dockerfile
+++ b/examples/golang-pgo/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7
+FROM golang:1.25.8
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/golang-pgo/go.mod
+++ b/examples/golang-pgo/go.mod
@@ -2,7 +2,7 @@ module rideshare
 
 go 1.24.6
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/agoda-com/opentelemetry-logs-go v0.5.1

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/Dockerfile
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7
+FROM golang:1.25.8
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/Dockerfile.load-generator
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/Dockerfile.load-generator
@@ -1,4 +1,4 @@
-FROM golang:1.25.7
+FROM golang:1.25.8
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/go.mod
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-alloy/go.mod
@@ -2,7 +2,7 @@ module rideshare
 
 go 1.24.6
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/agoda-com/opentelemetry-logs-go v0.4.1

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-k6/Dockerfile
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-k6/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7
+FROM golang:1.25.8
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-k6/Dockerfile.load-generator
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-k6/Dockerfile.load-generator
@@ -1,4 +1,4 @@
-FROM golang:1.25.7
+FROM golang:1.25.8
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare-k6/go.mod
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare-k6/go.mod
@@ -2,7 +2,7 @@ module rideshare
 
 go 1.24.6
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/agoda-com/opentelemetry-logs-go v0.4.1

--- a/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7
+FROM golang:1.25.8
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile.load-generator
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare/Dockerfile.load-generator
@@ -1,4 +1,4 @@
-FROM golang:1.25.7
+FROM golang:1.25.8
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/language-sdk-instrumentation/golang-push/rideshare/go.mod
+++ b/examples/language-sdk-instrumentation/golang-push/rideshare/go.mod
@@ -2,7 +2,7 @@ module rideshare
 
 go 1.24.6
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/agoda-com/opentelemetry-logs-go v0.5.1

--- a/examples/language-sdk-instrumentation/golang-push/simple/Dockerfile
+++ b/examples/language-sdk-instrumentation/golang-push/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7
+FROM golang:1.25.8
 
 WORKDIR /go/src/app
 

--- a/examples/language-sdk-instrumentation/golang-push/simple/go.mod
+++ b/examples/language-sdk-instrumentation/golang-push/simple/go.mod
@@ -2,7 +2,7 @@ module pushsimple
 
 go 1.24.6
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require github.com/grafana/pyroscope-go v1.2.7
 

--- a/examples/tracing/golang-push/Dockerfile
+++ b/examples/tracing/golang-push/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7
+FROM golang:1.25.8
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/tracing/golang-push/Dockerfile.load-generator
+++ b/examples/tracing/golang-push/Dockerfile.load-generator
@@ -1,4 +1,4 @@
-FROM golang:1.25.7
+FROM golang:1.25.8
 
 WORKDIR /go/src/app
 COPY . .

--- a/examples/tracing/golang-push/go.mod
+++ b/examples/tracing/golang-push/go.mod
@@ -2,7 +2,7 @@ module rideshare
 
 go 1.24.6
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	github.com/agoda-com/opentelemetry-logs-go v0.5.1

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/pyroscope
 
 go 1.24.6
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require (
 	connectrpc.com/connect v1.19.1

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.24.6
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 use (
 	.

--- a/lidia/go.mod
+++ b/lidia/go.mod
@@ -2,7 +2,7 @@ module github.com/grafana/pyroscope/lidia
 
 go 1.24.6
 
-toolchain go1.25.7
+toolchain go1.25.8
 
 require github.com/stretchr/testify v1.11.1
 

--- a/tools/update_examples.Dockerfile
+++ b/tools/update_examples.Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get -y install wget git build-essential libssl-dev lib
     gawk autoconf automake bison libffi-dev libgdbm-dev libsqlite3-dev libtool pkg-config sqlite3 libncurses5-dev \
     libreadline-dev gnupg
 
-ARG GO_VERSION=1.25.7
+ARG GO_VERSION=1.25.8
 RUN wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin

--- a/tools/upgrade-go-version.sh
+++ b/tools/upgrade-go-version.sh
@@ -23,6 +23,11 @@ sed -E -i.bak 's/GO_VERSION=[0-9.]+/GO_VERSION='$1'/g' .pyroscope.yaml tools/upd
 DOCKER_FILES=$(git ls-files '**/Dockerfile*' | grep -v ebpf/symtab/elf/testdata/Dockerfile)
 sed -E -i.bak 's/golang:[0-9.]+/golang:'$1'/g' $DOCKER_FILES
 
+# update toolchain in go.mod files
+GO_MOD_FILES=$(git ls-files 'go.work' '**go.mod')
+sed -i 's/toolchain go[0-9\.]\+/toolchain go'$1'/g' $GO_MOD_FILES
+git add -u $GO_MOD_FILES
+
 # clean up backup files created by sed -i.bak
 find . -name '*.bak' -delete
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bump that mainly affects CI/release tooling and build reproducibility; potential impact is limited to compiler/toolchain behavior changes in patch release.
> 
> **Overview**
> Updates the repository’s Go toolchain from `1.25.7` to `1.25.8` across CI workflows (build/test/lint/fuzz/release), GoReleaser’s version guard, `.pyroscope.yaml` source mapping, and the `tools/update_examples.Dockerfile` build image.
> 
> Bumps `toolchain go1.25.8` in the root `go.mod`, `go.work`, and module/example `go.mod` files, and updates example Dockerfiles to `golang:1.25.8`. Enhances `tools/upgrade-go-version.sh` to also update `toolchain` directives in `go.mod`/`go.work` during future version bumps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84875156d37c7e147e0762fc26f6865982a04acd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->