### PR TITLE
fix(scheduler): replace bufconn with TCP listener to fix flaky test

### DIFF
--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -68,12 +68,7 @@ func setupScheduler(t *testing.T, args schedulerArgs) (*Scheduler, schedulerpb.S
 	mux := mux.NewRouter()
 	server.Config.Handler = h2c.NewHandler(mux, &http2.Server{})
 
-	// Use an in-memory network connection to avoid test flake from network access.
-	listener := bufconn.Listen(256 << 10)
-	server.Listener = listener
-
 	server.Start()
-	require.NoError(t, err)
 	schedulerpbconnect.RegisterSchedulerForFrontendHandler(mux, s, args.handlerOpts...)
 	schedulerpbconnect.RegisterSchedulerForQuerierHandler(mux, s, args.handlerOpts...)
 
@@ -84,10 +79,7 @@ func setupScheduler(t *testing.T, args schedulerArgs) (*Scheduler, schedulerpb.S
 	})
 
 	c, err := grpc.NewClient(
-		// Target address is irrelevant as we're using an in-memory connection.
-		// We simply need the DNS resolution to succeed.
-		"localhost:3030",
-		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) { return listener.Dial() }),
+		server.Listener.Addr().String(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 
@@ -266,8 +258,12 @@ func TestCancelRequestInProgress(t *testing.T) {
 	// Simulate frontend disconnect.
 	require.NoError(t, frontendLoop.CloseSend())
 
-	// Add a little sleep to make sure that scheduler notices frontend disconnect.
-	time.Sleep(500 * time.Millisecond)
+	// Wait until the scheduler notices the frontend disconnect before sending
+	// a response. If we send too early, it completes the normal request cycle
+	// in forwardRequestToQuerier and the context cancellation is never triggered.
+	test.Poll(t, time.Second, float64(0), func() interface{} {
+		return promtest.ToFloat64(scheduler.connectedFrontendClients)
+	})
 
 	// Report back end of request processing. This should return error, since the QuerierLoop call has finished on scheduler.
 	// Note: testing on querierLoop.Context() cancellation didn't work :(


### PR DESCRIPTION
## Summary
- Replace `bufconn` (in-memory listener) with httptest's default TCP listener in scheduler tests — bufconn has a subtle incompatibility with h2c-hijacked HTTP/2 bidi streams that causes some EOF failures under load from time to time e.g. https://github.com/grafana/pyroscope/actions/runs/24395819884/job/71253229300
- Replace `time.Sleep(500ms)` with `connectedFrontendClients` metric polling in `TestCancelRequestInProgress`

## Context
`TestCancelRequestInProgress` was failing intermittently on CI with `rpc error: code = Unavailable desc = error reading from server: EOF` during the initial enqueue call. The flake was reproduced locally with `-race -count=1000` (~2 failures per 1000 runs) and traced to `bufconn` by swapping it for a real TCP listener (0 failures in 4500+ race detector runs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust transport setup and timing assertions; low risk to production code, but may affect test behavior/assumptions around connection lifecycle.
> 
> **Overview**
> Deflakes `pkg/scheduler/scheduler_test.go` by dropping the `bufconn` in-memory listener for the scheduler’s h2c/HTTP2 test server and dialing the real `httptest` TCP listener address instead.
> 
> Replaces a fixed `time.Sleep` in `TestCancelRequestInProgress` with polling on the `connectedFrontendClients` metric to wait for frontend disconnect detection before completing the querier response cycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59417fc35ad660f560feb208b7bf14ee52697949. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->