### PR TITLE
fix(ui): bump dompurify, immutable, brace-expansion to fix Trivy CVEs

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -38,6 +38,9 @@
   },
   "packageManager": "yarn@4.13.0",
   "resolutions": {
-    "react-custom-scrollbars-2@npm:4.5.0": "patch:react-custom-scrollbars-2@npm%3A4.5.0#~/.yarn/patches/react-custom-scrollbars-2-npm-4.5.0-420f40d266.patch"
+    "react-custom-scrollbars-2@npm:4.5.0": "patch:react-custom-scrollbars-2@npm%3A4.5.0#~/.yarn/patches/react-custom-scrollbars-2-npm-4.5.0-420f40d266.patch",
+    "brace-expansion@npm:^1.1.7": "npm:1.1.13",
+    "dompurify": "npm:^3.4.0",
+    "immutable": "npm:5.1.5"
   }
 }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2541,13 +2541,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12"
+"brace-expansion@npm:1.1.13":
+  version: 1.1.13
+  resolution: "brace-expansion@npm:1.1.13"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
+  checksum: 10c0/384c61bb329b6adfdcc0cbbdd108dc19fb5f3e84ae15a02a74f94c6c791b5a9b035aae73b2a51929a8a478e2f0f212a771eb6a8b5b514cccfb8d0c9f2ce8cbd8
   languageName: node
   linkType: hard
 
@@ -3191,15 +3191,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.3.0":
-  version: 3.3.0
-  resolution: "dompurify@npm:3.3.0"
+"dompurify@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "dompurify@npm:3.4.0"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/66b1787b0bc8250d8f58e13284cf7f5f6bb400a0a55515e7a2a030316a4bb0d8306fdb669c17ed86ed58ff7e53c62b5da4488c2f261d11c58870fe01b8fcc486
+  checksum: 10c0/5593ac44ee20b9aa521c2120884effc98927fb9128c548183c75e79e0a04357c62ee913a049a267c8f396cb8c9d520ecf72562826c5524c46d4fe03c12063638
   languageName: node
   linkType: hard
 
@@ -3892,10 +3892,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:5.1.4":
-  version: 5.1.4
-  resolution: "immutable@npm:5.1.4"
-  checksum: 10c0/f1c98382e4cde14a0b218be3b9b2f8441888da8df3b8c064aa756071da55fbed6ad696e5959982508456332419be9fdeaf29b2e58d0eadc45483cc16963c0446
+"immutable@npm:5.1.5":
+  version: 5.1.5
+  resolution: "immutable@npm:5.1.5"
+  checksum: 10c0/8017ece1578e3c5939ba3305176aee059def1b8a90c7fa2a347ef583ebbd38cbe77ce1bbd786a5fab57e2da00bbcb0493b92e4332cdc4e1fe5cfb09a4688df31
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- **dompurify** 3.3.0 → 3.4.0 — fixes CVE-2026-0540, GHSA-39q2-94rc-95cp, GHSA-cj63-jhhr-wcxv, GHSA-cjmm-f4jc-qw8r, GHSA-h8r8-wccr-v5f2 (XSS/prototype pollution in `@grafana/flamegraph` transitive dep)
- **immutable** 5.1.4 → 5.1.5 — fixes CVE-2026-29063 HIGH (prototype pollution / arbitrary code execution)
- **brace-expansion** 1.1.12 → 1.1.13 — fixes CVE-2026-33750 (DoS via zero step value in brace pattern)

All three are transitive dependencies (via `@grafana/flamegraph`/`minimatch`). Upgrades are pinned via yarn `resolutions` in `ui/package.json`. Frontend build verified clean after the upgrade.

## Test plan

- [x] `nix run sys#trivy -- fs ui/yarn.lock` reports 0 vulnerabilities
- [x] `corepack yarn build` in `ui/` completes without errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency maintenance change: pins a few transitive frontend packages to patched versions and updates `yarn.lock`, with minimal chance of runtime impact beyond upstream library behavior changes.
> 
> **Overview**
> Addresses frontend dependency CVEs by adding Yarn `resolutions` in `ui/package.json` to force patched transitive versions of `dompurify` (to `^3.4.0`), `immutable` (to `5.1.5`), and `brace-expansion` (to `1.1.13`).
> 
> Updates `ui/yarn.lock` accordingly so installs consistently resolve to the pinned versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 499878c155bc10571539a6e6248706e17ca76da0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->