### PR TITLE
feat(query-backend): add Prometheus metrics to concurrency limiter

### DIFF
--- a/pkg/pyroscope/modules.go
+++ b/pkg/pyroscope/modules.go
@@ -471,7 +471,7 @@ func (f *Pyroscope) initServer() (services.Service, error) {
 	if f.Cfg.V2 {
 		f.Cfg.Server.MetricsNativeHistogramFactor = 1.1 // 10% increase from bucket to bucket
 		if slices.Contains(f.Cfg.Target, QueryBackend) {
-			concurrencyInterceptor, err := querybackend.CreateConcurrencyInterceptor(f.logger)
+			concurrencyInterceptor, err := querybackend.CreateConcurrencyInterceptor(f.logger, f.reg)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/querybackend/client/client_test.go
+++ b/pkg/querybackend/client/client_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/grafana/dskit/grpcclient"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -98,7 +99,7 @@ func Test_Concurrency(t *testing.T) {
 	require.NoError(t, err)
 
 	for i := 0; i < nServers; i++ {
-		gclInterceptor, err := querybackend.CreateConcurrencyInterceptor(log.NewNopLogger())
+		gclInterceptor, err := querybackend.CreateConcurrencyInterceptor(log.NewNopLogger(), prometheus.NewRegistry())
 		require.NoError(t, err)
 
 		b, err := querybackend.New(querybackend.Config{

--- a/pkg/querybackend/concurrency.go
+++ b/pkg/querybackend/concurrency.go
@@ -3,6 +3,8 @@ package querybackend
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -11,6 +13,7 @@ import (
 	"github.com/platinummonkey/go-concurrency-limits/limit"
 	"github.com/platinummonkey/go-concurrency-limits/limiter"
 	"github.com/platinummonkey/go-concurrency-limits/strategy"
+	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 )
@@ -36,15 +39,15 @@ var (
 	}
 )
 
-func CreateConcurrencyInterceptor(logger log.Logger) (grpc.UnaryServerInterceptor, error) {
+func CreateConcurrencyInterceptor(logger log.Logger, reg prometheus.Registerer) (grpc.UnaryServerInterceptor, error) {
 	gclLog := newGclLogger(logger)
-	// TODO(aleks-p): Implement metric registry
-	serverLimit, err := limit.NewGradient2Limit("query-backend-concurrency-limit", minLimit, maxLimit, initialLimit, queueSizeFn, smoothing, longWindow, gclLog, nil)
+	metricRegistry := newPrometheusMetricRegistry(reg)
+	serverLimit, err := limit.NewGradient2Limit("query-backend", minLimit, maxLimit, initialLimit, queueSizeFn, smoothing, longWindow, gclLog, metricRegistry)
 	if err != nil {
 		return nil, err
 	}
 
-	serverLimiter, err := limiter.NewDefaultLimiter(serverLimit, minWindowTime, maxWindowTime, minRTTThreshold, windowSize, strategy.NewSimpleStrategy(initialLimit), gclLog, nil)
+	serverLimiter, err := limiter.NewDefaultLimiter(serverLimit, minWindowTime, maxWindowTime, minRTTThreshold, windowSize, strategy.NewSimpleStrategy(initialLimit), gclLog, metricRegistry)
 	if err != nil {
 		return nil, err
 	}
@@ -75,3 +78,115 @@ func (g gclLogger) IsDebugEnabled() bool {
 func newGclLogger(logger log.Logger) *gclLogger {
 	return &gclLogger{logger: logger}
 }
+
+// prometheusMetricRegistry implements core.MetricRegistry backed by Prometheus.
+type prometheusMetricRegistry struct {
+	reg prometheus.Registerer
+	mu  sync.Mutex
+
+	histograms map[string]prometheus.Histogram
+	counters   map[string]prometheus.Counter
+}
+
+func newPrometheusMetricRegistry(reg prometheus.Registerer) *prometheusMetricRegistry {
+	return &prometheusMetricRegistry{
+		reg:        reg,
+		histograms: make(map[string]prometheus.Histogram),
+		counters:   make(map[string]prometheus.Counter),
+	}
+}
+
+const metricPrefix = "query_backend_concurrency_"
+const gclNamePrefix = "query-backend."
+
+// sanitizeID converts a gcl metric ID (e.g. "query-backend.rtt")
+// to a valid Prometheus metric name (e.g. "query_backend_concurrency_rtt").
+func sanitizeID(id string) string {
+	suffix := strings.TrimPrefix(id, gclNamePrefix)
+	return metricPrefix + strings.NewReplacer("-", "_", ".", "_").Replace(suffix)
+}
+
+func (r *prometheusMetricRegistry) getOrRegisterHistogram(id string) prometheus.Histogram {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if h, ok := r.histograms[id]; ok {
+		return h
+	}
+	h := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name: sanitizeID(id),
+		Help: fmt.Sprintf("Concurrency limiter metric: %s", id),
+	})
+	if err := r.reg.Register(h); err != nil {
+		// If already registered, use the existing collector.
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			h = are.ExistingCollector.(prometheus.Histogram)
+		}
+	}
+	r.histograms[id] = h
+	return h
+}
+
+func (r *prometheusMetricRegistry) getOrRegisterCounter(id string) prometheus.Counter {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if c, ok := r.counters[id]; ok {
+		return c
+	}
+	c := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: sanitizeID(id),
+		Help: fmt.Sprintf("Concurrency limiter metric: %s", id),
+	})
+	if err := r.reg.Register(c); err != nil {
+		if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
+			c = are.ExistingCollector.(prometheus.Counter)
+		}
+	}
+	r.counters[id] = c
+	return c
+}
+
+type histogramListener struct{ h prometheus.Histogram }
+
+func (l *histogramListener) AddSample(value float64, tags ...string) { l.h.Observe(value) }
+
+type counterListener struct{ c prometheus.Counter }
+
+func (l *counterListener) AddSample(value float64, tags ...string) { l.c.Add(value) }
+
+// RegisterDistribution registers a histogram for sample distributions.
+func (r *prometheusMetricRegistry) RegisterDistribution(id string, tags ...string) core.MetricSampleListener {
+	return &histogramListener{h: r.getOrRegisterHistogram(id)}
+}
+
+// RegisterTiming registers a histogram for timing samples (values in nanoseconds).
+func (r *prometheusMetricRegistry) RegisterTiming(id string, tags ...string) core.MetricSampleListener {
+	return &histogramListener{h: r.getOrRegisterHistogram(id)}
+}
+
+// RegisterCount registers a counter.
+func (r *prometheusMetricRegistry) RegisterCount(id string, tags ...string) core.MetricSampleListener {
+	return &counterListener{c: r.getOrRegisterCounter(id)}
+}
+
+// RegisterGauge registers a gauge backed by a supplier function.
+func (r *prometheusMetricRegistry) RegisterGauge(id string, supplier core.MetricSupplier, tags ...string) {
+	g := prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+		Name: sanitizeID(id),
+		Help: fmt.Sprintf("Concurrency limiter metric: %s", id),
+	}, func() float64 {
+		val, ok := supplier()
+		if !ok {
+			return 0
+		}
+		return val
+	})
+	if err := r.reg.Register(g); err != nil {
+		// ignore if already registered
+	}
+}
+
+// Start is a no-op for Prometheus (pull-based).
+func (r *prometheusMetricRegistry) Start() {}
+
+// Stop is a no-op for Prometheus (pull-based).
+func (r *prometheusMetricRegistry) Stop() {}


### PR DESCRIPTION
The gradient2 concurrency limiter was running blind with no visibility into its behaviour. This wires up a Prometheus metric registry exposing `query_backend_concurrency_{limit,inflight,rtt,dropped,...}` metrics, making it possible to alert on request shedding and inform autoscaling decisions.