### PR TITLE
make: add frontend/build dependency to reference-help target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ clean: ## Delete intermediate build artifacts
 
 .PHONY: reference-help
 reference-help: ## Generates the reference help documentation.
-reference-help: go/bin
+reference-help: frontend/build go/bin
 	@(./pyroscope -h || true) > cmd/pyroscope/help.txt.tmpl
 	@(./pyroscope -help-all || true) > cmd/pyroscope/help-all.txt.tmpl
 


### PR DESCRIPTION
## Summary

- `reference-help` depends on `go/bin`, which by default builds with `-tags "netgo embedassets"`
- The `embedassets` tag activates `//go:embed dist` in `ui/assets_embedded.go`, so `ui/dist/` must exist before compilation
- Without this fix, `make reference-help` fails from a clean checkout if the frontend has never been built
- `build` and `docker-image/pyroscope/build` already list `frontend/build` as a prerequisite — this brings `reference-help` in line with them

## Test plan

- [x] Verified `reference-help` recipe unchanged — only the prerequisite is added
- [x] One-liner diff, no logic change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-graph change: only adds a prerequisite to `reference-help`, affecting build order but not runtime logic.
> 
> **Overview**
> `make reference-help` now depends on `frontend/build` in addition to `go/bin`, ensuring the `ui/dist` assets exist before compiling the binary used to generate `cmd/pyroscope/help*.txt.tmpl` from a clean checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09bcac1d429fafb134c2744acde5ef7512c5ceff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->