### PR TITLE
Add release notes for v1.19

### DIFF
--- a/docs/sources/release-notes/v1-19.md
+++ b/docs/sources/release-notes/v1-19.md
@@ -1,0 +1,57 @@
+---
+title: Version 1.19 release notes
+menuTitle: V1.19
+description: Release notes for Grafana Pyroscope 1.19
+weight: 710
+---
+
+## Version 1.19.0 release notes
+
+The Pyroscope team is excited to present Grafana Pyroscope 1.19.0
+
+This release contains enhancements, fixes, improves stability & performance.
+
+Notable changes are listed below. For more details, check out the [1.19.0 changelog](https://github.com/grafana/pyroscope/compare/v1.18.0...v1.19.0).
+
+### Enhancements
+* **profilecli**: Add `query top` command for top function analysis ([#4889](https://github.com/grafana/pyroscope/pull/4889))
+* **profilecli**: Add `recording-rules` command for rules self-service ([#4823](https://github.com/grafana/pyroscope/pull/4823))
+* **profilecli**: Add `kube-proxy` command for unified microservice access ([#4777](https://github.com/grafana/pyroscope/pull/4777))
+* **profilecli**: Add `--output=table|json` to `query series` ([#4890](https://github.com/grafana/pyroscope/pull/4890))
+* **profilecli**: Add `--span-selector` flag to `query profile` command ([#4873](https://github.com/grafana/pyroscope/pull/4873))
+* **profilecli**: Add `--force/-f` flag to overwrite output files ([#4776](https://github.com/grafana/pyroscope/pull/4776))
+* **profilecli**: Use `SelectMergeStacktraces` instead of `SelectMergeProfile` when `--tree` ([#4795](https://github.com/grafana/pyroscope/pull/4795))
+* Add support for Javascript and Typescript source code integration ([#4797](https://github.com/grafana/pyroscope/pull/4797))
+* Add configuration to skip label sanitization ([#4796](https://github.com/grafana/pyroscope/pull/4796))
+* Add S3 `aws_sdk_auth` config option ([#4819](https://github.com/grafana/pyroscope/pull/4819))
+* Add ad-hoc profiles Diff RPC ([#4850](https://github.com/grafana/pyroscope/pull/4850))
+* Add debug info upload service ([#4648](https://github.com/grafana/pyroscope/pull/4648))
+* Implement AttributeTable with string interning for exemplar labels ([#4756](https://github.com/grafana/pyroscope/pull/4756))
+* Allow retrieving heatmap from spans/individual profiles ([#4736](https://github.com/grafana/pyroscope/pull/4736))
+* Add normalization stats ([#4820](https://github.com/grafana/pyroscope/pull/4820))
+* Query diagnostics for v2 admin ([#4806](https://github.com/grafana/pyroscope/pull/4806))
+* Refactor symbolization into per-query backendWrapper ([#4887](https://github.com/grafana/pyroscope/pull/4887))
+* lidia: Add gopclntab support for Go symbol resolution ([#4782](https://github.com/grafana/pyroscope/pull/4782))
+* Update ebpf-profiler docs/examples to use official builds ([#4891](https://github.com/grafana/pyroscope/pull/4891))
+* Helm: Add `extraContainers` field to pyroscope helm chart ([#4783](https://github.com/grafana/pyroscope/pull/4783))
+* Helm: Allow to control mounting of shared volume ([#4809](https://github.com/grafana/pyroscope/pull/4809))
+* Update Go to 1.25.8 ([#4883](https://github.com/grafana/pyroscope/pull/4883))
+
+### Fixes
+* Filter profile IDs post-join instead of predicate push-down ([#4888](https://github.com/grafana/pyroscope/pull/4888))
+* Add `pyroscope_` prefix to memberlist metrics ([#4885](https://github.com/grafana/pyroscope/pull/4885))
+* Correctly visit str value on labels to not drop incorrect values from the string table ([#4826](https://github.com/grafana/pyroscope/pull/4826))
+* Correct datatype for Exemplar value uint64→int64 ([#4779](https://github.com/grafana/pyroscope/pull/4779))
+* Prevent panic in `Tree.IterateStacks` with >1024 root nodes ([#4841](https://github.com/grafana/pyroscope/pull/4841))
+* lidia: Use stable sort ([#4758](https://github.com/grafana/pyroscope/pull/4758))
+* Replace regex with manual string scanning in `DropGoTypeParameters` ([#4828](https://github.com/grafana/pyroscope/pull/4828))
+* Bump jfr-parser to v0.15.0 ([#4881](https://github.com/grafana/pyroscope/pull/4881))
+
+### Documentation
+* Update Java profile types support ([#4893](https://github.com/grafana/pyroscope/pull/4893))
+* Update profilecli docs for latest changes ([#4894](https://github.com/grafana/pyroscope/pull/4894))
+* Update profile-cli.md for #4980 ([#4902](https://github.com/grafana/pyroscope/pull/4902))
+* Update eBPF profiler supported languages ([#4822](https://github.com/grafana/pyroscope/pull/4822))
+* Remove `detect_subprocesses` from python client config ([#4854](https://github.com/grafana/pyroscope/pull/4854))
+* Clarify helm chart versioning strategy in release docs ([#4833](https://github.com/grafana/pyroscope/pull/4833))
+* Add traces-to-profiles example using wall profiles for Java ([#4863](https://github.com/grafana/pyroscope/pull/4863))


### PR DESCRIPTION
Add website release notes for the v1.19.0 release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new release notes page; no runtime code or configuration is modified.
> 
> **Overview**
> Adds a new `docs/sources/release-notes/v1-19.md` page publishing the **Grafana Pyroscope 1.19.0** release notes, including curated lists of enhancements, fixes, and documentation updates with links to the corresponding PRs and the 1.19.0 changelog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cb174fbaec5f164f2377781d9365271af6f1f41. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->