### PR TITLE
chore(renovate): raise prConcurrentLimit to 239

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:best-practices"],
   "timezone": "UTC",
   "schedule": ["before 4am on monday"],
-  "prConcurrentLimit": 10,
+  "prConcurrentLimit": 239,
   "prCreation": "not-pending",
   "internalChecksFilter": "strict",
   "ignoreDeps": [],


### PR DESCRIPTION
Raises Renovate's `prConcurrentLimit` from 10 to 239 to allow more open update PRs at once.

The previous limit of 10 could easily be occupied by PRs against language-specific SDK examples (examples/language-sdk-instrumentation/*, tracing examples, etc.), which we care about far less than updates to the actual database and its UI. Raising the cap ensures core database and UI dependency updates aren't starved by example/SDK churn.

Security PRs are unaffected — Renovate always bypasses `prConcurrentLimit` for vulnerability alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low code risk since this only changes Renovate configuration; the main impact is operational (many more dependency update PRs may be opened concurrently, increasing review/CI load).
> 
> **Overview**
> Raises Renovate’s `prConcurrentLimit` from `10` to `239`, allowing substantially more dependency update PRs to be open concurrently while leaving all other Renovate rules unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46373a23ca7c13c8962a772bee85cdb64dbbdc13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->