### PR TITLE
fix pkg/test/integration.TestStatusCode

### DIFF
--- a/pkg/test/integration/http_status_codes_test.go
+++ b/pkg/test/integration/http_status_codes_test.go
@@ -853,7 +853,7 @@ func TestStatusCodes(t *testing.T) {
 						"start":    time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":      time.Now().UnixMilli(),
 					}),
-					WantV1StatusCode: http.StatusOK,
+					WantV1StatusCode: http.StatusInternalServerError,
 				},
 				{
 					Name:   "invalid_json",
@@ -1046,7 +1046,7 @@ func TestStatusCodes(t *testing.T) {
 						"start":    time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":      time.Now().UnixMilli(),
 					}),
-					WantV1StatusCode: http.StatusOK,
+					WantV1StatusCode: http.StatusInternalServerError,
 				},
 			},
 			http.StatusMethodNotAllowed: {
@@ -1200,7 +1200,7 @@ func TestStatusCodes(t *testing.T) {
 						"start":    time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":      time.Now().UnixMilli(),
 					}),
-					WantV1StatusCode: http.StatusOK,
+					WantV1StatusCode: http.StatusInternalServerError,
 				},
 			},
 			http.StatusMethodNotAllowed: {
@@ -2309,7 +2309,7 @@ func TestStatusCodes(t *testing.T) {
 						"labelSelector": "{}",
 						"start":         time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":           time.Now().UnixMilli(),
-						"spanSelector":  []string{"span1", "span2"},
+						"spanSelector":  []string{"0123456789012345", "0123456789012346"},
 					}),
 				},
 				{
@@ -2323,7 +2323,7 @@ func TestStatusCodes(t *testing.T) {
 						"labelSelector": "{}",
 						"start":         time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":           time.Now().UnixMilli(),
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 						"maxNodes":      1024,
 					}),
 				},
@@ -2338,7 +2338,7 @@ func TestStatusCodes(t *testing.T) {
 						"labelSelector": "{}",
 						"start":         time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":           time.Now().UnixMilli(),
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 						"format":        2,
 					}),
 				},
@@ -2354,7 +2354,7 @@ func TestStatusCodes(t *testing.T) {
 						"labelSelector": "{}",
 						"start":         time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":           time.Now().UnixMilli(),
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 					}),
 				},
 				{
@@ -2368,7 +2368,7 @@ func TestStatusCodes(t *testing.T) {
 						"labelSelector": "{}",
 						"start":         time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":           time.Now().UnixMilli(),
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 					}),
 				},
 				{
@@ -2382,7 +2382,7 @@ func TestStatusCodes(t *testing.T) {
 						"labelSelector": "{}",
 						"start":         time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":           time.Now().UnixMilli(),
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 					}),
 				},
 				{
@@ -2395,7 +2395,7 @@ func TestStatusCodes(t *testing.T) {
 						"profileTypeID": profileTypeProcessCPU,
 						"start":         time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":           time.Now().UnixMilli(),
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 					}),
 				},
 				{
@@ -2409,7 +2409,7 @@ func TestStatusCodes(t *testing.T) {
 						"labelSelector": "!bad_syntax!",
 						"start":         time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":           time.Now().UnixMilli(),
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 					}),
 				},
 				{
@@ -2439,7 +2439,7 @@ func TestStatusCodes(t *testing.T) {
 						"labelSelector": "{}",
 						"start":         time.Now().UnixMilli(),
 						"end":           time.Now().Add(-1 * time.Hour).UnixMilli(),
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 					}),
 				},
 				{
@@ -2451,7 +2451,7 @@ func TestStatusCodes(t *testing.T) {
 					Body: toJSON(map[string]any{
 						"profileTypeID": profileTypeProcessCPU,
 						"labelSelector": "{}",
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 					}),
 				},
 			},
@@ -2474,7 +2474,7 @@ func TestStatusCodes(t *testing.T) {
 						"labelSelector": "{}",
 						"start":         time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":           time.Now().UnixMilli(),
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 					}),
 				},
 				{
@@ -2488,7 +2488,7 @@ func TestStatusCodes(t *testing.T) {
 						"labelSelector": "{}",
 						"start":         time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":           time.Now().UnixMilli(),
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 					}),
 				},
 				{
@@ -2502,7 +2502,7 @@ func TestStatusCodes(t *testing.T) {
 						"labelSelector": "{}",
 						"start":         time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":           time.Now().UnixMilli(),
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 					}),
 				},
 			},
@@ -2518,7 +2518,7 @@ func TestStatusCodes(t *testing.T) {
 						"labelSelector": "{}",
 						"start":         time.Now().Add(-1 * time.Hour).UnixMilli(),
 						"end":           time.Now().UnixMilli(),
-						"spanSelector":  []string{"span1"},
+						"spanSelector":  []string{"0123456789012345"},
 					}),
 				},
 			},

--- a/pkg/test/integration/http_status_codes_test.go
+++ b/pkg/test/integration/http_status_codes_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/pyroscope/pkg/pprof/testhelper"
 )
 
 type Request struct {
@@ -2538,6 +2540,18 @@ func TestStatusCodes(t *testing.T) {
 	}
 
 	EachPyroscopeTest(t, func(p *PyroscopeTest, t *testing.T) {
+		// Ingest a minimal profile so the head's time range covers [now-1h, now].
+		// Without this, the head has Bounds() = (0,0) and ForTimeRange excludes it,
+		// meaning invalid matchers are never parsed and always return 200.
+		rb := p.NewRequestBuilder(t)
+		profileBytes, err := testhelper.NewProfileBuilder(time.Now().Add(-time.Second).UnixNano()).
+			CPUProfile().
+			ForStacktraceString("foo", "bar").
+			AddSamples(1).
+			MarshalVT()
+		require.NoError(t, err)
+		rb.Push(rb.PushPPROFRequestFromBytes(profileBytes, "process_cpu"), 200, "")
+
 		client := http.DefaultClient
 		isV1Test := strings.HasSuffix(t.Name(), "v1")
 


### PR DESCRIPTION
In #5049 we noticed some regressions in the integration tests, this fixes them on main:

- **test: ingest data before status code tests to ensure head is in range**
- **fixing some more tests**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust expectations and add deterministic setup data; no production logic is modified.
> 
> **Overview**
> Fixes flaky/incorrect expectations in `TestStatusCodes` integration coverage by seeding a minimal pprof CPU profile before running endpoint status-code cases so queries hit an in-range head block and invalid matcher syntax is actually parsed.
> 
> Adjusts a few test vectors to match real behavior: v1 invalid matcher syntax now expects `500` (instead of `200`), and `SelectMergeSpanProfile` test requests use realistic span IDs instead of placeholder strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91587c650a48f5ce000148b30194c61293eb556b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->