### PR TITLE
feat(query-frontend): log user_agent on query log lines

### DIFF
--- a/pkg/util/spanlogger/query_log.go
+++ b/pkg/util/spanlogger/query_log.go
@@ -2,6 +2,7 @@ package spanlogger
 
 import (
 	"context"
+	"net/http"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -28,10 +29,20 @@ func NewLogSpanParametersWrapper(client querierv1connect.QuerierServiceClient, l
 	}
 }
 
+// logWithHTTPHeaders returns a SpanLogger enriched with HTTP request metadata.
+// Add new header extractions here to make them available on all query log lines.
+func (l LogSpanParametersWrapper) logWithHTTPHeaders(ctx context.Context, h http.Header) *SpanLogger {
+	logger := l.logger
+	if ua := h.Get("User-Agent"); ua != "" {
+		logger = log.With(logger, "user_agent", ua)
+	}
+	return FromContext(ctx, logger)
+}
+
 func (l LogSpanParametersWrapper) ProfileTypes(ctx context.Context, c *connect.Request[querierv1.ProfileTypesRequest]) (*connect.Response[querierv1.ProfileTypesResponse], error) {
 	spanName := "ProfileTypes"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(FromContext(ctx, l.logger)).Log(
+	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -45,7 +56,7 @@ func (l LogSpanParametersWrapper) ProfileTypes(ctx context.Context, c *connect.R
 func (l LogSpanParametersWrapper) LabelValues(ctx context.Context, c *connect.Request[typesv1.LabelValuesRequest]) (*connect.Response[typesv1.LabelValuesResponse], error) {
 	spanName := "LabelValues"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(FromContext(ctx, l.logger)).Log(
+	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -61,7 +72,7 @@ func (l LogSpanParametersWrapper) LabelValues(ctx context.Context, c *connect.Re
 func (l LogSpanParametersWrapper) LabelNames(ctx context.Context, c *connect.Request[typesv1.LabelNamesRequest]) (*connect.Response[typesv1.LabelNamesResponse], error) {
 	spanName := "LabelNames"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(FromContext(ctx, l.logger)).Log(
+	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -76,7 +87,7 @@ func (l LogSpanParametersWrapper) LabelNames(ctx context.Context, c *connect.Req
 func (l LogSpanParametersWrapper) Series(ctx context.Context, c *connect.Request[querierv1.SeriesRequest]) (*connect.Response[querierv1.SeriesResponse], error) {
 	spanName := "Series"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(FromContext(ctx, l.logger)).Log(
+	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -92,7 +103,7 @@ func (l LogSpanParametersWrapper) Series(ctx context.Context, c *connect.Request
 func (l LogSpanParametersWrapper) SelectMergeStacktraces(ctx context.Context, c *connect.Request[querierv1.SelectMergeStacktracesRequest]) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
 	spanName := "SelectMergeStacktraces"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(FromContext(ctx, l.logger)).Log(
+	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -111,7 +122,7 @@ func (l LogSpanParametersWrapper) SelectMergeStacktraces(ctx context.Context, c 
 func (l LogSpanParametersWrapper) SelectMergeSpanProfile(ctx context.Context, c *connect.Request[querierv1.SelectMergeSpanProfileRequest]) (*connect.Response[querierv1.SelectMergeSpanProfileResponse], error) {
 	spanName := "SelectMergeSpanProfile"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(FromContext(ctx, l.logger)).Log(
+	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -129,7 +140,7 @@ func (l LogSpanParametersWrapper) SelectMergeSpanProfile(ctx context.Context, c 
 func (l LogSpanParametersWrapper) SelectMergeProfile(ctx context.Context, c *connect.Request[querierv1.SelectMergeProfileRequest]) (*connect.Response[profilev1.Profile], error) {
 	spanName := "SelectMergeProfile"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(FromContext(ctx, l.logger)).Log(
+	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -148,7 +159,7 @@ func (l LogSpanParametersWrapper) SelectMergeProfile(ctx context.Context, c *con
 func (l LogSpanParametersWrapper) SelectSeries(ctx context.Context, c *connect.Request[querierv1.SelectSeriesRequest]) (*connect.Response[querierv1.SelectSeriesResponse], error) {
 	spanName := "SelectSeries"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(FromContext(ctx, l.logger)).Log(
+	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -170,7 +181,7 @@ func (l LogSpanParametersWrapper) SelectSeries(ctx context.Context, c *connect.R
 func (l LogSpanParametersWrapper) SelectHeatmap(ctx context.Context, c *connect.Request[querierv1.SelectHeatmapRequest]) (*connect.Response[querierv1.SelectHeatmapResponse], error) {
 	spanName := "SelectHeatmap"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(FromContext(ctx, l.logger)).Log(
+	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -202,7 +213,7 @@ func (l LogSpanParametersWrapper) Diff(ctx context.Context, c *connect.Request[q
 		right = c.Msg.Right
 	}
 
-	level.Info(FromContext(ctx, l.logger)).Log(
+	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
 		"method", spanName,
 		"left_start", model.Time(left.Start).Time().String(),
 		"left_end", model.Time(left.End).Time().String(),
@@ -234,7 +245,7 @@ func (l LogSpanParametersWrapper) GetProfileStats(ctx context.Context, c *connec
 func (l LogSpanParametersWrapper) AnalyzeQuery(ctx context.Context, c *connect.Request[querierv1.AnalyzeQueryRequest]) (*connect.Response[querierv1.AnalyzeQueryResponse], error) {
 	spanName := "AnalyzeQuery"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(FromContext(ctx, l.logger)).Log(
+	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),

--- a/pkg/util/spanlogger/query_log.go
+++ b/pkg/util/spanlogger/query_log.go
@@ -2,7 +2,6 @@ package spanlogger
 
 import (
 	"context"
-	"net/http"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -29,11 +28,11 @@ func NewLogSpanParametersWrapper(client querierv1connect.QuerierServiceClient, l
 	}
 }
 
-// logWithHTTPHeaders returns a SpanLogger enriched with HTTP request metadata.
-// Add new header extractions here to make them available on all query log lines.
-func (l LogSpanParametersWrapper) logWithHTTPHeaders(ctx context.Context, h http.Header) *SpanLogger {
+// logWithRequestMetadata returns a SpanLogger enriched with request metadata.
+// Add new extractions here to make them available on all query log lines.
+func (l LogSpanParametersWrapper) logWithRequestMetadata(ctx context.Context, req connect.AnyRequest) *SpanLogger {
 	logger := l.logger
-	if ua := h.Get("User-Agent"); ua != "" {
+	if ua := req.Header().Get("User-Agent"); ua != "" {
 		logger = log.With(logger, "user_agent", ua)
 	}
 	return FromContext(ctx, logger)
@@ -42,7 +41,7 @@ func (l LogSpanParametersWrapper) logWithHTTPHeaders(ctx context.Context, h http
 func (l LogSpanParametersWrapper) ProfileTypes(ctx context.Context, c *connect.Request[querierv1.ProfileTypesRequest]) (*connect.Response[querierv1.ProfileTypesResponse], error) {
 	spanName := "ProfileTypes"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
+	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -56,7 +55,7 @@ func (l LogSpanParametersWrapper) ProfileTypes(ctx context.Context, c *connect.R
 func (l LogSpanParametersWrapper) LabelValues(ctx context.Context, c *connect.Request[typesv1.LabelValuesRequest]) (*connect.Response[typesv1.LabelValuesResponse], error) {
 	spanName := "LabelValues"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
+	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -72,7 +71,7 @@ func (l LogSpanParametersWrapper) LabelValues(ctx context.Context, c *connect.Re
 func (l LogSpanParametersWrapper) LabelNames(ctx context.Context, c *connect.Request[typesv1.LabelNamesRequest]) (*connect.Response[typesv1.LabelNamesResponse], error) {
 	spanName := "LabelNames"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
+	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -87,7 +86,7 @@ func (l LogSpanParametersWrapper) LabelNames(ctx context.Context, c *connect.Req
 func (l LogSpanParametersWrapper) Series(ctx context.Context, c *connect.Request[querierv1.SeriesRequest]) (*connect.Response[querierv1.SeriesResponse], error) {
 	spanName := "Series"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
+	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -103,7 +102,7 @@ func (l LogSpanParametersWrapper) Series(ctx context.Context, c *connect.Request
 func (l LogSpanParametersWrapper) SelectMergeStacktraces(ctx context.Context, c *connect.Request[querierv1.SelectMergeStacktracesRequest]) (*connect.Response[querierv1.SelectMergeStacktracesResponse], error) {
 	spanName := "SelectMergeStacktraces"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
+	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -122,7 +121,7 @@ func (l LogSpanParametersWrapper) SelectMergeStacktraces(ctx context.Context, c 
 func (l LogSpanParametersWrapper) SelectMergeSpanProfile(ctx context.Context, c *connect.Request[querierv1.SelectMergeSpanProfileRequest]) (*connect.Response[querierv1.SelectMergeSpanProfileResponse], error) {
 	spanName := "SelectMergeSpanProfile"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
+	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -140,7 +139,7 @@ func (l LogSpanParametersWrapper) SelectMergeSpanProfile(ctx context.Context, c 
 func (l LogSpanParametersWrapper) SelectMergeProfile(ctx context.Context, c *connect.Request[querierv1.SelectMergeProfileRequest]) (*connect.Response[profilev1.Profile], error) {
 	spanName := "SelectMergeProfile"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
+	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -159,7 +158,7 @@ func (l LogSpanParametersWrapper) SelectMergeProfile(ctx context.Context, c *con
 func (l LogSpanParametersWrapper) SelectSeries(ctx context.Context, c *connect.Request[querierv1.SelectSeriesRequest]) (*connect.Response[querierv1.SelectSeriesResponse], error) {
 	spanName := "SelectSeries"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
+	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -181,7 +180,7 @@ func (l LogSpanParametersWrapper) SelectSeries(ctx context.Context, c *connect.R
 func (l LogSpanParametersWrapper) SelectHeatmap(ctx context.Context, c *connect.Request[querierv1.SelectHeatmapRequest]) (*connect.Response[querierv1.SelectHeatmapResponse], error) {
 	spanName := "SelectHeatmap"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
+	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),
@@ -213,7 +212,7 @@ func (l LogSpanParametersWrapper) Diff(ctx context.Context, c *connect.Request[q
 		right = c.Msg.Right
 	}
 
-	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
+	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
 		"method", spanName,
 		"left_start", model.Time(left.Start).Time().String(),
 		"left_end", model.Time(left.End).Time().String(),
@@ -245,7 +244,7 @@ func (l LogSpanParametersWrapper) GetProfileStats(ctx context.Context, c *connec
 func (l LogSpanParametersWrapper) AnalyzeQuery(ctx context.Context, c *connect.Request[querierv1.AnalyzeQueryRequest]) (*connect.Response[querierv1.AnalyzeQueryResponse], error) {
 	spanName := "AnalyzeQuery"
 	sp, ctx := tracing.StartSpanFromContext(ctx, spanName)
-	level.Info(l.logWithHTTPHeaders(ctx, c.Header())).Log(
+	level.Info(l.logWithRequestMetadata(ctx, c)).Log(
 		"method", spanName,
 		"start", model.Time(c.Msg.Start).Time().String(),
 		"end", model.Time(c.Msg.End).Time().String(),


### PR DESCRIPTION
## Summary

Adds `user_agent` to query log lines (`query_log.go`) by reading the `User-Agent` header from the incoming Connect request.

## Why

Today, `User-Agent` is logged at the HTTP middleware layer (`http.go`), but on a **separate log line** from query parameters like `profile_id_selector`, `selector`, and `profile_type`. While both share the same traceID, LogQL cannot join fields across log lines — making it impossible to answer questions like "which clients are sending exemplar queries?" in a single query.

As we introduce more clients (gcx, AI assistants) alongside existing ones (Grafana UI, profilecli, Alloy), being able to break down query traffic by client becomes increasingly useful for debugging and understanding usage patterns.

## Change

A single `logWithHTTPHeaders` helper enriches the logger with request headers. To add new headers in the future, add one line to this helper — all query log lines pick it up automatically.

## Test plan
- [ ] `go build ./pkg/util/spanlogger/...` passes
- [ ] Deploy to dev and verify `user_agent=` appears on query_log.go lines
- [ ] `{service_name="pyroscope/query-frontend"} | logfmt | caller=~"query_log.go:.*" | user_agent != ""`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: logging-only change that adds a single request header field to existing query log lines; main risk is minor log volume/PII considerations from user-agent strings.
> 
> **Overview**
> Adds a `logWithRequestMetadata` helper in `pkg/util/spanlogger/query_log.go` that extracts the `User-Agent` header from Connect requests and injects it into the logger as `user_agent`.
> 
> Updates all query span logging call sites (e.g., `ProfileTypes`, `SelectSeries`, `Diff`, `AnalyzeQuery`) to use this enriched logger so `user_agent` appears on the same log line as query parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4908f0592fe3619f5e29131497bd760d4cb744a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->