### PR TITLE
helm: update chart for v2.0 breaking changes

### DIFF
--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -4,7 +4,7 @@ description: 🔥 horizontally-scalable, highly-available, multi-tenant continuo
 home: https://grafana.com/oss/pyroscope/
 type: application
 version: 1.21.0
-appVersion: 1.21.0
+appVersion: main-3a68604
 dependencies:
   - name: grafana-agent
     alias: agent

--- a/operations/pyroscope/helm/pyroscope/Chart.yaml
+++ b/operations/pyroscope/helm/pyroscope/Chart.yaml
@@ -4,7 +4,7 @@ description: 🔥 horizontally-scalable, highly-available, multi-tenant continuo
 home: https://grafana.com/oss/pyroscope/
 type: application
 version: 1.21.0
-appVersion: main-3a68604
+appVersion: main-171db75
 dependencies:
   - name: grafana-agent
     alias: agent

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -30,8 +30,7 @@
 | architecture.microservices.enabled | bool | `false` | Enable micro-services deployment mode. This is recommend for larger scale deployment and allow right size each aspect of Pyroscope. |
 | architecture.overwriteResources | object | `{}` | This flag is useful for testing, it will overwrite all pods resource statements with its contents |
 | architecture.storage.migration.ingesterWeight | float | `1` | Specifies the fraction [0:1] that should be send to the v1 write path / ingester in combined mode. 0 means no traffics is sent to ingester. 1 means 100% of requests are sent to ingester. |
-| architecture.storage.migration.queryBackend | bool | `true` | Specify a time stamp from when the v2 read path should serve traffic. |
-| architecture.storage.migration.queryBackendFrom | string | `"auto"` | Specify a time stamp from when the v2 read path should serve traffic. |
+| architecture.storage.migration.queryBackendFrom | string | `"auto"` | Specify a time stamp from when the v2 read path should serve traffic. Defaults to "auto" which determines the split point from the metastore. |
 | architecture.storage.migration.segmentWriterWeight | float | `1` | Specifies the fraction [0:1] that should be send to the v2 write path / segment-writer in combined mode. 0 means no traffics is sent to segment-writer. 1 means 100% of requests are sent to segment-writer. |
 | architecture.storage.v1 | bool | `true` | Enable v1 storage layer. |
 | architecture.storage.v2 | bool | `false` | Enable v2 storage layer. |
@@ -83,8 +82,6 @@
 | pyroscope.persistence.annotations | object | `{}` |  |
 | pyroscope.persistence.enabled | bool | `false` |  |
 | pyroscope.persistence.metastore.subPath | string | `".metastore"` |  |
