### PR TITLE
docs: add v1.20.4 release notes

### DIFF
--- a/docs/sources/release-notes/v1-20.md
+++ b/docs/sources/release-notes/v1-20.md
@@ -5,6 +5,12 @@ description: Release notes for Grafana Pyroscope 1.20
 weight: 700
 ---
 
+## Version 1.20.4 release notes
+
+### Security fixes
+* Bump `protocol-buffers-schema` to 3.6.1 (security) ([#5059](https://github.com/grafana/pyroscope/pull/5059))
+* Bump `protobufjs` to 7.5.5 (security) ([#5062](https://github.com/grafana/pyroscope/pull/5062))
+
 ## Version 1.20.3 release notes
 
 ### Improvements


### PR DESCRIPTION
Release notes for the v1.20.4 patch release (security fixes for protocol-buffers-schema and protobufjs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime or dependency updates are introduced by this PR itself.
> 
> **Overview**
> Adds a new **v1.20.4** section to `docs/sources/release-notes/v1-20.md`, documenting security-related version bumps for `protocol-buffers-schema` and `protobufjs` (with PR links).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40184db9f268a85363a3bb8fa467f8518ad764e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->