### PR TITLE
test(integration): reproducer for #4789 unsymbolized maxNodes collapse

### DIFF
--- a/pkg/test/integration/symbolization_issue4789_test.go
+++ b/pkg/test/integration/symbolization_issue4789_test.go
@@ -15,6 +15,7 @@ import (
 	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
 	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
 	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	phlaremodel "github.com/grafana/pyroscope/pkg/model"
 	"github.com/grafana/pyroscope/pkg/tenant"
 	"github.com/grafana/pyroscope/pkg/test/integration/cluster"
 )
@@ -159,6 +160,22 @@ func TestMicroServicesIntegrationV2Issue4789Reproducer(t *testing.T) {
 	}, 10*time.Second, 500*time.Millisecond, "flamegraph never contained the symbolized function names")
 
 	t.Logf("flamegraph names: %v, total: %d", fg.Names, fg.Total)
+
+	// Fetch the same data again as a tree and log it so reviewers can
+	// see the shape of the result without decoding the flamegraph levels.
+	treeReq := connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: q.Msg.ProfileTypeID,
+		Start:         q.Msg.Start,
+		End:           q.Msg.End,
+		LabelSelector: q.Msg.LabelSelector,
+		Format:        querierv1.ProfileFormat_PROFILE_FORMAT_TREE,
+	})
+	treeResp, err := querier.SelectMergeStacktraces(ctx, treeReq)
+	require.NoError(t, err)
+	tree, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](treeResp.Msg.GetTree())
+	require.NoError(t, err)
+	t.Logf("tree:\n%s", tree.String())
+
 	assert.Contains(t, fg.Names, "foo")
 	assert.Contains(t, fg.Names, "bar")
 	for _, stub := range wantStubs {

--- a/pkg/test/integration/symbolization_issue4789_test.go
+++ b/pkg/test/integration/symbolization_issue4789_test.go
@@ -3,8 +3,6 @@ package integration
 import (
 	"bytes"
 	"context"
-	"path/filepath"
-	"runtime"
 	"slices"
 	"testing"
 	"time"
@@ -27,38 +25,30 @@ import (
 // When a flamegraph query hits blocks with unsymbolized profiles, the
 // query-frontend rewrites the tree query into a pprof query (see
 // backendTreeSymbolizer in pkg/frontend/readpath/queryfrontend/symbolizer.go)
-// forwarding MaxNodes (8192 by default via ValidateMaxNodes). The pprof
-// resolver then picks pprofTree, which builds the truncation tree from
+// and forwards MaxNodes (8192 by default via ValidateMaxNodes). The pprof
+// resolver then picks pprofTree, which builds its truncation tree from
 // each location's Line slice. Unsymbolized locations have an empty Line
-// slice, so all unsymbolized stack traces collapse onto a single empty
-// tree node and are reported as one "other" sample instead of remaining
-// distinct. After post-query symbolization, the user sees a merged
-// "other" function in the flamegraph rather than the individual function
-// names.
+// slice, so every unsymbolized stack trace collapses onto a single empty
+// tree node and ends up in the "fully truncated" bucket as one merged
+// "other" sample. After post-query symbolization the user sees a single
+// "other" node where the distinct unsymbolized stacks used to be.
 //
-// The test pushes an unsymbolized profile with two known addresses that
-// the test debuginfod server resolves to "main" and "atoll_b", then asks
-// for the flamegraph via SelectMergeStacktraces and asserts that both
-// function names appear. On current main the flamegraph contains only
-// "other" under "total".
+// The profile pushed here mirrors the one in the issue: one fully
+// symbolized stack (foo, bar) and two fully unsymbolized stacks with
+// addresses in library.so (no BuildID, so the symbolizer cannot resolve
+// them). On a fixed code path, the flamegraph preserves all three stacks
+// and "other" does not appear. On current main, the two unsymbolized
+// stacks collapse and "other" is present.
 func TestMicroServicesIntegrationV2Issue4789Reproducer(t *testing.T) {
-	debuginfodServer, err := NewTestDebuginfodServer()
-	require.NoError(t, err)
-
-	_, currentFile, _, _ := runtime.Caller(0)
-	testDataDir := filepath.Join(filepath.Dir(currentFile), "..", "..", "symbolizer", "testdata")
-	debugFilePath := filepath.Join(testDataDir, "symbols.debug")
-
-	debuginfodServer.AddDebugFile(testBuildID, debugFilePath)
-
-	require.NoError(t, debuginfodServer.Start())
-	defer func() {
-		_ = debuginfodServer.Stop()
-	}()
-
+	// The symbolizer has to be enabled so that the query-frontend wraps
+	// the backend with backendTreeSymbolizer — that wrapper is what
+	// rewrites QUERY_TREE into QUERY_PPROF and triggers the buggy path.
+	// The URL below is never contacted: our mappings carry no BuildID,
+	// so the symbolizer short-circuits to fallback symbols without any
+	// network call (see Symbolizer.symbolize, empty_build_id branch).
 	c := cluster.NewMicroServiceCluster(
 		cluster.WithV2(),
-		cluster.WithSymbolizer(debuginfodServer.URL()),
+		cluster.WithSymbolizer("http://127.0.0.1:1"),
 	)
 
 	ctx := context.Background()
@@ -87,28 +77,37 @@ func TestMicroServicesIntegrationV2Issue4789Reproducer(t *testing.T) {
 		},
 		PeriodType: &profile.ValueType{Type: "cpu", Unit: "nanoseconds"},
 	}
-	m := &profile.Mapping{
-		ID:      1,
-		Start:   0,
-		Limit:   0x1000000,
-		Offset:  0,
-		File:    "libfoo.so",
-		BuildID: testBuildID,
-	}
-	src.Mapping = []*profile.Mapping{m}
-	loc1 := &profile.Location{ID: 1, Mapping: m, Address: 0x1500}
-	loc2 := &profile.Location{ID: 2, Mapping: m, Address: 0x3c5a}
-	src.Location = []*profile.Location{loc1, loc2}
+	// Mirrors the profile from issue #4789: one empty mapping that
+	// owns the symbolized foo/bar locations, plus a library.so
+	// mapping with HasFunctions=false that owns the unsymbolized
+	// address-only locations. No BuildID, so the symbolizer cannot
+	// resolve library.so's addresses.
+	mSymbolized := &profile.Mapping{ID: 1}
+	mUnsymbolized := &profile.Mapping{ID: 2, File: "library.so"}
+	src.Mapping = []*profile.Mapping{mSymbolized, mUnsymbolized}
+
+	foo := &profile.Function{ID: 1, Name: "foo"}
+	bar := &profile.Function{ID: 2, Name: "bar"}
+	src.Function = []*profile.Function{foo, bar}
+
+	locFoo := &profile.Location{ID: 1, Mapping: mSymbolized, Line: []profile.Line{{Function: foo}}}
+	locBar := &profile.Location{ID: 2, Mapping: mSymbolized, Line: []profile.Line{{Function: bar}}}
+	locA := &profile.Location{ID: 3, Mapping: mUnsymbolized, Address: 0xcafe03000}
+	locB := &profile.Location{ID: 4, Mapping: mUnsymbolized, Address: 0xcafe04000}
+	locC := &profile.Location{ID: 5, Mapping: mUnsymbolized, Address: 0xcafe05000}
+	locD := &profile.Location{ID: 6, Mapping: mUnsymbolized, Address: 0xcafe06000}
+	src.Location = []*profile.Location{locFoo, locBar, locA, locB, locC, locD}
+
 	src.Sample = []*profile.Sample{
-		{Location: []*profile.Location{loc1}, Value: []int64{100}},
-		{Location: []*profile.Location{loc2}, Value: []int64{200}},
-		{Location: []*profile.Location{loc1, loc2}, Value: []int64{300}},
+		{Location: []*profile.Location{locFoo, locBar}, Value: []int64{1_000_000_000}},
+		{Location: []*profile.Location{locA, locB}, Value: []int64{1_000_000_000}},
+		{Location: []*profile.Location{locC, locD}, Value: []int64{1_000_000_000}},
 	}
 
 	var buf bytes.Buffer
 	require.NoError(t, src.Write(&buf))
 
-	_, err = pusher.Push(ctx, connect.NewRequest(&pushv1.PushRequest{
+	_, err := pusher.Push(ctx, connect.NewRequest(&pushv1.PushRequest{
 		Series: []*pushv1.RawProfileSeries{{
 			Labels: []*typesv1.LabelPair{
 				{Name: "service_name", Value: serviceName},
@@ -127,6 +126,18 @@ func TestMicroServicesIntegrationV2Issue4789Reproducer(t *testing.T) {
 		LabelSelector: `{service_name="` + serviceName + `"}`,
 	})
 
+	// Unsymbolized locations get a fallback name of "<binary>!0x<addr>"
+	// from the symbolizer (see createFallbackSymbol). We expect all four
+	// library.so addresses to appear in the flamegraph on a fixed code
+	// path; on current main they are lost because the backend collapses
+	// them into a single "other" sample before the symbolizer runs.
+	wantStubs := []string{
+		"library.so!0xcafe03000",
+		"library.so!0xcafe04000",
+		"library.so!0xcafe05000",
+		"library.so!0xcafe06000",
+	}
+
 	var fg *querierv1.FlameGraph
 	require.Eventually(t, func() bool {
 		resp, err := querier.SelectMergeStacktraces(ctx, q)
@@ -138,17 +149,23 @@ func TestMicroServicesIntegrationV2Issue4789Reproducer(t *testing.T) {
 		if fg == nil || fg.Total == 0 {
 			return false
 		}
-		if !slices.Contains(fg.Names, "main") || !slices.Contains(fg.Names, "atoll_b") {
-			t.Logf("flamegraph not yet symbolized: names=%v total=%d", fg.Names, fg.Total)
+		// Wait until the symbolized part of the profile has
+		// propagated through ingestion and into the query response.
+		if !slices.Contains(fg.Names, "foo") || !slices.Contains(fg.Names, "bar") {
+			t.Logf("flamegraph not yet populated: names=%v total=%d", fg.Names, fg.Total)
 			return false
 		}
 		return true
-	}, 10*time.Second, 500*time.Millisecond, "flamegraph never contained both resolved function names")
+	}, 10*time.Second, 500*time.Millisecond, "flamegraph never contained the symbolized function names")
 
 	t.Logf("flamegraph names: %v, total: %d", fg.Names, fg.Total)
-	assert.Contains(t, fg.Names, "main")
-	assert.Contains(t, fg.Names, "atoll_b")
+	assert.Contains(t, fg.Names, "foo")
+	assert.Contains(t, fg.Names, "bar")
+	for _, stub := range wantStubs {
+		assert.Contains(t, fg.Names, stub,
+			"unsymbolized fallback stub missing — the two unsymbolized stacks were merged in the backend before symbolization, see issue #4789")
+	}
 	assert.NotContains(t, fg.Names, "other",
-		"all unsymbolized stacks were merged into an 'other' node — see issue #4789")
-	assert.Equal(t, int64(600), fg.Total)
+		"the two unsymbolized stacks were merged into a single 'other' node — see issue #4789")
+	assert.Equal(t, int64(3_000_000_000), fg.Total)
 }

--- a/pkg/test/integration/symbolization_issue4789_test.go
+++ b/pkg/test/integration/symbolization_issue4789_test.go
@@ -42,8 +42,6 @@ import (
 // function names appear. On current main the flamegraph contains only
 // "other" under "total".
 func TestMicroServicesIntegrationV2Issue4789Reproducer(t *testing.T) {
-	t.Skip("TODO(#4789): reproducer for unsymbolized maxNodes collapse; unskip when the bug is fixed")
-
 	debuginfodServer, err := NewTestDebuginfodServer()
 	require.NoError(t, err)
 

--- a/pkg/test/integration/symbolization_issue4789_test.go
+++ b/pkg/test/integration/symbolization_issue4789_test.go
@@ -1,0 +1,156 @@
+package integration
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/pprof/profile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pushv1 "github.com/grafana/pyroscope/api/gen/proto/go/push/v1"
+	querierv1 "github.com/grafana/pyroscope/api/gen/proto/go/querier/v1"
+	typesv1 "github.com/grafana/pyroscope/api/gen/proto/go/types/v1"
+	"github.com/grafana/pyroscope/pkg/tenant"
+	"github.com/grafana/pyroscope/pkg/test/integration/cluster"
+)
+
+// TestMicroServicesIntegrationV2Issue4789Reproducer reproduces
+// https://github.com/grafana/pyroscope/issues/4789.
+//
+// When a flamegraph query hits blocks with unsymbolized profiles, the
+// query-frontend rewrites the tree query into a pprof query (see
+// backendTreeSymbolizer in pkg/frontend/readpath/queryfrontend/symbolizer.go)
+// forwarding MaxNodes (8192 by default via ValidateMaxNodes). The pprof
+// resolver then picks pprofTree, which builds the truncation tree from
+// each location's Line slice. Unsymbolized locations have an empty Line
+// slice, so all unsymbolized stack traces collapse onto a single empty
+// tree node and are reported as one "other" sample instead of remaining
+// distinct. After post-query symbolization, the user sees a merged
+// "other" function in the flamegraph rather than the individual function
+// names.
+//
+// The test pushes an unsymbolized profile with two known addresses that
+// the test debuginfod server resolves to "main" and "atoll_b", then asks
+// for the flamegraph via SelectMergeStacktraces and asserts that both
+// function names appear. On current main the flamegraph contains only
+// "other" under "total".
+func TestMicroServicesIntegrationV2Issue4789Reproducer(t *testing.T) {
+	t.Skip("TODO(#4789): reproducer for unsymbolized maxNodes collapse; unskip when the bug is fixed")
+
+	debuginfodServer, err := NewTestDebuginfodServer()
+	require.NoError(t, err)
+
+	_, currentFile, _, _ := runtime.Caller(0)
+	testDataDir := filepath.Join(filepath.Dir(currentFile), "..", "..", "symbolizer", "testdata")
+	debugFilePath := filepath.Join(testDataDir, "symbols.debug")
+
+	debuginfodServer.AddDebugFile(testBuildID, debugFilePath)
+
+	require.NoError(t, debuginfodServer.Start())
+	defer func() {
+		_ = debuginfodServer.Stop()
+	}()
+
+	c := cluster.NewMicroServiceCluster(
+		cluster.WithV2(),
+		cluster.WithSymbolizer(debuginfodServer.URL()),
+	)
+
+	ctx := context.Background()
+	require.NoError(t, c.Prepare(ctx))
+	require.NoError(t, c.Start(ctx))
+	t.Log("Cluster ready")
+	defer func() {
+		waitStopped := c.Stop()
+		require.NoError(t, waitStopped(ctx))
+	}()
+
+	pusher := c.PushClient()
+	querier := c.QueryClient()
+
+	const (
+		serviceName = "test-issue-4789-service"
+		tenantID    = "test-tenant"
+	)
+	ctx = tenant.InjectTenantID(ctx, tenantID)
+
+	src := &profile.Profile{
+		DurationNanos: int64(10 * time.Second),
+		Period:        1_000_000_000,
+		SampleType: []*profile.ValueType{
+			{Type: "cpu", Unit: "nanoseconds"},
+		},
+		PeriodType: &profile.ValueType{Type: "cpu", Unit: "nanoseconds"},
+	}
+	m := &profile.Mapping{
+		ID:      1,
+		Start:   0,
+		Limit:   0x1000000,
+		Offset:  0,
+		File:    "libfoo.so",
+		BuildID: testBuildID,
+	}
+	src.Mapping = []*profile.Mapping{m}
+	loc1 := &profile.Location{ID: 1, Mapping: m, Address: 0x1500}
+	loc2 := &profile.Location{ID: 2, Mapping: m, Address: 0x3c5a}
+	src.Location = []*profile.Location{loc1, loc2}
+	src.Sample = []*profile.Sample{
+		{Location: []*profile.Location{loc1}, Value: []int64{100}},
+		{Location: []*profile.Location{loc2}, Value: []int64{200}},
+		{Location: []*profile.Location{loc1, loc2}, Value: []int64{300}},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, src.Write(&buf))
+
+	_, err = pusher.Push(ctx, connect.NewRequest(&pushv1.PushRequest{
+		Series: []*pushv1.RawProfileSeries{{
+			Labels: []*typesv1.LabelPair{
+				{Name: "service_name", Value: serviceName},
+				{Name: "__name__", Value: "process_cpu"},
+			},
+			Samples: []*pushv1.RawSample{{RawProfile: buf.Bytes()}},
+		}},
+	}))
+	require.NoError(t, err)
+
+	now := time.Now()
+	q := connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
+		ProfileTypeID: "process_cpu:cpu:nanoseconds:cpu:nanoseconds",
+		Start:         now.Add(-time.Hour).UnixMilli(),
+		End:           now.Add(time.Hour).UnixMilli(),
+		LabelSelector: `{service_name="` + serviceName + `"}`,
+	})
+
+	var fg *querierv1.FlameGraph
+	require.Eventually(t, func() bool {
+		resp, err := querier.SelectMergeStacktraces(ctx, q)
+		if err != nil {
+			t.Logf("query error: %v", err)
+			return false
+		}
+		fg = resp.Msg.GetFlamegraph()
+		if fg == nil || fg.Total == 0 {
+			return false
+		}
+		if !slices.Contains(fg.Names, "main") || !slices.Contains(fg.Names, "atoll_b") {
+			t.Logf("flamegraph not yet symbolized: names=%v total=%d", fg.Names, fg.Total)
+			return false
+		}
+		return true
+	}, 10*time.Second, 500*time.Millisecond, "flamegraph never contained both resolved function names")
+
+	t.Logf("flamegraph names: %v, total: %d", fg.Names, fg.Total)
+	assert.Contains(t, fg.Names, "main")
+	assert.Contains(t, fg.Names, "atoll_b")
+	assert.NotContains(t, fg.Names, "other",
+		"all unsymbolized stacks were merged into an 'other' node — see issue #4789")
+	assert.Equal(t, int64(600), fg.Total)
+}

--- a/pkg/test/integration/symbolization_issue4789_test.go
+++ b/pkg/test/integration/symbolization_issue4789_test.go
@@ -162,7 +162,7 @@ func TestMicroServicesIntegrationV2Issue4789Reproducer(t *testing.T) {
 	t.Logf("flamegraph names: %v, total: %d", fg.Names, fg.Total)
 
 	// Fetch the same data again as a tree and log it so reviewers can
-	// see the shape of the result without decoding the flamegraph levels.
+	// see the shape of the flamegraph result without decoding levels.
 	treeReq := connect.NewRequest(&querierv1.SelectMergeStacktracesRequest{
 		ProfileTypeID: q.Msg.ProfileTypeID,
 		Start:         q.Msg.Start,
@@ -174,7 +174,25 @@ func TestMicroServicesIntegrationV2Issue4789Reproducer(t *testing.T) {
 	require.NoError(t, err)
 	tree, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](treeResp.Msg.GetTree())
 	require.NoError(t, err)
-	t.Logf("tree:\n%s", tree.String())
+	t.Logf("stacktraces tree (via SelectMergeStacktraces, buggy path):\n%s", tree.String())
+
+	// Query the same data as pprof via SelectMergeProfile (the pprof export
+	// path). With query-tree-enabled=true this goes through QUERY_TREE /
+	// resolver.Tree() and is NOT affected by the bug — it's a reference for
+	// what the data looks like when the truncation tree is built over
+	// symbols rather than function IDs.
+	pprofResp, err := querier.SelectMergeProfile(ctx, connect.NewRequest(&querierv1.SelectMergeProfileRequest{
+		ProfileTypeID: q.Msg.ProfileTypeID,
+		Start:         q.Msg.Start,
+		End:           q.Msg.End,
+		LabelSelector: q.Msg.LabelSelector,
+	}))
+	require.NoError(t, err)
+	pprofTreeBytes, err := phlaremodel.TreeFromBackendProfile(pprofResp.Msg, 8192)
+	require.NoError(t, err)
+	pprofTree, err := phlaremodel.UnmarshalTree[phlaremodel.FunctionName, phlaremodel.FunctionNameI](pprofTreeBytes)
+	require.NoError(t, err)
+	t.Logf("pprof tree (via SelectMergeProfile → TreeFromBackendProfile, reference path):\n%s", pprofTree.String())
 
 	assert.Contains(t, fg.Names, "foo")
 	assert.Contains(t, fg.Names, "bar")


### PR DESCRIPTION
Reproducer only — no fix. Tracks https://github.com/grafana/pyroscope/issues/4789.

When the V2 flamegraph path (`SelectMergeStacktraces`) hits blocks with unsymbolized profiles, the query-frontend wraps the backend with `backendTreeSymbolizer`, which rewrites `QUERY_TREE` into `QUERY_PPROF` while forwarding `MaxNodes` (8192 by default via `ValidateMaxNodes`). The backend then runs `resolver.Pprof()`, which selects `pprofTree` whenever `maxNodes > 0`. `pprofTree` builds its truncation tree from each `Location.Line` slice; for unsymbolized locations that slice is empty, so `locFunctions` returns an empty slice and every unsymbolized stacktrace collapses onto the same (empty) tree node and ends up in the "fully truncated" bucket. The frontend symbolizer then applies addresses to the already-collapsed profile, and the user sees a single `other` sample where the distinct unsymbolized stacks used to be.

The test reproduces the exact profile from issue #4789: one pre-symbolized `foo;bar` stack plus two fully-unsymbolized stacks at hex addresses in `library.so` (no BuildID, so the symbolizer short-circuits to fallback symbols). The symbolizer has to be enabled for the query-frontend to wrap the backend with `backendTreeSymbolizer`; no real debuginfod server is needed — a dummy URL is enough because empty BuildIDs never trigger a lookup.

On current `main` the test fails with (buggy) vs (reference) trees in the log:

```
stacktraces tree (via SelectMergeStacktraces, buggy path):
.
├── bar: self 0 total 1000000000
│   └── foo: self 1000000000 total 1000000000
└── other: self 2000000000 total 2000000000

pprof tree (via SelectMergeProfile → TreeFromBackendProfile, reference path):
.
├── bar: self 0 total 1000000000
│   └── foo: self 1000000000 total 1000000000
├── library.so!0xcafe04000: self 0 total 1000000000
│   └── library.so!0xcafe03000: self 1000000000 total 1000000000
└── library.so!0xcafe06000: self 0 total 1000000000
    └── library.so!0xcafe05000: self 1000000000 total 1000000000
```

Both queries ran against the same data. `SelectMergeProfile` goes through the newer generic `LocationRefName` tree path introduced by #4790 (`FullSymbols=true`) and preserves every location; the symbolizer runs afterwards on the pprof and only needs to fill in fallback names for the address stubs. `SelectMergeStacktraces` still routes through `backendTreeSymbolizer`, which rewrites the query into the pprof path on the backend and hits `pprofTree`, collapsing the unsymbolized stacks before the symbolizer can ever see them.

So the generic-tree refactor (#4790) fixes the pprof export path but leaves the flamegraph/stacktraces path on the old code. There is no flag we can toggle to reuse the new tree path for `SelectMergeStacktraces` — the actual fix likely has to refactor `selectMergeStacktracesTree` to use `FullSymbols=true` and apply symbolization on the converted pprof (the way `selectMergeProfileTree` already does), or teach `pprofTree` / its replacement to build the truncation tree over locations instead of function IDs (as `origin/feat/pprof-loc-tree-trimming` does).

Related code paths (all on current `main`):
- `pkg/frontend/readpath/queryfrontend/query_select_merge_stacktraces.go` — still wraps with `backendTreeSymbolizer` when `shouldSymbolize`.
- `pkg/frontend/readpath/queryfrontend/symbolizer.go:47` — rewrites `QUERY_TREE` to `QUERY_PPROF` carrying `MaxNodes`.
- `pkg/querybackend/query_pprof.go` → `resolver.Pprof()` → `pkg/phlaredb/symdb/resolver_pprof.go:42` picks `pprofTree` when `maxNodes > 0`.
- `pkg/phlaredb/symdb/resolver_pprof_tree.go:81` `locFunctions` — the collapse point.