### PR TITLE
chore: Add V2 run instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ go run ./cmd/pyroscope --target all,embedded-grafana
 # Grafana: http://localhost:4041
 
 # Run with V2 architecture (segment writers, query backend, symbolizer)
-PYROSCOPE_V2_EXPERIMENT=1 go run ./cmd/pyroscope \
+PYROSCOPE_V2=1 go run ./cmd/pyroscope \
   -target=all \
   -storage.backend=filesystem \
   -write-path=segment-writer \


### PR DESCRIPTION
## Summary
- Add instructions for running Pyroscope with V2 architecture (segment writers, query backend, symbolizer) to AGENTS.md

## Test plan
- [ ] Documentation only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on runtime code paths or configuration defaults.
> 
> **Overview**
> Updates `AGENTS.md` to document how to run Pyroscope locally using the V2 architecture by adding an example command that sets `PYROSCOPE_V2=1` and enables the segment writer, query backend, and symbolizer with filesystem storage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdcda08bd10759386adadf1c92e98c381a95d2a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->