### PR TITLE
feat(validation): error on startup when V2 storage layer has no backend

### DIFF
--- a/pkg/pyroscope/pyroscope.go
+++ b/pkg/pyroscope/pyroscope.go
@@ -322,6 +322,11 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	// Validate that V2 storage layers have a storage backend configured.
+	if c.ArchitectureStorage != V1 && c.Storage.Bucket.Backend == objstoreclient.None {
+		return fmt.Errorf("storage.backend is required for %s storage layer", c.ArchitectureStorage)
+	}
+
 	// Validate that write-path matches the storage layer.
 	storageLayerRequirements := map[StorageLayer]writepath.WritePath{
 		V1: writepath.IngesterPath,

--- a/pkg/pyroscope/pyroscope_test.go
+++ b/pkg/pyroscope/pyroscope_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	statusv1 "github.com/grafana/pyroscope/api/gen/proto/go/status/v1"
+	objstoreclient "github.com/grafana/pyroscope/pkg/objstore/client"
 )
 
 func TestFlagDefaults(t *testing.T) {
@@ -157,4 +158,53 @@ func TestConfigDiff(t *testing.T) {
 		require.Equal(t, "text/plain; charset=utf-8", result.ContentType)
 		require.Equal(t, "limits:\n    max_label_name_length: 123\n", string(result.Data))
 	})
+}
+
+func TestConfigValidate_StorageBackendRequired(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		wantErr        bool
+		wantErrContain string
+	}{
+		{
+			name:           "v2 with no backend errors",
+			args:           []string{"-architecture.storage=v2", "-storage.backend=", "-write-path=segment-writer"},
+			wantErr:        true,
+			wantErrContain: "storage.backend is required",
+		},
+		{
+			name:           "v1-v2-dual with no backend errors",
+			args:           []string{"-architecture.storage=v1-v2-dual", "-storage.backend=", "-write-path=segment-writer"},
+			wantErr:        true,
+			wantErrContain: "storage.backend is required",
+		},
+		{
+			name:    "v1 with no backend is allowed",
+			args:    []string{"-architecture.storage=v1", "-storage.backend=", "-write-path=ingester"},
+			wantErr: false,
+		},
+		{
+			name:    "v2 with filesystem backend is valid",
+			args:    []string{"-architecture.storage=v2", "-storage.backend=" + objstoreclient.Filesystem, "-write-path=segment-writer"},
+			wantErr: false,
+		},
+		{
+			name:    "v1-v2-dual with filesystem backend is valid",
+			args:    []string{"-architecture.storage=v1-v2-dual", "-storage.backend=" + objstoreclient.Filesystem, "-write-path=segment-writer"},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := newTestConfig(t, tt.args)
+			err := cfg.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErrContain)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #5038 (suggested by @marcsanmi in the review).

Without this check, starting with `architecture.storage=v2` (or `v1-v2-dual`) and `storage.backend=""` causes V2 modules to skip initialisation silently — the process reports ready but cannot write or read any data.

This adds an explicit validation in `Config.Validate()` that turns this silent failure into a clear startup error:

```
storage.backend is required for v2 storage layer
```

## Test plan

- [x] Unit tests added in `TestConfigValidate_StorageBackendRequired` covering all three storage layers (v1, v2, v1-v2-dual) with and without a backend configured

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup validation for `architecture.storage=v2`/`v1-v2-dual`, which may newly block misconfigured deployments that previously started but behaved incorrectly.
> 
> **Overview**
> Adds a new `Config.Validate()` check that **requires `storage.backend` to be set** when `architecture.storage` is `v2` or `v1-v2-dual`, turning a previously silent misconfiguration into a clear startup error.
> 
> Includes `TestConfigValidate_StorageBackendRequired` to verify the error/ok cases across `v1`, `v2`, and `v1-v2-dual` (with and without a backend).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d22b4324e3d56411936f3f0dd10f40c7aecd2c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->