### PR TITLE
lidia: tolerate elf.ErrNoSymbols when both symbol tables are missing

### DIFF
--- a/lidia/lidia.go
+++ b/lidia/lidia.go
@@ -176,9 +176,8 @@ func CreateLidiaFromELF(elfFile *elf.File, output io.WriteSeeker, opts ...Option
 		if symErr != nil {
 			symbols, dynSymErr = elfFile.DynamicSymbols()
 			if dynSymErr != nil {
-				err := fmt.Errorf("failed to read symbols from ELF file: %w, %w", symErr, dynSymErr)
-				if !errors.Is(err, elf.ErrNoSymbols) {
-					return err
+				if !errors.Is(symErr, elf.ErrNoSymbols) || !errors.Is(dynSymErr, elf.ErrNoSymbols) {
+					return fmt.Errorf("failed to read symbols from ELF file: %w, %w", symErr, dynSymErr)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Tolerate `elf.ErrNoSymbols` in `CreateLidiaFromELF` when both `elfFile.Symbols()` and `elfFile.DynamicSymbols()` fail.

Previously, if both calls returned errors, the function would unconditionally return a hard error. This is incorrect for stripped ELF binaries that have no symbol tables at all — `elf.ErrNoSymbols` is expected in that case, not a fatal condition.

Now, the two errors are wrapped into a combined error using `fmt.Errorf` with two `%w` verbs, and `errors.Is` checks whether the combined error wraps `elf.ErrNoSymbols`. If it does, processing continues; otherwise, the error is returned as before.

## Context

Extracted from #4648 per [review comment](https://github.com/grafana/pyroscope/pull/4648/files#diff-2a29d4c7082fc45c52bbc42fac4141d5f392968e977802c9da2508facb8dd6c8R179) requesting this change be submitted separately.

## Changes

- `lidia/lidia.go`: Added `"errors"` import; changed the error path in `CreateLidiaFromELF` to check `errors.Is(err, elf.ErrNoSymbols)` before returning when both symbol table reads fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to ELF symbol error handling; main risk is unintentionally suppressing unexpected symbol-read errors, mitigated by only tolerating `elf.ErrNoSymbols` on both calls.
> 
> **Overview**
> `CreateLidiaFromELF` now treats the case where both `elfFile.Symbols()` and `elfFile.DynamicSymbols()` return `elf.ErrNoSymbols` as non-fatal, allowing lidia generation to continue for stripped ELF binaries.
> 
> All other symbol-read failures still return an error; this change adds an `errors` import and gates the existing combined error return on `errors.Is(..., elf.ErrNoSymbols)` checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 221da0f0933a5b22312d443f690f1a88da9144ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->