### PR TITLE
Fix missed v1 import path in pyroscope_test.go after module bump to v2

### DIFF
--- a/pkg/pyroscope/pyroscope_test.go
+++ b/pkg/pyroscope/pyroscope_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	statusv1 "github.com/grafana/pyroscope/api/gen/proto/go/status/v1"
-	objstoreclient "github.com/grafana/pyroscope/pkg/objstore/client"
+	objstoreclient "github.com/grafana/pyroscope/v2/pkg/objstore/client"
 )
 
 func TestFlagDefaults(t *testing.T) {


### PR DESCRIPTION
## Summary

- `pkg/pyroscope/pyroscope_test.go` was still importing `github.com/grafana/pyroscope/pkg/objstore/client` (old v1 path) after the module was bumped to `github.com/grafana/pyroscope/v2` in #5073
- This caused `golangci-lint` / `gofmt` to fail with `no export data for "github.com/grafana/pyroscope/pkg/objstore/client"`
- It also caused `go mod tidy` to pull in `github.com/grafana/pyroscope v1.21.0` as an unintended dependency, breaking the `check/go/mod` step

## Fix

One-line change: update the import path to `github.com/grafana/pyroscope/v2/pkg/objstore/client`.

## Test plan

- [ ] CI passes on main after merge (lint, format, go mod checks)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line test-only import path fix to align with the v2 module; no runtime logic changes.
> 
> **Overview**
> Fixes `pkg/pyroscope/pyroscope_test.go` to import `objstoreclient` from `github.com/grafana/pyroscope/v2/...` instead of the pre-v2 module path, preventing accidental `v1` dependency pulls and related lint/`go mod` failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c49423a6884854f7cacd43ab277bd2e26b724da9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->