### PR TITLE
helm(refactor): remove redundant adaptive-placement default

### DIFF
--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -3376,8 +3376,6 @@ spec:
             - "-memberlist.join=dns+pyroscope-dev-memberlist.default.svc.cluster.local.:7946"
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
-            - "-adaptive-placement.max-dataset-shards=1024"
-            - "-adaptive-placement.unit-size-bytes=131072"
             - "-log.level=debug"
             - "-metastore.index.cleanup-interval=1m"
             - "-metastore.raft.bootstrap-expect-peers=3"

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -415,9 +415,6 @@ architecture:
         extraArgs:
           # Expect 3 metastores
           metastore.raft.bootstrap-expect-peers: 3
-          # TODO(kolesnikovae): Update defaults.
-          adaptive-placement.max-dataset-shards: 1024
-          adaptive-placement.unit-size-bytes: 131072
           # enable cleanup of blocks beyond retention
           metastore.index.cleanup-interval: 1m
           metastore.snapshot-compact-on-restore: true

--- a/operations/pyroscope/jsonnet/values.json
+++ b/operations/pyroscope/jsonnet/values.json
@@ -250,8 +250,6 @@
         },
         "metastore": {
           "extraArgs": {
-            "adaptive-placement.max-dataset-shards": 1024,
-            "adaptive-placement.unit-size-bytes": 131072,
             "metastore.index.cleanup-interval": "1m",
             "metastore.raft.bootstrap-expect-peers": 3,
             "metastore.snapshot-compact-on-restore": true


### PR DESCRIPTION
The TODO involved was already addressed in #4125

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change that removes two explicit flags to fall back to existing defaults; risk is limited to behavioral differences if deployments were relying on the overridden values.
> 
> **Overview**
> Removes the explicit `adaptive-placement.max-dataset-shards` and `adaptive-placement.unit-size-bytes` overrides from Pyroscope v2 metastore Helm configuration, relying on upstream defaults instead.
> 
> This update is applied consistently across Helm `values.yaml`, Jsonnet `values.json`, and the generated `micro-services-v2.yaml`, reducing config drift without changing any other deployment settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 464f35fc7881e196a36468cb0185c54480f051e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->