### PR TITLE
chore: Release helm chart for v1.21.0

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -3,8 +3,8 @@ name: pyroscope
 description: 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 home: https://grafana.com/oss/pyroscope/
 type: application
-version: 1.20.3
-appVersion: 1.20.3
+version: 1.21.0
+appVersion: 1.21.0
 dependencies:
   - name: grafana-agent
     alias: agent

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 1.20.3](https://img.shields.io/badge/Version-1.20.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.20.3](https://img.shields.io/badge/AppVersion-1.20.3-informational?style=flat-square)
+![Version: 1.21.0](https://img.shields.io/badge/Version-1.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.21.0](https://img.shields.io/badge/AppVersion-1.21.0-informational?style=flat-square)
 
 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -176,10 +176,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -523,10 +523,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1381,10 +1381,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1398,10 +1398,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1683,10 +1683,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1710,10 +1710,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1735,10 +1735,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1761,10 +1761,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1786,10 +1786,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1812,10 +1812,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1837,10 +1837,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1863,10 +1863,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1888,10 +1888,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1914,10 +1914,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -1939,10 +1939,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -1965,10 +1965,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -1990,10 +1990,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2016,10 +2016,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2041,10 +2041,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2067,10 +2067,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2082,9 +2082,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2107,7 +2107,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2169,10 +2169,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2184,9 +2184,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2209,7 +2209,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2271,10 +2271,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2286,9 +2286,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2311,7 +2311,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2373,10 +2373,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2388,9 +2388,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2413,7 +2413,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2475,10 +2475,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2503,10 +2503,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2534,10 +2534,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2562,10 +2562,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2773,10 +2773,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -2791,9 +2791,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2816,7 +2816,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -2883,10 +2883,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -2901,9 +2901,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2926,7 +2926,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -2989,10 +2989,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3007,9 +3007,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3032,7 +3032,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1423,10 +1423,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1440,10 +1440,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1725,10 +1725,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1752,10 +1752,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1777,10 +1777,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1803,10 +1803,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1828,10 +1828,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1854,10 +1854,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1879,10 +1879,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1905,10 +1905,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1930,10 +1930,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1956,10 +1956,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1981,10 +1981,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2007,10 +2007,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2032,10 +2032,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2058,10 +2058,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2083,10 +2083,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2109,10 +2109,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2134,10 +2134,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2160,10 +2160,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2185,10 +2185,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2211,10 +2211,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2227,9 +2227,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2252,7 +2252,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2314,10 +2314,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2330,9 +2330,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2355,7 +2355,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2417,10 +2417,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2433,9 +2433,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2458,7 +2458,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2520,10 +2520,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2536,9 +2536,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2561,7 +2561,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2623,10 +2623,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2639,9 +2639,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2664,7 +2664,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2726,10 +2726,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2742,9 +2742,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2767,7 +2767,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3012,10 +3012,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -3030,9 +3030,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3055,7 +3055,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3122,10 +3122,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3140,9 +3140,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3165,7 +3165,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3228,10 +3228,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3246,9 +3246,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3271,7 +3271,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1423,10 +1423,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1440,10 +1440,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1598,10 +1598,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1623,10 +1623,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1770,10 +1770,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1797,10 +1797,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1826,10 +1826,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1856,10 +1856,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1885,10 +1885,10 @@ metadata:
   name: pyroscope-dev-admin-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1915,10 +1915,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1944,10 +1944,10 @@ metadata:
   name: pyroscope-dev-compaction-worker-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1974,10 +1974,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2003,10 +2003,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2033,10 +2033,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2066,10 +2066,10 @@ metadata:
   name: pyroscope-dev-metastore-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2101,10 +2101,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2130,10 +2130,10 @@ metadata:
   name: pyroscope-dev-query-backend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2160,10 +2160,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2189,10 +2189,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2219,10 +2219,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2248,10 +2248,10 @@ metadata:
   name: pyroscope-dev-segment-writer-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2278,10 +2278,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2307,10 +2307,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2337,10 +2337,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2353,9 +2353,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2378,7 +2378,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2451,10 +2451,10 @@ metadata:
   name: pyroscope-dev-admin
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -2467,9 +2467,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2492,7 +2492,7 @@ spec:
         - name: "admin"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=admin"
@@ -2565,10 +2565,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2581,9 +2581,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2606,7 +2606,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2680,10 +2680,10 @@ metadata:
   name: pyroscope-dev-query-backend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2696,9 +2696,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2721,7 +2721,7 @@ spec:
         - name: "query-backend"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-backend"
@@ -2794,10 +2794,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2810,9 +2810,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2835,7 +2835,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2909,10 +2909,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2925,9 +2925,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2950,7 +2950,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3206,10 +3206,10 @@ metadata:
   name: pyroscope-dev-compaction-worker
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -3224,9 +3224,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3249,7 +3249,7 @@ spec:
         - name: "compaction-worker"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compaction-worker"
@@ -3323,10 +3323,10 @@ metadata:
   name: pyroscope-dev-metastore
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -3341,9 +3341,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3366,7 +3366,7 @@ spec:
         - name: "metastore"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=metastore"
@@ -3456,10 +3456,10 @@ metadata:
   name: pyroscope-dev-segment-writer
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -3474,9 +3474,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3499,7 +3499,7 @@ spec:
         - name: "segment-writer"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=segment-writer"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -69,10 +69,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -90,10 +90,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -111,10 +111,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -132,10 +132,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -153,10 +153,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -174,10 +174,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -218,10 +218,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -565,10 +565,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1423,10 +1423,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1440,10 +1440,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1725,10 +1725,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1752,10 +1752,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1777,10 +1777,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1803,10 +1803,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1828,10 +1828,10 @@ metadata:
   name: pyroscope-dev-compactor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1854,10 +1854,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1879,10 +1879,10 @@ metadata:
   name: pyroscope-dev-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1905,10 +1905,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1930,10 +1930,10 @@ metadata:
   name: pyroscope-dev-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1956,10 +1956,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1981,10 +1981,10 @@ metadata:
   name: pyroscope-dev-querier-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2007,10 +2007,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2032,10 +2032,10 @@ metadata:
   name: pyroscope-dev-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2058,10 +2058,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2083,10 +2083,10 @@ metadata:
   name: pyroscope-dev-query-scheduler-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2109,10 +2109,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2134,10 +2134,10 @@ metadata:
   name: pyroscope-dev-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2160,10 +2160,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2185,10 +2185,10 @@ metadata:
   name: pyroscope-dev-tenant-settings-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2211,10 +2211,10 @@ metadata:
   name: pyroscope-dev-ad-hoc-profiles
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2227,9 +2227,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2252,7 +2252,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2313,10 +2313,10 @@ metadata:
   name: pyroscope-dev-distributor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2329,9 +2329,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2354,7 +2354,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2415,10 +2415,10 @@ metadata:
   name: pyroscope-dev-querier
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2431,9 +2431,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2456,7 +2456,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2518,10 +2518,10 @@ metadata:
   name: pyroscope-dev-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2534,9 +2534,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2559,7 +2559,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2620,10 +2620,10 @@ metadata:
   name: pyroscope-dev-query-scheduler
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2636,9 +2636,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2661,7 +2661,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2722,10 +2722,10 @@ metadata:
   name: pyroscope-dev-tenant-settings
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2738,9 +2738,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2763,7 +2763,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3007,10 +3007,10 @@ metadata:
   name: pyroscope-dev-compactor
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -3025,9 +3025,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3050,7 +3050,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3116,10 +3116,10 @@ metadata:
   name: pyroscope-dev-ingester
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3134,9 +3134,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3159,7 +3159,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3221,10 +3221,10 @@ metadata:
   name: pyroscope-dev-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3239,9 +3239,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ff08b7ca292c3cdc926b6d2927de7ba59157a13250db93ac4383234827a6cf83
+        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3264,7 +3264,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -43,10 +43,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -56,10 +56,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -914,10 +914,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -931,10 +931,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1082,10 +1082,10 @@ kind: Role
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1107,10 +1107,10 @@ kind: RoleBinding
 metadata:
   name: pyroscope-dev-discovery
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1186,10 +1186,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1213,10 +1213,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1246,10 +1246,10 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1371,10 +1371,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1389,9 +1389,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5c6d24f4c01d40f6c1694616ca548205172022c5e38a45af7c9f15cd84015d5c
+        checksum/config: fbd928f21b3db7574eb01571d06ea679904aa0af4b2d57bbc3d6cbc694de8a8d
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1414,7 +1414,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -6,10 +6,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -43,10 +43,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -56,10 +56,10 @@ metadata:
   name: alloy-config-pyroscope
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -914,10 +914,10 @@ metadata:
   name: pyroscope-dev-overrides-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -931,10 +931,10 @@ metadata:
   name: pyroscope-dev-config
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1141,10 +1141,10 @@ metadata:
   name: pyroscope-dev-memberlist
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1168,10 +1168,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1193,10 +1193,10 @@ metadata:
   name: pyroscope-dev-headless
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1309,10 +1309,10 @@ metadata:
   name: pyroscope-dev
   namespace: default
   labels:
-    helm.sh/chart: pyroscope-1.20.3
+    helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.20.3"
+    app.kubernetes.io/version: "1.21.0"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1327,9 +1327,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 5c6d24f4c01d40f6c1694616ca548205172022c5e38a45af7c9f15cd84015d5c
+        checksum/config: fbd928f21b3db7574eb01571d06ea679904aa0af4b2d57bbc3d6cbc694de8a8d
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.20.3"
+        profiles.grafana.com/service_git_ref: "v1.21.0"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1352,7 +1352,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.20.3"
+          image: "grafana/pyroscope:1.21.0"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates the deployed `grafana/pyroscope` image tag and Helm chart metadata to `1.21.0`, which can change runtime behavior when users upgrade. Rendered manifests are updated accordingly (labels/annotations/checksums), so the main risk is compatibility/regressions in the new upstream Pyroscope version rather than template logic.
> 
> **Overview**
> Bumps the `pyroscope` Helm chart `version`/`appVersion` from `1.20.3` to `1.21.0` and updates the README version badges.
> 
> Refreshes all committed rendered Kubernetes manifests to match the release, including updated `grafana/pyroscope:1.21.0` image tags plus corresponding chart/app labels, `profiles.grafana.com/service_git_ref`, and config checksum annotations across the various deployment modes (single-binary and microservices variants).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbf7d243b874d26360d96aa6dccb9e5ef404e559. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->