-| pyroscope.persistence.shared.enabled | bool | `true` |  |
-| pyroscope.persistence.shared.subPath | string | `".shared"` |  |
 | pyroscope.persistence.size | string | `"10Gi"` |  |
 | pyroscope.podAnnotations."profiles.grafana.com/cpu.port_name" | string | `"http2"` |  |
 | pyroscope.podAnnotations."profiles.grafana.com/cpu.scrape" | string | `"true"` |  |

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 1.21.0](https://img.shields.io/badge/Version-1.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main-3a68604](https://img.shields.io/badge/AppVersion-main--3a68604-informational?style=flat-square)
+![Version: 1.21.0](https://img.shields.io/badge/Version-1.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main-171db75](https://img.shields.io/badge/AppVersion-main--171db75-informational?style=flat-square)
 
 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 

--- a/operations/pyroscope/helm/pyroscope/README.md
+++ b/operations/pyroscope/helm/pyroscope/README.md
@@ -1,6 +1,6 @@
 # pyroscope
 
-![Version: 1.21.0](https://img.shields.io/badge/Version-1.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.21.0](https://img.shields.io/badge/AppVersion-1.21.0-informational?style=flat-square)
+![Version: 1.21.0](https://img.shields.io/badge/Version-1.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: main-3a68604](https://img.shields.io/badge/AppVersion-main--3a68604-informational?style=flat-square)
 
 🔥 horizontally-scalable, highly-available, multi-tenant continuous profiling aggregation system
 

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
@@ -2224,6 +2224,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2327,6 +2328,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2430,6 +2432,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2834,6 +2837,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2945,6 +2949,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3052,6 +3057,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -30,7 +30,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -51,7 +51,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -72,7 +72,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -93,7 +93,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -114,7 +114,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -135,7 +135,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -179,7 +179,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -526,7 +526,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1384,7 +1384,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1401,7 +1401,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1686,7 +1686,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1713,7 +1713,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1738,7 +1738,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1764,7 +1764,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1789,7 +1789,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1815,7 +1815,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1840,7 +1840,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1866,7 +1866,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1891,7 +1891,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1917,7 +1917,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -1942,7 +1942,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -1968,7 +1968,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -1993,7 +1993,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2019,7 +2019,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2044,7 +2044,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2070,7 +2070,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2082,9 +2082,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2107,7 +2107,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2174,7 +2174,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2186,9 +2186,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2211,7 +2211,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2278,7 +2278,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2290,9 +2290,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2315,7 +2315,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2382,7 +2382,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2394,9 +2394,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2419,7 +2419,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2486,7 +2486,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2514,7 +2514,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2545,7 +2545,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2573,7 +2573,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2784,7 +2784,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -2799,9 +2799,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2824,7 +2824,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -2896,7 +2896,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -2911,9 +2911,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2936,7 +2936,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3004,7 +3004,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3019,9 +3019,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3044,7 +3044,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -30,7 +30,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -51,7 +51,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -72,7 +72,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -93,7 +93,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -114,7 +114,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -135,7 +135,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -179,7 +179,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -526,7 +526,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1384,7 +1384,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1401,7 +1401,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1686,7 +1686,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1713,7 +1713,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1738,7 +1738,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1764,7 +1764,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1789,7 +1789,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1815,7 +1815,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1840,7 +1840,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1866,7 +1866,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1891,7 +1891,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1917,7 +1917,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -1942,7 +1942,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -1968,7 +1968,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -1993,7 +1993,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2019,7 +2019,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2044,7 +2044,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2070,7 +2070,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2082,9 +2082,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2107,7 +2107,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2174,7 +2174,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2186,9 +2186,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2211,7 +2211,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2278,7 +2278,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2290,9 +2290,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2315,7 +2315,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2382,7 +2382,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2394,9 +2394,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2419,7 +2419,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2486,7 +2486,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2514,7 +2514,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2545,7 +2545,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2573,7 +2573,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2784,7 +2784,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -2799,9 +2799,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2824,7 +2824,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -2896,7 +2896,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -2911,9 +2911,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2936,7 +2936,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3004,7 +3004,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3019,9 +3019,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3044,7 +3044,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services-hpa.yaml
@@ -2119,6 +2119,8 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2221,6 +2223,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2323,6 +2326,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2425,6 +2429,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2828,6 +2833,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2938,6 +2944,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3044,6 +3051,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
@@ -2265,6 +2265,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2474,6 +2475,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2578,6 +2580,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2682,6 +2685,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2786,6 +2790,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3075,6 +3080,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3186,6 +3192,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3293,6 +3300,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
@@ -2264,6 +2264,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2367,6 +2368,8 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2470,6 +2473,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2573,6 +2577,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2676,6 +2681,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2779,6 +2785,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3067,6 +3074,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3177,6 +3185,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3283,6 +3292,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -30,7 +30,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -51,7 +51,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -72,7 +72,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -93,7 +93,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -114,7 +114,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -135,7 +135,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -156,7 +156,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -177,7 +177,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -221,7 +221,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -568,7 +568,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1426,7 +1426,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1443,7 +1443,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1728,7 +1728,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1755,7 +1755,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1780,7 +1780,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1806,7 +1806,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1831,7 +1831,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1857,7 +1857,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1882,7 +1882,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1908,7 +1908,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1933,7 +1933,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1959,7 +1959,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1984,7 +1984,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2010,7 +2010,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2035,7 +2035,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2061,7 +2061,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2086,7 +2086,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2112,7 +2112,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2137,7 +2137,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2163,7 +2163,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2188,7 +2188,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2214,7 +2214,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2227,9 +2227,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2252,7 +2252,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2319,7 +2319,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2332,9 +2332,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2357,7 +2357,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2424,7 +2424,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2437,9 +2437,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2462,7 +2462,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2529,7 +2529,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2542,9 +2542,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2567,7 +2567,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2634,7 +2634,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2647,9 +2647,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2672,7 +2672,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2739,7 +2739,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2752,9 +2752,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2777,7 +2777,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3027,7 +3027,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -3042,9 +3042,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3067,7 +3067,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3139,7 +3139,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3154,9 +3154,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3179,7 +3179,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3247,7 +3247,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3262,9 +3262,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3287,7 +3287,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/legacy-micro-services.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -30,7 +30,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -51,7 +51,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -72,7 +72,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -93,7 +93,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -114,7 +114,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -135,7 +135,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -156,7 +156,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -177,7 +177,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -221,7 +221,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -568,7 +568,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1426,7 +1426,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1443,7 +1443,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1728,7 +1728,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1755,7 +1755,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1780,7 +1780,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1806,7 +1806,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1831,7 +1831,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1857,7 +1857,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1882,7 +1882,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1908,7 +1908,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1933,7 +1933,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1959,7 +1959,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1984,7 +1984,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2010,7 +2010,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2035,7 +2035,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2061,7 +2061,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2086,7 +2086,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2112,7 +2112,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2137,7 +2137,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2163,7 +2163,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2188,7 +2188,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2214,7 +2214,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2227,9 +2227,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2252,7 +2252,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2319,7 +2319,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2332,9 +2332,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2357,7 +2357,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2424,7 +2424,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2437,9 +2437,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2462,7 +2462,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2529,7 +2529,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2542,9 +2542,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2567,7 +2567,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2634,7 +2634,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2647,9 +2647,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2672,7 +2672,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2739,7 +2739,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2752,9 +2752,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2777,7 +2777,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3027,7 +3027,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -3042,9 +3042,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3067,7 +3067,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3139,7 +3139,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3154,9 +3154,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3179,7 +3179,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3247,7 +3247,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3262,9 +3262,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3287,7 +3287,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -30,7 +30,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -51,7 +51,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -72,7 +72,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -93,7 +93,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -114,7 +114,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -135,7 +135,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -156,7 +156,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -177,7 +177,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -221,7 +221,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -568,7 +568,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1426,7 +1426,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1443,7 +1443,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1601,7 +1601,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1626,7 +1626,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1773,7 +1773,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1800,7 +1800,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1829,7 +1829,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1859,7 +1859,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1888,7 +1888,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1918,7 +1918,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1947,7 +1947,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1977,7 +1977,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2006,7 +2006,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2036,7 +2036,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2069,7 +2069,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2104,7 +2104,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2133,7 +2133,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2163,7 +2163,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2192,7 +2192,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2222,7 +2222,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2251,7 +2251,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2281,7 +2281,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2310,7 +2310,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2340,7 +2340,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2353,9 +2353,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2378,7 +2378,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2450,7 +2450,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -2463,9 +2463,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2488,7 +2488,7 @@ spec:
         - name: "admin"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=admin"
@@ -2560,7 +2560,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2573,9 +2573,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2598,7 +2598,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2670,7 +2670,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2683,9 +2683,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2708,7 +2708,7 @@ spec:
         - name: "query-backend"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-backend"
@@ -2780,7 +2780,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2793,9 +2793,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2818,7 +2818,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2890,7 +2890,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2903,9 +2903,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2928,7 +2928,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3183,7 +3183,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -3198,9 +3198,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3223,7 +3223,7 @@ spec:
         - name: "compaction-worker"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compaction-worker"
@@ -3296,7 +3296,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -3311,9 +3311,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3336,7 +3336,7 @@ spec:
         - name: "metastore"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=metastore"
@@ -3425,7 +3425,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -3440,9 +3440,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3465,7 +3465,7 @@ spec:
         - name: "segment-writer"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=segment-writer"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -2832,7 +2832,6 @@ spec:
             - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
             - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
             - "-architecture.storage=v2"
-            - "-enable-query-backend-from=auto"
           env:
             - name: POD_NAME
               valueFrom:

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -30,7 +30,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -51,7 +51,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -72,7 +72,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -93,7 +93,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -114,7 +114,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -135,7 +135,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -156,7 +156,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -177,7 +177,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -221,7 +221,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -568,7 +568,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1426,7 +1426,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1443,7 +1443,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1601,7 +1601,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1626,7 +1626,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1773,7 +1773,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1800,7 +1800,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1829,7 +1829,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1859,7 +1859,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1888,7 +1888,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -1918,7 +1918,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1947,7 +1947,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -1977,7 +1977,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2006,7 +2006,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2036,7 +2036,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2069,7 +2069,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -2104,7 +2104,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2133,7 +2133,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2163,7 +2163,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2192,7 +2192,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2222,7 +2222,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2251,7 +2251,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -2281,7 +2281,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2310,7 +2310,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2340,7 +2340,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2353,9 +2353,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2378,7 +2378,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2450,7 +2450,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "admin"
 spec:
@@ -2463,9 +2463,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2488,7 +2488,7 @@ spec:
         - name: "admin"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=admin"
@@ -2560,7 +2560,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2573,9 +2573,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2598,7 +2598,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2670,7 +2670,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-backend"
 spec:
@@ -2683,9 +2683,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2708,7 +2708,7 @@ spec:
         - name: "query-backend"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-backend"
@@ -2780,7 +2780,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2793,9 +2793,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2818,7 +2818,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2890,7 +2890,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2903,9 +2903,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2928,7 +2928,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3183,7 +3183,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compaction-worker"
 spec:
@@ -3198,9 +3198,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3223,7 +3223,7 @@ spec:
         - name: "compaction-worker"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compaction-worker"
@@ -3296,7 +3296,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "metastore"
 spec:
@@ -3311,9 +3311,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3336,7 +3336,7 @@ spec:
         - name: "metastore"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=metastore"
@@ -3425,7 +3425,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "segment-writer"
 spec:
@@ -3440,9 +3440,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3465,7 +3465,7 @@ spec:
         - name: "segment-writer"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=segment-writer"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services-v2.yaml
@@ -2391,6 +2391,7 @@ spec:
             - "-log.level=debug"
             - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
             - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2398,8 +2399,6 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_V2_EXPERIMENT
-              value: "1"
             - name: PYROSCOPE_METASTORE_SERVICE
               value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
@@ -2425,9 +2424,6 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-            - name: data
-              mountPath: /data-shared
-              subPath: .shared
           resources:
             limits:
               memory: 256Mi
@@ -2505,6 +2501,7 @@ spec:
             - "-log.level=debug"
             - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
             - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2512,8 +2509,6 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_V2_EXPERIMENT
-              value: "1"
             - name: PYROSCOPE_METASTORE_SERVICE
               value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
@@ -2539,9 +2534,6 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-            - name: data
-              mountPath: /data-shared
-              subPath: .shared
           resources:
             limits:
               memory: 256Mi
@@ -2619,7 +2611,7 @@ spec:
             - "-log.level=debug"
             - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
             - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
-            - "-write-path=segment-writer"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2627,8 +2619,6 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_V2_EXPERIMENT
-              value: "1"
             - name: PYROSCOPE_METASTORE_SERVICE
               value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
@@ -2654,9 +2644,6 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-            - name: data
-              mountPath: /data-shared
-              subPath: .shared
           resources:
             limits:
               memory: 1Gi
@@ -2734,6 +2721,7 @@ spec:
             - "-log.level=debug"
             - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
             - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2741,8 +2729,6 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_V2_EXPERIMENT
-              value: "1"
             - name: PYROSCOPE_METASTORE_SERVICE
               value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
@@ -2768,9 +2754,6 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-            - name: data
-              mountPath: /data-shared
-              subPath: .shared
           resources:
             limits:
               memory: 1Gi
@@ -2848,7 +2831,8 @@ spec:
             - "-log.level=debug"
             - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
             - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
-            - "-enable-query-backend=true"
+            - "-architecture.storage=v2"
+            - "-enable-query-backend-from=auto"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2856,8 +2840,6 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_V2_EXPERIMENT
-              value: "1"
             - name: PYROSCOPE_METASTORE_SERVICE
               value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
@@ -2883,9 +2865,6 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-            - name: data
-              mountPath: /data-shared
-              subPath: .shared
           resources:
             limits:
               memory: 1Gi
@@ -2963,6 +2942,7 @@ spec:
             - "-log.level=debug"
             - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
             - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2970,8 +2950,6 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_V2_EXPERIMENT
-              value: "1"
             - name: PYROSCOPE_METASTORE_SERVICE
               value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
@@ -2997,9 +2975,6 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-            - name: data
-              mountPath: /data-shared
-              subPath: .shared
           resources:
             limits:
               memory: 256Mi
@@ -3262,6 +3237,7 @@ spec:
             - "-log.level=debug"
             - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
             - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3269,8 +3245,6 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_V2_EXPERIMENT
-              value: "1"
             - name: PYROSCOPE_METASTORE_SERVICE
               value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
@@ -3296,9 +3270,6 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-            - name: data
-              mountPath: /data-shared
-              subPath: .shared
           resources:
             limits:
               memory: 2Gi
@@ -3389,6 +3360,7 @@ spec:
             - "-metastore.raft.server-id=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
             - "-metastore.raft.advertise-address=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
             - "-metastore.raft.bootstrap-peers=dnssrvnoa+_raft._tcp.$(PYROSCOPE_METASTORE_SERVICE)"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3396,8 +3368,6 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_V2_EXPERIMENT
-              value: "1"
             - name: PYROSCOPE_METASTORE_SERVICE
               value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
@@ -3426,9 +3396,6 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-            - name: data
-              mountPath: /data-shared
-              subPath: .shared
             - name: data
               mountPath: /data-metastore
               subPath: .metastore
@@ -3512,6 +3479,7 @@ spec:
             - "-log.level=debug"
             - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-query-backend-headless.$(NAMESPACE_FQDN):9095"
             - "-metastore.address=kubernetes:///pyroscope-dev-metastore-headless.$(NAMESPACE_FQDN):9095"
+            - "-architecture.storage=v2"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3519,8 +3487,6 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_V2_EXPERIMENT
-              value: "1"
             - name: PYROSCOPE_METASTORE_SERVICE
               value: "pyroscope-dev-metastore-headless.default.svc.cluster.local.:9099"
           ports:
@@ -3546,9 +3512,6 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-            - name: data
-              mountPath: /data-shared
-              subPath: .shared
           resources:
             limits:
               memory: 4Gi

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -2263,6 +2263,7 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2365,6 +2366,8 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2468,6 +2471,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2570,6 +2574,7 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2672,6 +2677,7 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2774,6 +2780,7 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3061,6 +3068,7 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3170,6 +3178,7 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3276,6 +3285,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
+            - "-architecture.storage=v1"
           env:
             - name: POD_NAME
               valueFrom:

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -30,7 +30,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -51,7 +51,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -72,7 +72,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -93,7 +93,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -114,7 +114,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -135,7 +135,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -156,7 +156,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -177,7 +177,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -221,7 +221,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -568,7 +568,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1426,7 +1426,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1443,7 +1443,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1728,7 +1728,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1755,7 +1755,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1780,7 +1780,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1806,7 +1806,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1831,7 +1831,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1857,7 +1857,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1882,7 +1882,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1908,7 +1908,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1933,7 +1933,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1959,7 +1959,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1984,7 +1984,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2010,7 +2010,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2035,7 +2035,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2061,7 +2061,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2086,7 +2086,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2112,7 +2112,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2137,7 +2137,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2163,7 +2163,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2188,7 +2188,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2214,7 +2214,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2227,9 +2227,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2252,7 +2252,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2318,7 +2318,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2331,9 +2331,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2356,7 +2356,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2422,7 +2422,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2435,9 +2435,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2460,7 +2460,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2527,7 +2527,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2540,9 +2540,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2565,7 +2565,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2631,7 +2631,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2644,9 +2644,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2669,7 +2669,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2735,7 +2735,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2748,9 +2748,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2773,7 +2773,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3022,7 +3022,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -3037,9 +3037,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3062,7 +3062,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3133,7 +3133,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3148,9 +3148,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3173,7 +3173,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3240,7 +3240,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3255,9 +3255,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9c9081f06cc377549498dd36107c317a75d725d99af11b2f77bafac6d42b4c1f
+        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3280,7 +3280,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -30,7 +30,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -51,7 +51,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -72,7 +72,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -93,7 +93,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -114,7 +114,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -135,7 +135,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -156,7 +156,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -177,7 +177,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -221,7 +221,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/charts/minio/templates/secrets.yaml
@@ -568,7 +568,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -1426,7 +1426,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -1443,7 +1443,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1728,7 +1728,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1755,7 +1755,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1780,7 +1780,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -1806,7 +1806,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1831,7 +1831,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -1857,7 +1857,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1882,7 +1882,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -1908,7 +1908,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1933,7 +1933,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -1959,7 +1959,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -1984,7 +1984,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2010,7 +2010,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2035,7 +2035,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2061,7 +2061,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2086,7 +2086,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2112,7 +2112,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2137,7 +2137,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -2163,7 +2163,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2188,7 +2188,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2214,7 +2214,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ad-hoc-profiles"
 spec:
@@ -2227,9 +2227,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2252,7 +2252,7 @@ spec:
         - name: "ad-hoc-profiles"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ad-hoc-profiles"
@@ -2318,7 +2318,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "distributor"
 spec:
@@ -2331,9 +2331,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2356,7 +2356,7 @@ spec:
         - name: "distributor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -2422,7 +2422,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "querier"
 spec:
@@ -2435,9 +2435,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2460,7 +2460,7 @@ spec:
         - name: "querier"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -2527,7 +2527,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-frontend"
 spec:
@@ -2540,9 +2540,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2565,7 +2565,7 @@ spec:
         - name: "query-frontend"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -2631,7 +2631,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "query-scheduler"
 spec:
@@ -2644,9 +2644,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2669,7 +2669,7 @@ spec:
         - name: "query-scheduler"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-scheduler"
@@ -2735,7 +2735,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "tenant-settings"
 spec:
@@ -2748,9 +2748,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -2773,7 +2773,7 @@ spec:
         - name: "tenant-settings"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=tenant-settings"
@@ -3022,7 +3022,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "compactor"
 spec:
@@ -3037,9 +3037,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3062,7 +3062,7 @@ spec:
         - name: "compactor"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -3133,7 +3133,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "ingester"
 spec:
@@ -3148,9 +3148,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3173,7 +3173,7 @@ spec:
         - name: "ingester"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -3240,7 +3240,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "store-gateway"
 spec:
@@ -3255,9 +3255,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e698331ca72bd79ab8434f44fe8c3a73922b46e2f31820a6f1bd5e00e813145b
+        checksum/config: 8cd4dd9b1303a930f7347b594e7449b7139233679a2a90173a0e7c776e010f22
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -3280,7 +3280,7 @@ spec:
         - name: "store-gateway"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"

--- a/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/micro-services.yaml
@@ -2264,6 +2264,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2472,6 +2473,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2575,6 +2577,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2678,6 +2681,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -2781,6 +2785,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3069,6 +3074,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3179,6 +3185,7 @@ spec:
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:
@@ -3286,6 +3293,7 @@ spec:
             - "-log.level=debug"
             - "-store-gateway.sharding-ring.replication-factor=3"
             - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
@@ -1425,7 +1425,6 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
-            - "-storage.backend=filesystem"
             - "-query-backend.address=dns:///_grpc._tcp.pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
             - "-metastore.address=kubernetes:///pyroscope-dev-headless.$(NAMESPACE_FQDN):9095"
             - "-metastore.data-dir=./data-metastore/data"
@@ -1435,10 +1434,8 @@ spec:
             - "-metastore.raft.server-id=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
             - "-metastore.raft.advertise-address=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
             - "-metastore.raft.bootstrap-peers=dnssrvnoa+_raft._tcp.$(PYROSCOPE_METASTORE_SERVICE)"
-            - "-write-path=segment-writer"
-            - "-all.enable-v1-write-path=false"
-            - "-all.enable-v1-read-path=false"
-            - "-enable-query-backend=true"
+            - "-architecture.storage=v2"
+            - "-enable-query-backend-from=auto"
           env:
             - name: POD_NAME
               valueFrom:
@@ -1446,8 +1443,6 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "default.svc.cluster.local."
-            - name: PYROSCOPE_V2_EXPERIMENT
-              value: "1"
             - name: PYROSCOPE_METASTORE_SERVICE
               value: "pyroscope-dev-headless.default.svc.cluster.local.:9099"
           ports:
@@ -1476,9 +1471,6 @@ spec:
               mountPath: /etc/pyroscope/overrides/
             - name: data
               mountPath: /data
-            - name: data
-              mountPath: /data-shared
-              subPath: .shared
             - name: data
               mountPath: /data-metastore
               subPath: .metastore

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -46,7 +46,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -59,7 +59,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -917,7 +917,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -934,7 +934,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1085,7 +1085,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1110,7 +1110,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1189,7 +1189,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1216,7 +1216,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1249,7 +1249,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1374,7 +1374,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1389,9 +1389,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2c5ebd88e66ab5adeea1f3c1551a42111cc86c961662500721016a2018740b5a
+        checksum/config: 5c82c812cd288ff8b12368a190656be7f3105dcb893d9a8ae8194319e39ba008
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1414,7 +1414,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
@@ -1435,7 +1435,6 @@ spec:
             - "-metastore.raft.advertise-address=$(POD_NAME).$(PYROSCOPE_METASTORE_SERVICE)"
             - "-metastore.raft.bootstrap-peers=dnssrvnoa+_raft._tcp.$(PYROSCOPE_METASTORE_SERVICE)"
             - "-architecture.storage=v2"
-            - "-enable-query-backend-from=auto"
           env:
             - name: POD_NAME
               valueFrom:

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary-v2.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -46,7 +46,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -59,7 +59,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -917,7 +917,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -934,7 +934,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1085,7 +1085,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -1110,7 +1110,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -1189,7 +1189,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1216,7 +1216,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1249,7 +1249,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1374,7 +1374,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1389,9 +1389,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fbd928f21b3db7574eb01571d06ea679904aa0af4b2d57bbc3d6cbc694de8a8d
+        checksum/config: 2c5ebd88e66ab5adeea1f3c1551a42111cc86c961662500721016a2018740b5a
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1414,7 +1414,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -46,7 +46,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -59,7 +59,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -917,7 +917,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -934,7 +934,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1144,7 +1144,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1171,7 +1171,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1196,7 +1196,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1312,7 +1312,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "1.21.0"
+    app.kubernetes.io/version: "main-3a68604"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1327,9 +1327,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: fbd928f21b3db7574eb01571d06ea679904aa0af4b2d57bbc3d6cbc694de8a8d
+        checksum/config: 2c5ebd88e66ab5adeea1f3c1551a42111cc86c961662500721016a2018740b5a
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "v1.21.0"
+        profiles.grafana.com/service_git_ref: "vmain-3a68604"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1352,7 +1352,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:1.21.0"
+          image: "grafana/pyroscope:main-3a68604"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -1363,6 +1363,8 @@ spec:
             - "-config.file=/etc/pyroscope/config.yaml"
             - "-runtime-config.file=/etc/pyroscope/overrides/overrides.yaml"
             - "-log.level=debug"
+            - "-architecture.storage=v1"
+            - "-write-path=ingester"
           env:
             - name: POD_NAME
               valueFrom:

--- a/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
+++ b/operations/pyroscope/helm/pyroscope/rendered/single-binary.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -46,7 +46,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: pyroscope/templates/configmap-alloy.yaml
@@ -59,7 +59,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   config.alloy: |
@@ -917,7 +917,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   overrides.yaml: |
@@ -934,7 +934,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 data:
   config.yaml: |
@@ -1144,7 +1144,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -1171,7 +1171,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1196,7 +1196,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1312,7 +1312,7 @@ metadata:
     helm.sh/chart: pyroscope-1.21.0
     app.kubernetes.io/name: pyroscope
     app.kubernetes.io/instance: pyroscope-dev
-    app.kubernetes.io/version: "main-3a68604"
+    app.kubernetes.io/version: "main-171db75"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: "all"
 spec:
@@ -1327,9 +1327,9 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2c5ebd88e66ab5adeea1f3c1551a42111cc86c961662500721016a2018740b5a
+        checksum/config: 5c82c812cd288ff8b12368a190656be7f3105dcb893d9a8ae8194319e39ba008
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
-        profiles.grafana.com/service_git_ref: "vmain-3a68604"
+        profiles.grafana.com/service_git_ref: "main-171db75"
         profiles.grafana.com/cpu.port_name: http2
         profiles.grafana.com/cpu.scrape: "true"
         profiles.grafana.com/goroutine.port_name: http2
@@ -1352,7 +1352,7 @@ spec:
         - name: "pyroscope"
           securityContext:
             {}
-          image: "grafana/pyroscope:main-3a68604"
+          image: "grafana/pyroscope:main-171db75"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=all"

--- a/operations/pyroscope/helm/pyroscope/templates/NOTES.txt
+++ b/operations/pyroscope/helm/pyroscope/templates/NOTES.txt
@@ -51,11 +51,7 @@ Write traffic will be written to:
 - {{ mul $storage.migration.ingesterWeight 100 }}% v1: ingester
 - {{ mul $storage.migration.segmentWriterWeight 100 }}% v2: segment-writer
 
-{{ if $storage.migration.queryBackend }}
 Read traffic is served from v2 read path from {{if eq $storage.migration.queryBackendFrom "auto"}}as soon as data was first ingested to v2{{else}}{{$storage.migration.queryBackendFrom}}{{end}}.
-{{- else }}
-Read traffic is served from v1 read path.
-{{- end }}
 {{- end }}
 
 {{- if and (not $storage.v1) (not $storage.v2) }}

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -128,8 +128,7 @@ spec:
             - "-architecture.storage=v2"
           {{- end }}
           {{- end }}
-          {{- /* distributor write path config */}}
-          {{-  if or (eq $component "all") (eq $component "distributor") }}
+          {{- /* write path config */}}
           {{-  if (not (hasKey $extraArgs "write-path"))  }}
           {{-  if and $hasV1 $hasV2 }}
             - "-write-path=combined"
@@ -138,7 +137,6 @@ spec:
           {{- end }}
           {{- else if not $hasV2 }}
             - "-write-path=ingester"
-          {{- end }}
           {{- end }}
           {{- end }}
           {{- /* query-frontend v2 migration config */}}

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -139,10 +139,11 @@ spec:
             - "-write-path=ingester"
           {{- end }}
           {{- end }}
-          {{- /* query-frontend v2 migration config */}}
-          {{- if and $hasV2 (or (eq $component "all") (eq $component "query-frontend")) }}
-          {{-   if and (not (hasKey $extraArgs "enable-query-backend-from")) $global.Values.architecture.storage.migration.queryBackendFrom }}
-            - "-enable-query-backend-from={{$global.Values.architecture.storage.migration.queryBackendFrom}}"
+          {{- /* query-frontend v1-v2-dual migration config */}}
+          {{- if and $hasV1 $hasV2 (or (eq $component "all") (eq $component "query-frontend")) }}
+          {{-   $qbFrom := $global.Values.architecture.storage.migration.queryBackendFrom }}
+          {{-   if and (not (hasKey $extraArgs "enable-query-backend-from")) $qbFrom (ne $qbFrom "auto") }}
+            - "-enable-query-backend-from={{$qbFrom}}"
           {{-   end }}
           {{- end }}
           env:

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -132,6 +132,9 @@ spec:
           {{-  if (not (hasKey $extraArgs "write-path"))  }}
           {{-  if and $hasV1 $hasV2 }}
             - "-write-path=combined"
+          {{-  if not (hasKey $extraArgs "write-path.ingester-weight")  }}
+            - "-write-path.ingester-weight={{ $global.Values.architecture.storage.migration.ingesterWeight }}"
+          {{- end }}
           {{-  if not (hasKey $extraArgs "write-path.segment-writer-weight")  }}
             - "-write-path.segment-writer-weight={{ $global.Values.architecture.storage.migration.segmentWriterWeight }}"
           {{- end }}

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -85,12 +85,6 @@ spec:
           {{- range $key, $value := $extraArgs }}
             - "-{{ $key }}={{ $value }}"
           {{- end }}
-          {{- /* When v2 and single binary is used we need to explicitly configure "filesystem" (TODO: This should be the default in v2) */}}
-          {{- if and $hasV2 (eq $component "all") }}
-          {{-  if (not (hasKey $extraArgs "storage.backend")) }}
-            - "-storage.backend=filesystem"
-          {{- end }}
-          {{- end }}
           {{- /* v2 specific options for all components */}}
           {{- if $hasV2 }}
           {{-  if (not (hasKey $extraArgs "query-backend.address"))  }}
@@ -124,39 +118,33 @@ spec:
             - "-metastore.raft.bootstrap-peers=dnssrvnoa+_raft._tcp.$(PYROSCOPE_METASTORE_SERVICE)"
           {{- end }}
           {{- end }}
-          {{- /* distributor specific v1/v2 migration config */}}
+          {{- /* architecture storage layer */}}
+          {{- if not (hasKey $extraArgs "architecture.storage") }}
+          {{- if and $hasV1 $hasV2 }}
+            - "-architecture.storage=v1-v2-dual"
+          {{- else if $hasV1 }}
+            - "-architecture.storage=v1"
+          {{- else if $hasV2 }}
+            - "-architecture.storage=v2"
+          {{- end }}
+          {{- end }}
+          {{- /* distributor write path config */}}
           {{-  if or (eq $component "all") (eq $component "distributor") }}
-          {{-  if and $hasV2 (not (hasKey $extraArgs "write-path"))  }}
-          {{-  if $hasV1 }}
+          {{-  if (not (hasKey $extraArgs "write-path"))  }}
+          {{-  if and $hasV1 $hasV2 }}
             - "-write-path=combined"
           {{-  if not (hasKey $extraArgs "write-path.segment-writer-weight")  }}
             - "-write-path.segment-writer-weight=1"
           {{- end }}
-          {{- else }}
-            - "-write-path=segment-writer"
+          {{- else if not $hasV2 }}
+            - "-write-path=ingester"
           {{- end }}
           {{- end }}
           {{- end }}
-          {{- /* single-binary v2: disable v1 components when v1 storage is off */}}
-          {{- if and (eq $component "all") $hasV2 (not $hasV1) }}
-          {{-   if not (hasKey $extraArgs "all.enable-v1-write-path") }}
-            - "-all.enable-v1-write-path=false"
-          {{-   end }}
-          {{-   if not (hasKey $extraArgs "all.enable-v1-read-path") }}
-            - "-all.enable-v1-read-path=false"
-          {{-   end }}
-          {{- end }}
-          {{- /* query-frontend specific v1/v2 migration config */}}
-          {{- if or (eq $component "all") (eq $component "query-frontend") }}
-          {{-   if and $hasV2 (not (hasKey $extraArgs "enable-query-backend"))  }}
-          {{-     if and $hasV1 $global.Values.architecture.storage.migration.queryBackend }}
-            - "-enable-query-backend=true"
-          {{-       if and (not (hasKey $extraArgs "enable-query-backend-from")) $global.Values.architecture.storage.migration.queryBackendFrom }}
+          {{- /* query-frontend v2 migration config */}}
+          {{- if and $hasV2 (or (eq $component "all") (eq $component "query-frontend")) }}
+          {{-   if and (not (hasKey $extraArgs "enable-query-backend-from")) $global.Values.architecture.storage.migration.queryBackendFrom }}
             - "-enable-query-backend-from={{$global.Values.architecture.storage.migration.queryBackendFrom}}"
-          {{-       end }}
-          {{-     else }}
-            - "-enable-query-backend=true"
-          {{-     end }}
           {{-   end }}
           {{- end }}
           env:
@@ -166,10 +154,6 @@ spec:
                   fieldPath: metadata.name
             - name: NAMESPACE_FQDN
               value: "{{ .Release.Namespace }}.svc{{ .Values.pyroscope.cluster_domain }}"
-          {{- if and $hasV2 (not (hasKey $values.extraEnvVars "PYROSCOPE_V2_EXPERIMENT"))  }}
-            - name: PYROSCOPE_V2_EXPERIMENT
-              value: "1"
-          {{- end }}
           {{- if and $hasV2 (not (hasKey $values.extraEnvVars "PYROSCOPE_METASTORE_SERVICE"))  }}
             - name: PYROSCOPE_METASTORE_SERVICE
               value: "{{ include "pyroscope.fullname" .}}{{ if $hasMetastore }}-metastore{{ end }}-headless.{{ .Release.Namespace }}.svc{{ .Values.pyroscope.cluster_domain }}:{{ .Values.pyroscope.metastore.port }}"
@@ -229,11 +213,6 @@ spec:
             - name: data
               mountPath: /data-compactor
               subPath: compactor
-            {{- end }}
-            {{- if (and $hasV2 $values.persistence.shared.enabled) }}
-            - name: data
-              mountPath: /data-shared
-              subPath: {{ $values.persistence.shared.subPath }}
             {{- end }}
             {{- if $isMetastore }}
             - name: data

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -133,7 +133,7 @@ spec:
           {{-  if and $hasV1 $hasV2 }}
             - "-write-path=combined"
           {{-  if not (hasKey $extraArgs "write-path.segment-writer-weight")  }}
-            - "-write-path.segment-writer-weight=1"
+            - "-write-path.segment-writer-weight={{ $global.Values.architecture.storage.migration.segmentWriterWeight }}"
           {{- end }}
           {{- else if not $hasV2 }}
             - "-write-path=ingester"

--- a/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
+++ b/operations/pyroscope/helm/pyroscope/templates/deployments-statefulsets.yaml
@@ -40,7 +40,7 @@ spec:
         profiles.grafana.com/service_repository: "https://github.com/grafana/pyroscope"
         {{- end }}
         {{- if not (hasKey $values.podAnnotations "profiles.grafana.com/service_git_ref")  }}
-        profiles.grafana.com/service_git_ref: "v{{ .Chart.AppVersion }}"
+        profiles.grafana.com/service_git_ref: "{{ if regexMatch "^[0-9]" .Chart.AppVersion }}v{{ end }}{{ .Chart.AppVersion }}"
         {{- end }}
         {{- with $values.podAnnotations }}
         {{- toYaml . | nindent 8 }}

--- a/operations/pyroscope/helm/pyroscope/values.yaml
+++ b/operations/pyroscope/helm/pyroscope/values.yaml
@@ -158,11 +158,6 @@ pyroscope:
       # subPath to use of the data volume for the metastore persistence.
       subPath: .metastore
 
-    shared:
-      enabled: true
-      # subPath to use of the data volume for the shared storage used as bucket replacement.
-      subPath: .shared
-
   extraVolumes:
     []
     # - name: backup-volume
@@ -227,9 +222,7 @@ architecture:
       # -- (float) Specifies the fraction [0:1] that should be send to the v2 write path / segment-writer in combined mode. 0 means no traffics is sent to segment-writer. 1 means 100% of requests are sent to segment-writer.
       segmentWriterWeight: 1.0
 
-      # -- (bool) Specify a time stamp from when the v2 read path should serve traffic.
-      queryBackend: true
-      # -- (string) Specify a time stamp from when the v2 read path should serve traffic.
+      # -- (string) Specify a time stamp from when the v2 read path should serve traffic. Defaults to "auto" which determines the split point from the metastore.
       queryBackendFrom: auto
 
   # -- This flag is useful for testing, it will overwrite all pods resource statements with its contents

--- a/operations/pyroscope/jsonnet/values.json
+++ b/operations/pyroscope/jsonnet/values.json
@@ -329,7 +329,6 @@
     "storage": {
       "migration": {
         "ingesterWeight": 1,
-        "queryBackend": true,
         "queryBackendFrom": "auto",
         "segmentWriterWeight": 1
       },
@@ -431,10 +430,6 @@
       "enabled": false,
       "metastore": {
         "subPath": ".metastore"
-      },
-      "shared": {
-        "enabled": true,
-        "subPath": ".shared"
       },
       "size": "10Gi"
     },


### PR DESCRIPTION
## Summary

Aligns the Helm chart with the binary breaking changes from 3a68604b9 (Pyroscope OSS v2.0).

- **Fix write-path for v1 deployments**: Binary default changed from `ingester` to `segment-writer`; without explicit `-write-path=ingester` all v1 write traffic would be routed to the segment-writer and fail. Applied to all components (not just distributor) since the validation runs at startup for every component.
- **Replace removed flags with `-architecture.storage`**: `all.enable-v1-write-path` and `all.enable-v1-read-path` were deleted; replaced by `-architecture.storage=v1|v2|v1-v2-dual`.
- **Remove `PYROSCOPE_V2_EXPERIMENT` env var**: No longer read by the binary.
- **Remove explicit `-storage.backend=filesystem`**: Now the binary default.
- **Remove explicit `-enable-query-backend=true`**: Now defaults to `true`.
- **Remove `/data-shared` volume mount**: The new default filesystem dir `./data/v2/shared` falls naturally under the existing `/data` PVC mount.
- **Clean up values.yaml**: Remove `migration.queryBackend` (flag no longer exists) and `persistence.shared` stanza (mount no longer used).

## Test plan

- [ ] `make helm/check` passes (all 6 rendered variants validate with kubeconform)
- [ ] v1 single-binary: verify `-architecture.storage=v1` and `-write-path=ingester` are set
- [ ] v2 single-binary: verify `-architecture.storage=v2` is set, no v1 flags
- [ ] v1-v2-dual: verify `-architecture.storage=v1-v2-dual` and `-write-path=combined` are set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime flags and storage/write-path behavior across all deployed components; misconfiguration could break ingestion/querying during upgrades despite being mostly Helm-level changes.
> 
> **Overview**
> Updates the Pyroscope Helm chart to match **v2.0 binary flag/behavior changes** by switching components to the new `-architecture.storage` flag and explicitly setting `-write-path` (including `ingester` for v1-only installs and `combined` for dual-mode).
> 
> Bumps chart `appVersion`/rendered manifests from `1.21.0` to `main-171db75`, removes deprecated v2 experiment/env and legacy shared data mount expectations, and adjusts documented values (eg. `architecture.storage.migration.queryBackendFrom`) to reflect the new migration semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12436594b5269a229d208bd27648ebc86a7e8257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->