### PR TITLE
fix(debug-info): LimitReader for upload size

### DIFF
--- a/pkg/debuginfo/store.go
+++ b/pkg/debuginfo/store.go
@@ -165,7 +165,11 @@ func (s *Store) Upload(ctx context.Context, stream *connect.BidiStream[debuginfo
 	}
 
 	r := debuginforeader.New(ctx, readChunksFromStream(stream))
-	if err := s.bucket.Upload(ctx, ObjectPath(tenantID, id), r); err != nil {
+	var uploadReader io.Reader = r
+	if s.cfg.MaxUploadSize > 0 {
+		uploadReader = io.LimitReader(r, s.cfg.MaxUploadSize+1)
+	}
+	if err := s.bucket.Upload(ctx, ObjectPath(tenantID, id), uploadReader); err != nil {
 		return connect.NewError(connect.CodeInternal, fmt.Errorf("upload debuginfo: %w", err))
 	}
 	if s.cfg.MaxUploadSize > 0 && r.Size() > uint64(s.cfg.MaxUploadSize) {


### PR DESCRIPTION
## Summary
- Wrap the upload reader with `io.LimitReader` when `MaxUploadSize` is configured, so the upload is actually bounded rather than reading the full stream before checking the size

## Test plan
- [ ] Verify upload with size under limit succeeds
- [ ] Verify upload exceeding limit is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the debug-info upload path and object storage writes; incorrect limits could reject valid uploads or leave partial objects if error handling differs across backends.
> 
> **Overview**
> **Enforces configured upload size limits during debug-info streaming uploads.** When `MaxUploadSize` is set, the upload now uses an `io.LimitReader` (`max+1` bytes) so oversized streams are bounded during `bucket.Upload` rather than only being detected after fully reading the stream.
> 
> The existing post-upload size check and cleanup remains, but oversized uploads should now stop early, reducing resource usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd3692f770ef3290a85ad087c793edb865e3f773. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->